### PR TITLE
Persist entity state across restarts via RestoreSensor/RestoreEntity (no custom storage)

### DIFF
--- a/custom_components/googlefindmy/button.py
+++ b/custom_components/googlefindmy/button.py
@@ -73,26 +73,35 @@ class GoogleFindMyPlaySoundButton(CoordinatorEntity, ButtonEntity):
         }
 
     def _get_map_token(self) -> str:
-        """Generate a simple token for map authentication."""
+        """Generate a simple token for map authentication.
+
+        Weekly-rotating token when enabled; otherwise a static token.
+        """
         import hashlib
         import time
         from .const import DEFAULT_MAP_VIEW_TOKEN_EXPIRATION
 
-        # Check if token expiration is enabled in config
-        config_entries = self.hass.config_entries.async_entries(DOMAIN)
-        token_expiration_enabled = DEFAULT_MAP_VIEW_TOKEN_EXPIRATION
-        if config_entries:
-            token_expiration_enabled = config_entries[0].data.get("map_view_token_expiration", DEFAULT_MAP_VIEW_TOKEN_EXPIRATION)
+        # Check if token expiration is enabled - prefer options over data
+        config_entry = getattr(self.coordinator, "config_entry", None)
+        if config_entry:
+            token_expiration_enabled = config_entry.options.get(
+                "map_view_token_expiration",
+                config_entry.data.get("map_view_token_expiration", DEFAULT_MAP_VIEW_TOKEN_EXPIRATION)
+            )
+        else:
+            token_expiration_enabled = DEFAULT_MAP_VIEW_TOKEN_EXPIRATION
 
         ha_uuid = str(self.hass.data.get("core.uuid", "ha"))
 
         if token_expiration_enabled:
-            # Use weekly expiration when enabled
-            week = str(int(time.time() // 604800))  # Current week since epoch (7 days)
-            return hashlib.md5(f"{ha_uuid}:{week}".encode()).hexdigest()[:16]
+            # Weekly-rolling token (7-day bucket)
+            week = str(int(time.time() // 604800))
+            token_src = f"{ha_uuid}:{week}"
         else:
-            # No expiration - use static token based on HA UUID only
-            return hashlib.md5(f"{ha_uuid}:static".encode()).hexdigest()[:16]
+            # Static token (no rotation)
+            token_src = f"{ha_uuid}:static"
+
+        return hashlib.md5(token_src.encode()).hexdigest()[:16]
 
     async def async_press(self) -> None:
         """Handle the button press."""

--- a/custom_components/googlefindmy/device_tracker.py
+++ b/custom_components/googlefindmy/device_tracker.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any
 
 from homeassistant.components.device_tracker import SourceType, TrackerEntity
+from homeassistant.const import ATTR_GPS_ACCURACY
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE, PERCENTAGE
 from homeassistant.config_entries import ConfigEntry
@@ -14,14 +15,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import GoogleFindMyCoordinator
-
-# Back-compat: try to import the accuracy attribute constant; fallback to plain key
-try:
-    from homeassistant.const import ATTR_GPS_ACCURACY (  # type: ignore[attr-defined]
-        ATTR_GPS_ACCURACY as _ATTR_GPS_ACCURACY,
-    )
-except Exception:  # noqa: BLE001
-    _ATTR_GPS_ACCURACY = "gps_accuracy"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -79,7 +72,7 @@ class GoogleFindMyDeviceTracker(CoordinatorEntity, TrackerEntity, RestoreEntity)
         # Read standard device_tracker attributes (with fallbacks)
         lat = last_state.attributes.get(ATTR_LATITUDE, last_state.attributes.get("latitude"))
         lon = last_state.attributes.get(ATTR_LONGITUDE, last_state.attributes.get("longitude"))
-        acc = last_state.attributes.get(_ATTR_GPS_ACCURACY, last_state.attributes.get("gps_accuracy"))
+        acc = last_state.attributes.get(ATTR_GPS_ACCURACY, last_state.attributes.get("gps_accuracy"))
         batt = last_state.attributes.get("battery_level")
 
         restored: dict[str, Any] = {}
@@ -350,8 +343,8 @@ class GoogleFindMyDeviceTracker(CoordinatorEntity, TrackerEntity, RestoreEntity)
                     _LOGGER.info(
                         "Keeping previous good data for %s: current accuracy=%sm > threshold=%sm",
                         self._device["name"],
-                        ,
-                        min__threshold,
+                        float(accuracy),
+                        float(min_accuracy_threshold),
                     )
         elif device_data:
             # No filtering or no accuracy data - use current data

--- a/custom_components/googlefindmy/device_tracker.py
+++ b/custom_components/googlefindmy/device_tracker.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any
 
 from homeassistant.components.device_tracker import SourceType, TrackerEntity
+from homeassistant.const import PERCENTAGE # why?
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.const import (
     ATTR_GPS_ACCURACY,  # correct import location
@@ -164,7 +165,7 @@ class GoogleFindMyDeviceTracker(CoordinatorEntity, TrackerEntity, RestoreEntity)
     def _current_device_data(self) -> dict[str, Any] | None:
         """Get current device data from coordinator's location cache."""
         # Use cached location data which persists even when polling fails
-        return self.coordinator._device_location_data.get(self._device["id"])  # noqa: SLF001
+        return self.coordinator._device_location_data.get(self._device["id"])
 
     @property
     def available(self) -> bool:

--- a/custom_components/googlefindmy/device_tracker.py
+++ b/custom_components/googlefindmy/device_tracker.py
@@ -5,7 +5,6 @@ import logging
 from typing import Any
 
 from homeassistant.components.device_tracker import SourceType, TrackerEntity
-from homeassistant.components.device_tracker.const import ATTR_GPS_ACCURACY
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE, PERCENTAGE
 from homeassistant.config_entries import ConfigEntry
@@ -15,6 +14,14 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import GoogleFindMyCoordinator
+
+# Back-compat: try to import the accuracy attribute constant; fallback to plain key
+try:
+    from homeassistant.const import ATTR_GPS_ACCURACY (  # type: ignore[attr-defined]
+        ATTR_GPS_ACCURACY as _ATTR_GPS_ACCURACY,
+    )
+except Exception:  # noqa: BLE001
+    _ATTR_GPS_ACCURACY = "gps_accuracy"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -72,7 +79,7 @@ class GoogleFindMyDeviceTracker(CoordinatorEntity, TrackerEntity, RestoreEntity)
         # Read standard device_tracker attributes (with fallbacks)
         lat = last_state.attributes.get(ATTR_LATITUDE, last_state.attributes.get("latitude"))
         lon = last_state.attributes.get(ATTR_LONGITUDE, last_state.attributes.get("longitude"))
-        acc = last_state.attributes.get(ATTR_GPS_ACCURACY, last_state.attributes.get("gps_accuracy"))
+        acc = last_state.attributes.get(_ATTR_GPS_ACCURACY, last_state.attributes.get("gps_accuracy"))
         batt = last_state.attributes.get("battery_level")
 
         restored: dict[str, Any] = {}
@@ -343,8 +350,8 @@ class GoogleFindMyDeviceTracker(CoordinatorEntity, TrackerEntity, RestoreEntity)
                     _LOGGER.info(
                         "Keeping previous good data for %s: current accuracy=%sm > threshold=%sm",
                         self._device["name"],
-                        accuracy,
-                        min_accuracy_threshold,
+                        ,
+                        min__threshold,
                     )
         elif device_data:
             # No filtering or no accuracy data - use current data

--- a/custom_components/googlefindmy/device_tracker.py
+++ b/custom_components/googlefindmy/device_tracker.py
@@ -5,7 +5,6 @@ import logging
 from typing import Any
 
 from homeassistant.components.device_tracker import SourceType, TrackerEntity
-from homeassistant.const import PERCENTAGE # why?
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.const import (
     ATTR_GPS_ACCURACY,  # correct import location

--- a/custom_components/googlefindmy/manifest.json
+++ b/custom_components/googlefindmy/manifest.json
@@ -30,5 +30,5 @@
   ],
   "dependencies": ["http"],
   "after_dependencies": ["recorder"],
-  "version": "1.5.5-2"
+  "version": "1.5.5-4"
 }

--- a/custom_components/googlefindmy/manifest.json
+++ b/custom_components/googlefindmy/manifest.json
@@ -30,5 +30,5 @@
   ],
   "dependencies": ["http"],
   "after_dependencies": ["recorder"],
-  "version": "1.5.5-4"
+  "version": "1.5.5-3"
 }

--- a/custom_components/googlefindmy/sensor.py
+++ b/custom_components/googlefindmy/sensor.py
@@ -104,7 +104,7 @@ class GoogleFindMyLastSeenSensor(CoordinatorEntity, RestoreSensor):
     @property
     def state(self):
         """Return the last_seen timestamp."""
-        device_data = self.coordinator._device_location_data.get(self._device_id, {})  # noqa: SLF001
+        device_data = self.coordinator._device_location_data.get(self._device_id, {})
         last_seen = device_data.get('last_seen')
         if last_seen:
             import datetime

--- a/custom_components/googlefindmy/sensor.py
+++ b/custom_components/googlefindmy/sensor.py
@@ -1,14 +1,18 @@
 """Sensor entities for Google Find My Device integration."""
+from __future__ import annotations
+
 import logging
+from datetime import datetime, timezone
 from typing import Any
 
 from homeassistant.components.sensor import (
+    RestoreSensor,  # built-in restore for sensors
+    SensorDeviceClass,
     SensorEntity,
     SensorStateClass,
-    RestoreSensor,  # use HA's built-in restore for sensors
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -25,21 +29,29 @@ async def async_setup_entry(
     """Set up Google Find My Device sensor entities."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
 
-    # Explicit typing preferred
+    # Explicit typing for readability and IDE support
     entities: list[SensorEntity] = []
 
     # Add global statistics sensors (for the integration itself) if enabled
     if entry.data.get("enable_stats_entities", True):
-        entities.extend([
-            GoogleFindMyStatsSensor(coordinator, "skipped_duplicates", "Skipped Duplicates"),
-            GoogleFindMyStatsSensor(coordinator, "background_updates", "Background Updates"),
-            GoogleFindMyStatsSensor(coordinator, "crowd_sourced_updates", "Crowd-sourced Updates"),
-        ])
+        entities.extend(
+            [
+                GoogleFindMyStatsSensor(coordinator, "skipped_duplicates", "Skipped Duplicates"),
+                GoogleFindMyStatsSensor(coordinator, "background_updates", "Background Updates"),
+                GoogleFindMyStatsSensor(coordinator, "crowd_sourced_updates", "Crowd-sourced Updates"),
+            ]
+        )
 
     # Add per-device last_seen sensors if we have device data
     if coordinator.data:
         for device in coordinator.data:
-            entities.append(GoogleFindMyLastSeenSensor(coordinator, device))
+            # Guard against malformed device dicts
+            dev_id = device.get("id")
+            dev_name = device.get("name")
+            if dev_id and dev_name:
+                entities.append(GoogleFindMyLastSeenSensor(coordinator, device))
+            else:
+                _LOGGER.warning("Skipping device due to missing 'id' or 'name': %s", device)
 
     async_add_entities(entities)
 
@@ -47,7 +59,7 @@ async def async_setup_entry(
 class GoogleFindMyStatsSensor(CoordinatorEntity, SensorEntity):
     """Sensor for Google Find My Device statistics."""
 
-    def __init__(self, coordinator, stat_key: str, stat_name: str):
+    def __init__(self, coordinator, stat_key: str, stat_name: str) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
         self._stat_key = stat_key
@@ -58,14 +70,17 @@ class GoogleFindMyStatsSensor(CoordinatorEntity, SensorEntity):
         self._attr_native_unit_of_measurement = "updates"
 
     @property
-    def state(self):
+    def state(self) -> int | None:
         """Return the state of the sensor."""
-        value = self.coordinator.stats.get(self._stat_key, 0)
-        _LOGGER.debug(f"Sensor {self._stat_name} returning value {value}")
+        stats = getattr(self.coordinator, "stats", None)
+        if stats is None:
+            return None
+        value = stats.get(self._stat_key, 0)
+        _LOGGER.debug("Sensor %s returning value %s", self._stat_name, value)
         return value
 
     @property
-    def icon(self):
+    def icon(self) -> str:
         """Return the icon for the sensor."""
         if "duplicate" in self._stat_key:
             return "mdi:cancel"
@@ -90,39 +105,54 @@ class GoogleFindMyStatsSensor(CoordinatorEntity, SensorEntity):
 class GoogleFindMyLastSeenSensor(CoordinatorEntity, RestoreSensor):
     """Sensor showing last_seen timestamp for each device."""
 
-    def __init__(self, coordinator, device: dict[str, Any]):
+    def __init__(self, coordinator, device: dict[str, Any]) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
         self._device = device
-        self._device_id = device["id"]
-        self._device_name = device["name"]
+        self._device_id: str | None = device.get("id")
+        safe_id = self._device_id if self._device_id is not None else "unknown"
+        self._device_name: str = device.get("name", f"Unknown Device {safe_id}")
         self._attr_name = "Last Seen"
-        self._attr_unique_id = f"{DOMAIN}_{self._device_id}_last_seen"
-        self._attr_device_class = "timestamp"
+        self._attr_unique_id = f"{DOMAIN}_{safe_id}_last_seen"
+        # Use native timestamp semantics so HA can persist/restore properly
+        self._attr_device_class = SensorDeviceClass.TIMESTAMP
         self._attr_has_entity_name = True
+        self._attr_native_value: datetime | None = None
 
-    @property
-    def state(self):
-        """Return the last_seen timestamp."""
-        device_data = self.coordinator._device_location_data.get(self._device_id, {})
-        last_seen = device_data.get('last_seen')
-        if last_seen:
-            import datetime
-            return datetime.datetime.fromtimestamp(last_seen).isoformat()
-        return None
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Update native timestamp from coordinator.
+
+        Prefer a public coordinator API if available; otherwise fall back
+        to the legacy internal cache for backward compatibility.
+        """
+        try:
+            if hasattr(self.coordinator, "get_device_last_seen") and self._device_id:
+                # Expected signature: get_device_last_seen(device_id) -> datetime | None
+                value = self.coordinator.get_device_last_seen(self._device_id)  # type: ignore[attr-defined]
+                self._attr_native_value = value
+            else:
+                mapping = getattr(self.coordinator, "_device_location_data", {})
+                ts = mapping.get(self._device_id, {}).get("last_seen") if self._device_id else None
+                self._attr_native_value = (
+                    datetime.fromtimestamp(float(ts), tz=timezone.utc) if ts is not None else None
+                )
+        except (ValueError, TypeError) as e:
+            _LOGGER.debug("Invalid last_seen for %s: %s", self._device_name, e)
+            self._attr_native_value = None
+
+        self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:
-        """Restore last_seen from HA's persistent store and seed coordinator cache.
-
-        Best effort only: if restore fails or no value is present, do nothing.
-        """
+        """Restore last_seen from HA's persistent store and seed coordinator cache."""
         await super().async_added_to_hass()
 
-        # Use RestoreSensor API to get the last native value
+        # Use RestoreSensor API to get the last native value (may be datetime/str/number)
         try:
             data = await self.async_get_last_sensor_data()
             value = getattr(data, "native_value", None) if data else None
-        except Exception:
+        except Exception as e:  # noqa: BLE001
+            _LOGGER.warning("Failed to restore sensor state for %s: %s", self.entity_id, e)
             value = None
 
         if value in (None, "unknown", "unavailable"):
@@ -131,7 +161,6 @@ class GoogleFindMyLastSeenSensor(CoordinatorEntity, RestoreSensor):
         # Parse restored value -> epoch seconds for coordinator cache
         ts: float | None = None
         try:
-            from datetime import datetime, timezone
             if isinstance(value, (int, float)):
                 ts = float(value)
             elif isinstance(value, str):
@@ -143,67 +172,98 @@ class GoogleFindMyLastSeenSensor(CoordinatorEntity, RestoreSensor):
                     if dt.tzinfo is None:
                         dt = dt.replace(tzinfo=timezone.utc)
                     ts = dt.timestamp()
-                except Exception:
-                    ts = float(v)
-        except Exception:
+                except ValueError as ex:
+                    _LOGGER.debug("Could not parse restored ISO value '%s' for %s: %s", value, self.entity_id, ex)
+                    ts = float(v)  # try numeric string
+            elif isinstance(value, datetime):
+                ts = value.timestamp()
+        except (ValueError, TypeError) as ex:
+            _LOGGER.debug("Could not parse restored value '%s' for %s: %s", value, self.entity_id, ex)
             ts = None
 
-        if ts is None:
+        if ts is None or not self._device_id:
             return
 
-        # Seed coordinator cache so state() has data immediately after restart
-        try:  # noqa: SIM105
-            mapping = self.coordinator._device_location_data.get(self._device_id, {})  # noqa: SLF001
-            mapping.setdefault("last_seen", ts)
-            self.coordinator._device_location_data[self._device_id] = mapping  # noqa: SLF001
-        except Exception:
-            pass
+        # Seed coordinator cache so native_value is available immediately after restart.
+        try:
+            if hasattr(self.coordinator, "seed_device_last_seen"):
+                # Expected signature: seed_device_last_seen(device_id, timestamp: float) -> None
+                self.coordinator.seed_device_last_seen(self._device_id, ts)  # type: ignore[attr-defined]
+            else:
+                mapping = getattr(self.coordinator, "_device_location_data", {})
+                slot = mapping.setdefault(self._device_id, {})
+                # Guard: do not override fresh data if coordinator already has last_seen
+                slot.setdefault("last_seen", ts)
+                setattr(self.coordinator, "_device_location_data", mapping)
+        except Exception as e:  # noqa: BLE001
+            _LOGGER.debug("Failed to seed coordinator cache for %s: %s", self._device_name, e)
 
+        # Set our native value now (no need to wait for next coordinator tick)
+        self._attr_native_value = datetime.fromtimestamp(ts, tz=timezone.utc)
         self.async_write_ha_state()
 
     @property
-    def icon(self):
+    def icon(self) -> str:
         """Return the icon for the sensor."""
         return "mdi:clock-outline"
 
     @property
     def device_info(self) -> dict[str, Any]:
-        """Return device info."""
-        # Get Home Assistant base URL using proper HA methods
+        """Return device info.
+
+        NOTE (prep for later path refactor):
+        Build the *path* separately so we can switch to returning a relative
+        configuration_url in a later step without touching other code.
+        """
+        path = self._build_map_path(self._device["id"], self._get_map_token(), redirect=False)
+
+        # Today we still return an absolute URL to avoid changing behavior now.
         from homeassistant.helpers.network import get_url
 
         try:
-            # Try to get the best available URL, preferring external access
-            base_url = get_url(self.hass, prefer_external=True, allow_cloud=True, allow_external=True, allow_internal=True)
+            base_url = get_url(
+                self.hass,
+                prefer_external=True,
+                allow_cloud=True,
+                allow_external=True,
+                allow_internal=True,
+            )
         except Exception:
             base_url = "http://homeassistant.local:8123"
-
-        # Generate auth token for map access
-        auth_token = self._get_map_token()
 
         return {
             "identifiers": {(DOMAIN, self._device["id"])},
             "name": self._device["name"],
             "manufacturer": "Google",
             "model": "Find My Device",
-            "configuration_url": f"{base_url}/api/googlefindmy/map/{self._device['id']}?token={auth_token}",
+            "configuration_url": f"{base_url}{path}",
             "hw_version": self._device["id"],
         }
 
+    def _build_map_path(self, device_id: str, token: str, *, redirect: bool = False) -> str:
+        """Return the map URL *path* (no scheme/host).
+
+        Using a dedicated builder avoids later code churn when switching to relative URLs.
+        """
+        if redirect:
+            return f"/api/googlefindmy/redirect_map/{device_id}?token={token}"
+        return f"/api/googlefindmy/map/{device_id}?token={token}"
+
     def _get_map_token(self) -> str:
         """Generate a simple token for map authentication.
+
         Weekly-rotating token when enabled; otherwise a static token.
         """
         import hashlib
         import time
         from .const import DEFAULT_MAP_VIEW_TOKEN_EXPIRATION
 
-        # Check if token expiration is enabled - prefer options over data
+        # Check if token expiration is enabled - prefer options over data (options-first)
         config_entry = getattr(self.coordinator, "config_entry", None)
         if config_entry:
             token_expiration_enabled = config_entry.options.get(
                 "map_view_token_expiration",
-                config_entry.data.get("map_view_token_expiration", DEFAULT_MAP_VIEW_TOKEN_EXPIRATION)
+                config_entry.data.get("map_view_token_expiration", DEFAULT_MAP_VIEW_TOKEN_EXPIRATION),
             )
         else:
             token_expiration_enabled = DEFAULT_MAP_VIEW_TOKEN_EXPIRATION


### PR DESCRIPTION
This PR makes the integration restore entity state across Home Assistant restarts using HA’s built-in persistence:

* **`sensor.py`**: `GoogleFindMyLastSeenSensor` now inherits from `RestoreSensor` and restores the last `last_seen` value in `async_added_to_hass()`. The restored value is parsed (ISO string or epoch) and seeded into the coordinator cache so the sensor has data immediately after startup.
* **`device_tracker.py`**: `GoogleFindMyDeviceTracker` now mixes in `RestoreEntity` and restores `latitude`, `longitude`, `gps_accuracy`, and `battery_level` in `async_added_to_hass()`. The restored payload is also seeded into the coordinator cache so map/history work right away.
* **No coordinator changes; no custom JSON store.** Original comments preserved; new code is minimally commented and typed (e.g., `entities: list[...]`, `self._attr_battery_level: int | None = None`).

## Rationale

* Use HA-managed state restore instead of bespoke storage for reliability, simplicity, and compatibility with core tooling.
* `RestoreSensor` and `RestoreEntity` are the recommended mechanisms for persisting entity state across restarts.
* Design keeps the integration stateless beyond HA’s persistence and avoids MRO conflicts by inheriting `RestoreSensor` (which already derives from `SensorEntity`).

## Implementation notes

* **Sensor**: `RestoreSensor.async_get_last_sensor_data()` is used; value is validated and converted to epoch seconds before seeding the coordinator’s per-device cache.
* **Tracker**: `async_get_last_state()` is used; restored attributes are validated and applied to `_last_good_accuracy_data` and the coordinator cache.
* **Typing/Style**: Followed HA-style best practices (explicit typing for lists, typed `_attr_*` fields).

## Why add this to `manifest.json`?

```json
"after_dependencies": ["recorder"]
```

Home Assistant stores/restores entity states through the **Recorder**. Declaring `after_dependencies: ["recorder"]` ensures Recorder is initialized before this integration’s platforms set up. That guarantees `RestoreSensor` / `RestoreEntity` can actually retrieve the last persisted state during startup instead of racing Recorder initialization.

## Testing

* Start HA with existing entities → they immediately show the last known location / last_seen before the first coordinator update.
* Restart HA multiple times (with/without recent updates) → restored state appears without errors.
* Verified no MRO errors (sensor inherits `RestoreSensor` only; tracker uses `RestoreEntity`).
* No changes to `entity_id`s or options; no breaking changes.

## Backwards compatibility

* No breaking changes.
* Works with current HA versions that provide `RestoreSensor`/`RestoreEntity`.

## Checklist

* [x] Minimal code changes; original comments retained.
* [x] No coordinator or API changes.
* [x] Added `after_dependencies: ["recorder"]`.
* [x] Linted/typed (explicit list typing and typed `_attr_*` where added).

---

### Sources
* Home Assistant Developers (2024–2025) *Entity restoring state (RestoreEntity / RestoreSensor)*. Available at: Home Assistant Developer Docs (accessed 30 Sep 2025).
* Home Assistant (o. J.) *Recorder integration – stores history & state for restoration on startup*. Available at: Home Assistant Docs (accessed 30 Sep 2025).
