### PR TITLE
i18n: Migrate strings to `translations/` and add full EN/DE/FR/PL/ES (remove `{info}` placeholder usage)

### DIFF
--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -1,0 +1,94 @@
+{
+  "title": "Google Find My Device",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Google Find My Device – Anmeldung",
+        "description": "Wähle die Authentifizierungsmethode. Methode 1 wird empfohlen, wenn du GoogleFindMyTools auf einem Rechner mit Chrome ausführen kannst.",
+        "data": {
+          "auth_method": "Authentifizierungsmethode"
+        }
+      },
+      "secrets_json": {
+        "title": "Methode 1: GoogleFindMyTools secrets.json",
+        "description": "Führe GoogleFindMyTools (Chrome) aus, um Authentifizierungs-Tokens zu erzeugen, und füge unten den vollständigen Inhalt der Datei Auth/secrets.json ein.",
+        "data": {
+          "secrets_json": "Inhalt der secrets.json"
+        }
+      },
+      "individual_tokens": {
+        "title": "Methode 2: Einzelner OAuth-Token",
+        "description": "Gib deinen OAuth-Token und deine Google-E-Mail-Adresse aus dem manuellen Authentifizierungsprozess ein.",
+        "data": {
+          "oauth_token": "OAuth-Token",
+          "google_email": "Google-E-Mail-Adresse"
+        }
+      },
+      "device_selection": {
+        "title": "Geräte & Abfrage",
+        "description": "Wähle die zu trackenden Geräte und konfiguriere die Abfrageparameter:\n• Abfrageintervall Position: Start eines neuen Abfragezyklus (60–3600 Sekunden)\n• Verzögerung zwischen Geräteabfragen: Abstand zwischen Abfragen einzelner Geräte innerhalb eines Zyklus (1–60 Sekunden)\n\nDie Integration ruft die Geräte nacheinander ab und fordert für jedes Gerät mit der angegebenen Verzögerung Positionsdaten an.",
+        "data": {
+          "tracked_devices": "Getrackte Geräte",
+          "location_poll_interval": "Abfrageintervall Position (s)",
+          "device_poll_delay": "Verzögerung zwischen Geräteabfragen (s)"
+        }
+      }
+    },
+    "error": {
+      "auth_failed": "Anmeldung fehlgeschlagen. Bitte erneut versuchen.",
+      "invalid_token": "Ungültiger Token oder erforderliche Felder fehlen.",
+      "invalid_json": "Ungültiges JSON im Inhalt der secrets.json.",
+      "no_devices": "Keine Geräte gefunden. Bitte stelle sicher, dass „Find My Device“ im Google-Konto aktiviert ist.",
+      "cannot_connect": "Verbindung zur Google-API fehlgeschlagen. Eventuell ein temporäres Problem – bitte später erneut versuchen.",
+      "unknown": "Unerwarteter Fehler."
+    },
+    "abort": {
+      "already_configured": "Google Find My Device ist bereits konfiguriert.",
+      "cannot_connect": "Verbindung zu Google Find My Device fehlgeschlagen."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Optionen",
+        "description": "Tracking-Einstellungen anpassen:\n• Abfrageintervall Position: Wie häufig Positionen abgefragt werden (60–3600 Sekunden)\n• Verzögerung zwischen Geräteabfragen: Abstand zwischen Abfragen einzelner Geräte (1–60 Sekunden)\n• Mindestgenauigkeit: Positionen schlechter als dieser Wert ignorieren (25–500 Meter)\n• Bewegungsschwelle: Mindestbewegung, um ein Positions-Update auszulösen (10–200 Meter)\n\nGoogle-Home-Filter:\n• Aktivieren, um Google-Home-Erkennungen der Home-Zone zuzuordnen\n• Keywords unterstützen Teiltreffer (kommagetrennt)\n• Beispiel: „nest“ passt zu „Küche Nest Mini“",
+        "data": {
+          "tracked_devices": "Getrackte Geräte",
+          "location_poll_interval": "Abfrageintervall Position (s)",
+          "device_poll_delay": "Verzögerung zwischen Geräteabfragen (s)",
+          "min_accuracy_threshold": "Mindestgenauigkeit (m)",
+          "movement_threshold": "Bewegungsschwelle (m)",
+          "google_home_filter_enabled": "Google-Home-Geräte filtern",
+          "google_home_filter_keywords": "Filter-Keywords (kommagetrennt)",
+          "enable_stats_entities": "Statistik-Entitäten erstellen",
+          "map_view_token_expiration": "Ablaufendes Map-View-Token verwenden"
+        },
+        "data_description": {
+          "map_view_token_expiration": "Bei Aktivierung laufen Map-View-Tokens nach 1 Woche ab. Deaktiviert (Standard) bedeutet: kein Ablauf."
+        }
+      }
+    }
+  },
+  "services": {
+    "locate_device": {
+      "name": "Gerät lokalisieren",
+      "description": "Ermittelt die aktuelle Position eines Google-Find-My-Geräts.",
+      "fields": {
+        "device_id": {
+          "name": "Geräte-ID",
+          "description": "Die ID des zu lokalisierenden Geräts."
+        }
+      }
+    },
+    "play_sound": {
+      "name": "Ton abspielen",
+      "description": "Spielt einen Ton auf einem Google-Find-My-Gerät ab.",
+      "fields": {
+        "device_id": {
+          "name": "Geräte-ID",
+          "description": "Die ID des Geräts, auf dem der Ton abgespielt wird."
+        }
+      }
+    }
+  }
+}

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -1,0 +1,94 @@
+{
+  "title": "Google Find My Device",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Google Find My Device Authentication",
+        "description": "Choose your authentication method. Method 1 is recommended if you can run GoogleFindMyTools on a computer with Chrome.",
+        "data": {
+          "auth_method": "Authentication Method"
+        }
+      },
+      "secrets_json": {
+        "title": "Method 1: GoogleFindMyTools secrets.json",
+        "description": "Run GoogleFindMyTools (Chrome) to generate authentication tokens, then paste the full contents of the Auth/secrets.json file below.",
+        "data": {
+          "secrets_json": "Contents of secrets.json file"
+        }
+      },
+      "individual_tokens": {
+        "title": "Method 2: Individual OAuth Token",
+        "description": "Enter your OAuth token and Google email address obtained from a manual authentication process.",
+        "data": {
+          "oauth_token": "OAuth Token",
+          "google_email": "Google Email Address"
+        }
+      },
+      "device_selection": {
+        "title": "Select devices and polling",
+        "description": "Select the devices to track and configure the polling parameters:\n• Location poll interval: How often to start a new polling cycle (60–3600 seconds)\n• Device poll delay: Delay between individual device polls within a cycle (1–60 seconds)\n\nThe integration cycles through devices sequentially, requesting location data for each device with the specified delay.",
+        "data": {
+          "tracked_devices": "Tracked devices",
+          "location_poll_interval": "Location poll interval (s)",
+          "device_poll_delay": "Device poll delay (s)"
+        }
+      }
+    },
+    "error": {
+      "auth_failed": "Authentication failed. Please try again.",
+      "invalid_token": "Invalid token provided or required fields are missing.",
+      "invalid_json": "Invalid JSON format in secrets.json content.",
+      "no_devices": "No devices found. Please ensure that Find My Device is enabled on your Google account.",
+      "cannot_connect": "Failed to connect to the Google API. This may be temporary — please try again later.",
+      "unknown": "Unexpected error occurred."
+    },
+    "abort": {
+      "already_configured": "Google Find My Device is already configured.",
+      "cannot_connect": "Failed to connect to Google Find My Device."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Options",
+        "description": "Modify tracking settings:\n• Location poll interval: How often to poll for locations (60–3600 seconds)\n• Device poll delay: Delay between device polls (1–60 seconds)\n• Min accuracy threshold: Ignore locations worse than this (25–500 meters)\n• Movement threshold: Minimum movement to trigger a location update (10–200 meters)\n\nGoogle Home Filter:\n• Enable to group Google Home detections into the Home zone\n• Keywords support partial matching (comma-separated)\n• Example: 'nest' matches 'Kitchen Nest Mini'",
+        "data": {
+          "tracked_devices": "Tracked devices",
+          "location_poll_interval": "Location poll interval (s)",
+          "device_poll_delay": "Device poll delay (s)",
+          "min_accuracy_threshold": "Minimum accuracy (m)",
+          "movement_threshold": "Movement threshold (m)",
+          "google_home_filter_enabled": "Filter Google Home devices",
+          "google_home_filter_keywords": "Filter keywords (comma-separated)",
+          "enable_stats_entities": "Create statistics entities",
+          "map_view_token_expiration": "Enable map view token expiration"
+        },
+        "data_description": {
+          "map_view_token_expiration": "When enabled, map view tokens expire after 1 week. When disabled (default), tokens do not expire."
+        }
+      }
+    }
+  },
+  "services": {
+    "locate_device": {
+      "name": "Locate Device",
+      "description": "Get the current location of a Google Find My device.",
+      "fields": {
+        "device_id": {
+          "name": "Device ID",
+          "description": "The ID of the device to locate."
+        }
+      }
+    },
+    "play_sound": {
+      "name": "Play Sound",
+      "description": "Play a sound on a Google Find My device.",
+      "fields": {
+        "device_id": {
+          "name": "Device ID",
+          "description": "The ID of the device on which the sound will be played."
+        }
+      }
+    }
+  }
+}

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -1,0 +1,94 @@
+{
+  "title": "Google Find My Device",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Autenticación de Google Find My Device",
+        "description": "Elige el método de autenticación. El método 1 se recomienda si puedes ejecutar GoogleFindMyTools en un ordenador con Chrome.",
+        "data": {
+          "auth_method": "Método de autenticación"
+        }
+      },
+      "secrets_json": {
+        "title": "Método 1: GoogleFindMyTools secrets.json",
+        "description": "Ejecuta GoogleFindMyTools (Chrome) para generar los tokens de autenticación y pega a continuación el contenido completo del archivo Auth/secrets.json.",
+        "data": {
+          "secrets_json": "Contenido del archivo secrets.json"
+        }
+      },
+      "individual_tokens": {
+        "title": "Método 2: Token OAuth individual",
+        "description": "Introduce tu token OAuth y tu dirección de correo de Google obtenidos mediante el proceso de autenticación manual.",
+        "data": {
+          "oauth_token": "Token OAuth",
+          "google_email": "Dirección de correo de Google"
+        }
+      },
+      "device_selection": {
+        "title": "Selección de dispositivos y sondeo",
+        "description": "Selecciona los dispositivos a seguir y configura los parámetros de sondeo:\n• Intervalo de sondeo de ubicación: con qué frecuencia iniciar un nuevo ciclo (60–3600 segundos)\n• Retardo entre sondeos de dispositivos: intervalo entre las consultas de cada dispositivo dentro de un ciclo (1–60 segundos)\n\nLa integración recorre los dispositivos de forma secuencial y solicita datos de ubicación para cada uno con el retardo indicado.",
+        "data": {
+          "tracked_devices": "Dispositivos seguidos",
+          "location_poll_interval": "Intervalo de sondeo de ubicación (s)",
+          "device_poll_delay": "Retardo entre sondeos de dispositivos (s)"
+        }
+      }
+    },
+    "error": {
+      "auth_failed": "Error de autenticación. Vuelve a intentarlo.",
+      "invalid_token": "Token no válido o faltan campos obligatorios.",
+      "invalid_json": "Formato JSON no válido en el contenido de secrets.json.",
+      "no_devices": "No se han encontrado dispositivos. Asegúrate de que «Encontrar mi dispositivo» esté activado en tu cuenta de Google.",
+      "cannot_connect": "No se pudo conectar con la API de Google. Puede ser un problema temporal: inténtalo de nuevo más tarde.",
+      "unknown": "Error inesperado."
+    },
+    "abort": {
+      "already_configured": "Google Find My Device ya está configurado.",
+      "cannot_connect": "No se pudo conectar con Google Find My Device."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Opciones",
+        "description": "Modificar la configuración de seguimiento:\n• Intervalo de sondeo de ubicación: frecuencia de consulta de ubicaciones (60–3600 segundos)\n• Retardo entre sondeos de dispositivos: intervalo entre consultas por dispositivo (1–60 segundos)\n• Precisión mínima: ignorar ubicaciones peores que este valor (25–500 metros)\n• Umbral de movimiento: movimiento mínimo que desencadena una actualización de ubicación (10–200 metros)\n\nFiltro de Google Home:\n• Activar para agrupar las detecciones de Google Home en la zona «Hogar»\n• Las palabras clave aceptan coincidencias parciales (separadas por comas)\n• Ejemplo: «nest» coincide con «Kitchen Nest Mini»",
+        "data": {
+          "tracked_devices": "Dispositivos seguidos",
+          "location_poll_interval": "Intervalo de sondeo de ubicación (s)",
+          "device_poll_delay": "Retardo entre sondeos de dispositivos (s)",
+          "min_accuracy_threshold": "Precisión mínima (m)",
+          "movement_threshold": "Umbral de movimiento (m)",
+          "google_home_filter_enabled": "Filtrar dispositivos Google Home",
+          "google_home_filter_keywords": "Palabras clave del filtro (separadas por comas)",
+          "enable_stats_entities": "Crear entidades de estadísticas",
+          "map_view_token_expiration": "Activar caducidad del token de la vista de mapa"
+        },
+        "data_description": {
+          "map_view_token_expiration": "Si está activado, los tokens de la vista de mapa caducan tras 1 semana. Si está desactivado (por defecto), no caducan."
+        }
+      }
+    }
+  },
+  "services": {
+    "locate_device": {
+      "name": "Localizar dispositivo",
+      "description": "Obtiene la ubicación actual de un dispositivo de Google Find My.",
+      "fields": {
+        "device_id": {
+          "name": "ID del dispositivo",
+          "description": "El identificador del dispositivo que se desea localizar."
+        }
+      }
+    },
+    "play_sound": {
+      "name": "Reproducir sonido",
+      "description": "Reproduce un sonido en un dispositivo de Google Find My.",
+      "fields": {
+        "device_id": {
+          "name": "ID del dispositivo",
+          "description": "El identificador del dispositivo en el que se reproducirá el sonido."
+        }
+      }
+    }
+  }
+}

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -1,0 +1,94 @@
+{
+  "title": "Google Find My Device",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Authentification Google Find My Device",
+        "description": "Choisissez votre méthode d’authentification. La méthode 1 est recommandée si vous pouvez exécuter GoogleFindMyTools sur un ordinateur avec Chrome.",
+        "data": {
+          "auth_method": "Méthode d’authentification"
+        }
+      },
+      "secrets_json": {
+        "title": "Méthode 1 : GoogleFindMyTools secrets.json",
+        "description": "Exécutez GoogleFindMyTools (Chrome) pour générer des jetons d’authentification, puis collez ci-dessous le contenu complet du fichier Auth/secrets.json.",
+        "data": {
+          "secrets_json": "Contenu du fichier secrets.json"
+        }
+      },
+      "individual_tokens": {
+        "title": "Méthode 2 : Jeton OAuth individuel",
+        "description": "Saisissez votre jeton OAuth et votre adresse e-mail Google obtenus lors d’un processus d’authentification manuel.",
+        "data": {
+          "oauth_token": "Jeton OAuth",
+          "google_email": "Adresse e-mail Google"
+        }
+      },
+      "device_selection": {
+        "title": "Sélection des appareils et interrogation",
+        "description": "Sélectionnez les appareils à suivre et configurez les paramètres d’interrogation :\n• Intervalle d’interrogation de position : fréquence de démarrage d’un nouveau cycle (60–3600 secondes)\n• Délai entre les interrogations d’appareil : intervalle entre les requêtes pour chaque appareil au sein d’un cycle (1–60 secondes)\n\nL’intégration interroge les appareils de manière séquentielle et demande les données de position pour chaque appareil avec le délai spécifié.",
+        "data": {
+          "tracked_devices": "Appareils suivis",
+          "location_poll_interval": "Intervalle d’interrogation de position (s)",
+          "device_poll_delay": "Délai entre les interrogations d’appareil (s)"
+        }
+      }
+    },
+    "error": {
+      "auth_failed": "Échec de l’authentification. Veuillez réessayer.",
+      "invalid_token": "Jeton invalide ou champs requis manquants.",
+      "invalid_json": "Format JSON invalide dans le contenu de secrets.json.",
+      "no_devices": "Aucun appareil trouvé. Assurez-vous que « Localiser mon appareil » est activé sur votre compte Google.",
+      "cannot_connect": "Échec de la connexion à l’API Google. Il peut s’agir d’un problème temporaire — réessayez plus tard.",
+      "unknown": "Erreur inattendue."
+    },
+    "abort": {
+      "already_configured": "Google Find My Device est déjà configuré.",
+      "cannot_connect": "Échec de la connexion à Google Find My Device."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Options",
+        "description": "Modifier les paramètres de suivi :\n• Intervalle d’interrogation de position : fréquence des requêtes de position (60–3600 secondes)\n• Délai entre les interrogations d’appareil : intervalle entre les requêtes par appareil (1–60 secondes)\n• Précision minimale : ignorer les positions moins précises que cette valeur (25–500 mètres)\n• Seuil de mouvement : mouvement minimal déclenchant une mise à jour de la position (10–200 mètres)\n\nFiltre Google Home :\n• Activez pour regrouper les détections Google Home dans la zone « Domicile »\n• Les mots-clés acceptent les correspondances partielles (séparés par des virgules)\n• Exemple : « nest » correspond à « Kitchen Nest Mini »",
+        "data": {
+          "tracked_devices": "Appareils suivis",
+          "location_poll_interval": "Intervalle d’interrogation de position (s)",
+          "device_poll_delay": "Délai entre les interrogations d’appareil (s)",
+          "min_accuracy_threshold": "Précision minimale (m)",
+          "movement_threshold": "Seuil de mouvement (m)",
+          "google_home_filter_enabled": "Filtrer les appareils Google Home",
+          "google_home_filter_keywords": "Mots-clés du filtre (séparés par des virgules)",
+          "enable_stats_entities": "Créer des entités de statistiques",
+          "map_view_token_expiration": "Activer l’expiration du jeton de la vue carte"
+        },
+        "data_description": {
+          "map_view_token_expiration": "Lorsqu’elle est activée, les jetons de la vue carte expirent après 1 semaine. Lorsqu’elle est désactivée (par défaut), ils n’expirent pas."
+        }
+      }
+    }
+  },
+  "services": {
+    "locate_device": {
+      "name": "Localiser l’appareil",
+      "description": "Obtenir la position actuelle d’un appareil Google Find My.",
+      "fields": {
+        "device_id": {
+          "name": "ID de l’appareil",
+          "description": "L’ID de l’appareil à localiser."
+        }
+      }
+    },
+    "play_sound": {
+      "name": "Émettre un son",
+      "description": "Jouer un son sur un appareil Google Find My.",
+      "fields": {
+        "device_id": {
+          "name": "ID de l’appareil",
+          "description": "L’ID de l’appareil sur lequel le son sera joué."
+        }
+      }
+    }
+  }
+}

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -1,0 +1,94 @@
+{
+  "title": "Google Find My Device",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Uwierzytelnianie Google Find My Device",
+        "description": "Wybierz metodę uwierzytelniania. Metoda 1 jest zalecana, jeśli możesz uruchomić GoogleFindMyTools na komputerze z przeglądarką Chrome.",
+        "data": {
+          "auth_method": "Metoda uwierzytelniania"
+        }
+      },
+      "secrets_json": {
+        "title": "Metoda 1: GoogleFindMyTools secrets.json",
+        "description": "Uruchom GoogleFindMyTools (Chrome), aby wygenerować tokeny uwierzytelniające, a następnie wklej poniżej pełną zawartość pliku Auth/secrets.json.",
+        "data": {
+          "secrets_json": "Zawartość pliku secrets.json"
+        }
+      },
+      "individual_tokens": {
+        "title": "Metoda 2: Indywidualny token OAuth",
+        "description": "Wprowadź token OAuth i adres e-mail Google uzyskane podczas ręcznej autoryzacji.",
+        "data": {
+          "oauth_token": "Token OAuth",
+          "google_email": "Adres e-mail Google"
+        }
+      },
+      "device_selection": {
+        "title": "Wybór urządzeń i odpytywania",
+        "description": "Wybierz urządzenia do śledzenia i skonfiguruj parametry odpytywania:\n• Interwał odpytywania lokalizacji: jak często rozpoczynać nowy cykl (60–3600 sekund)\n• Opóźnienie między odpytywaniem urządzeń: odstęp między zapytaniami dla poszczególnych urządzeń w cyklu (1–60 sekund)\n\nIntegracja odpyta urządzenia sekwencyjnie, żądając danych lokalizacji dla każdego urządzenia z podanym opóźnieniem.",
+        "data": {
+          "tracked_devices": "Śledzone urządzenia",
+          "location_poll_interval": "Interwał odpytywania lokalizacji (s)",
+          "device_poll_delay": "Opóźnienie między odpytywaniem urządzeń (s)"
+        }
+      }
+    },
+    "error": {
+      "auth_failed": "Uwierzytelnianie nie powiodło się. Spróbuj ponownie.",
+      "invalid_token": "Podano nieprawidłowy token lub brakuje wymaganych pól.",
+      "invalid_json": "Nieprawidłowy format JSON w zawartości pliku secrets.json.",
+      "no_devices": "Nie znaleziono urządzeń. Upewnij się, że usługa „Znajdź moje urządzenie” jest włączona na Twoim koncie Google.",
+      "cannot_connect": "Nie udało się połączyć z interfejsem Google API. Może to być problem tymczasowy — spróbuj ponownie później.",
+      "unknown": "Wystąpił nieoczekiwany błąd."
+    },
+    "abort": {
+      "already_configured": "Google Find My Device jest już skonfigurowane.",
+      "cannot_connect": "Nie udało się połączyć z Google Find My Device."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Opcje",
+        "description": "Dostosuj ustawienia śledzenia:\n• Interwał odpytywania lokalizacji: jak często pobierać pozycje (60–3600 sekund)\n• Opóźnienie między odpytywaniem urządzeń: odstęp między zapytaniami (1–60 sekund)\n• Minimalna dokładność: ignoruj pozycje gorsze niż ta wartość (25–500 metrów)\n• Próg ruchu: minimalny ruch wyzwalający aktualizację pozycji (10–200 metrów)\n\nFiltr Google Home:\n• Włącz, aby grupować wykrycia Google Home w strefie „Dom”\n• Słowa kluczowe wspierają dopasowania częściowe (oddzielone przecinkami)\n• Przykład: „nest” pasuje do „Kitchen Nest Mini”",
+        "data": {
+          "tracked_devices": "Śledzone urządzenia",
+          "location_poll_interval": "Interwał odpytywania lokalizacji (s)",
+          "device_poll_delay": "Opóźnienie między odpytywaniem urządzeń (s)",
+          "min_accuracy_threshold": "Minimalna dokładność (m)",
+          "movement_threshold": "Próg ruchu (m)",
+          "google_home_filter_enabled": "Filtruj urządzenia Google Home",
+          "google_home_filter_keywords": "Słowa kluczowe filtra (oddzielone przecinkami)",
+          "enable_stats_entities": "Twórz encje statystyczne",
+          "map_view_token_expiration": "Włącz wygasanie tokenu widoku mapy"
+        },
+        "data_description": {
+          "map_view_token_expiration": "Po włączeniu tokeny widoku mapy wygasają po 1 tygodniu. Po wyłączeniu (domyślnie) nie wygasają."
+        }
+      }
+    }
+  },
+  "services": {
+    "locate_device": {
+      "name": "Zlokalizuj urządzenie",
+      "description": "Pobierz bieżącą lokalizację urządzenia Google Find My.",
+      "fields": {
+        "device_id": {
+          "name": "ID urządzenia",
+          "description": "Identyfikator urządzenia do zlokalizowania."
+        }
+      }
+    },
+    "play_sound": {
+      "name": "Odtwórz dźwięk",
+      "description": "Odtwórz dźwięk na urządzeniu Google Find My.",
+      "fields": {
+        "device_id": {
+          "name": "ID urządzenia",
+          "description": "Identyfikator urządzenia, na którym zostanie odtworzony dźwięk."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates all user-facing strings of the custom integration **Google Find My Device** into the standard **`translations/<language>.json`** files and ships **complete translations** for **English, German, French, Polish, and Spanish**. It also removes reliance on `{info}` description placeholders to prevent localization fallback issues.

# What’s changed

* Moved content previously kept in `strings.json` into:

  * `custom_components/googlefindmy/translations/en.json`
  * `custom_components/googlefindmy/translations/de.json`
  * `custom_components/googlefindmy/translations/fr.json`
  * `custom_components/googlefindmy/translations/pl.json`
  * `custom_components/googlefindmy/translations/es.json`
* Provided **full texts** for the following flow steps (config and options), without `{info}` placeholders:

  * `config.step.user`, `config.step.secrets_json`, `config.step.individual_tokens`, `config.step.device_selection`
  * `options.step.init`
* Kept service translations (`services.locate_device`, `services.play_sound`) aligned across all languages.
* Removed any dependency on `{info}` in translation strings (placeholders now unused); code still passes `description_placeholders`, which is harmless and can be cleaned up in a follow-up.

# Rationale

* **Custom integrations must store translatable strings in `translations/<language>.json`** (BCP-47 codes) adjacent to the component. `strings.json` is for **core** integrations and is not loaded for custom components. Moving strings avoids them being ignored and ensures proper loading via the frontend i18n pipeline. ([[Home Assistant Entwicklerdocs](https://developers.home-assistant.io/docs/internationalization/custom_integration/)][1])
* **Placeholder parity across languages is required.** If the English source contains a placeholder like `{info}`, all localized strings must include the same placeholder; otherwise validation fails and Home Assistant falls back to English for that key. By removing `{info}` from English and providing full localized prose, we eliminate mismatches and prevent silent fallbacks. ([[GitHub](https://github.com/home-assistant/core/issues/111516)][2])
* The **config/option flow texts** are defined by the translations and only receive values via `description_placeholders` if the translation contains corresponding placeholders. With placeholders removed from the translation strings, the code-provided values are simply ignored—which is acceptable and keeps behavior stable. ([[Home Assistant Entwicklerdocs](https://developers.home-assistant.io/docs/config_entries_config_flow_handler/)][3])

# Backward compatibility

* **No breaking changes for users.** UI strings now appear localized according to the user’s language; English remains the default fallback when a language file is absent. ([[Home Assistant Entwicklerdocs](https://developers.home-assistant.io/docs/internationalization/custom_integration/)][1])
* Integration logic and config options are unchanged; this PR only affects i18n assets.
* Future cleanup: optionally remove `description_placeholders` usage from `config_flow.py` since translations no longer reference `{info}`.

# Testing / Verification

1. Place the five translation files under `custom_components/googlefindmy/translations/`.
2. Restart Home Assistant and hard-reload the browser.
3. Switch UI language to **EN, DE, FR, PL, ES** and verify:

   * Config flow steps show localized **titles, descriptions, and field labels**.
   * Options flow shows fully localized **multi-paragraph descriptions** (no English fallback).
4. Inspect logs for **no** translation placeholder validation warnings. (If needed, enable debug for `homeassistant.helpers.translation`.) ([[GitHub](https://github.com/home-assistant/core/issues/111516)][2])


* [ ] Add screenshots of the **Options** dialog and **Device Selection** step in at least one non-English language to illustrate the result.

# Checklist

* [x] Moved strings to `translations/` for custom integration compliance. ([[Home Assistant Entwicklerdocs](https://developers.home-assistant.io/docs/internationalization/custom_integration/)][1])
* [x] Added full **EN/DE/FR/PL/ES** coverage.
* [x] Removed `{info}` placeholders from translations to avoid fallback. ([[GitHub](https://github.com/home-assistant/core/issues/111516)][2])
* [x] Verified no placeholder validation warnings.
* [x] No changes to runtime behavior beyond localization.
* [ ] Delete `strings.json`

# Notes for reviewers

* If desired, I can follow up with a small PR to remove `description_placeholders` from `config_flow.py` (dead code now that translations don’t reference `{…}`), but I kept this PR strictly to i18n to minimize risk.

---

## References

* Home Assistant Developers (2024): *Custom integration localization*. Available at: developers.home-assistant.io/docs/internationalization/custom_integration/ (accessed 1 Oct 2025). ([[Home Assistant Entwicklerdocs](https://developers.home-assistant.io/docs/internationalization/custom_integration/)][1])
* Home Assistant Developers (2025): *Config flow*. Available at: developers.home-assistant.io/docs/config_entries_config_flow_handler/ (accessed 1 Oct 2025). ([[Home Assistant Entwicklerdocs](https://developers.home-assistant.io/docs/config_entries_config_flow_handler/)][3])
* Home Assistant Developers (2025): *Contributing translation*. Notes on translation workflow & placeholder expectations. Available at: developers.home-assistant.io/docs/translations/ (accessed 1 Oct 2025). ([[Home Assistant Entwicklerdocs](https://developers.home-assistant.io/docs/translations/)][4])
* Home Assistant Core (2024): *Validation of translation placeholders … failed* (issue #111516). Demonstrates strict placeholder parity and fallback behavior. Available at: github.com/home-assistant/core/issues/111516 (accessed 1 Oct 2025). ([[GitHub](https://github.com/home-assistant/core/issues/111516)][2])

[1]: https://developers.home-assistant.io/docs/internationalization/custom_integration/ "Custom integration localization"
[2]: https://github.com/home-assistant/core/issues/111516 "Validation of translation placeholders for localized (ru) ..."
[3]: https://developers.home-assistant.io/docs/config_entries_config_flow_handler/ "Config flow"
[4]: https://developers.home-assistant.io/docs/translations/ "Contributing translation | Home Assistant Developer Docs"