### PR TITLE
Make Map View origin-agnostic (relative redirect) and fix `configuration_url` to a stable absolute base URL

### DIFF
--- a/custom_components/googlefindmy/button.py
+++ b/custom_components/googlefindmy/button.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -21,19 +21,58 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Google Find My Device button entities."""
+    """Set up Google Find My Device button entities.
+
+    Design goals:
+    - Create Play Sound buttons for devices available at setup time.
+    - Dynamically add buttons for devices that appear later (post-initial refresh),
+      guarded by a known_ids set to avoid duplicates.
+    - Do NOT create skeleton buttons for unknown devices (buttons do not benefit
+      from Restore like sensors/trackers do).
+    """
     coordinator: GoogleFindMyCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    entities = []
-    if coordinator.data:
-        for device in coordinator.data:
-            entities.append(GoogleFindMyPlaySoundButton(coordinator, device))
+    known_ids: set[str] = set()
+    entities: list[GoogleFindMyPlaySoundButton] = []
 
-    async_add_entities(entities, True)
+    # Initial population from coordinator.data (if already available)
+    for device in (coordinator.data or []):
+        dev_id = device.get("id")
+        name = device.get("name")
+        if dev_id and name and dev_id not in known_ids:
+            entities.append(GoogleFindMyPlaySoundButton(coordinator, device))
+            known_ids.add(dev_id)
+
+    # Add initial entities and write state immediately
+    if entities:
+        _LOGGER.debug("Adding %d initial Play Sound button(s)", len(entities))
+        async_add_entities(entities, True)
+
+    # Dynamically add buttons when new devices appear later
+    @callback
+    def _add_new_devices() -> None:
+        new_entities: list[GoogleFindMyPlaySoundButton] = []
+        for device in (coordinator.data or []):
+            dev_id = device.get("id")
+            name = device.get("name")
+            if dev_id and name and dev_id not in known_ids:
+                new_entities.append(GoogleFindMyPlaySoundButton(coordinator, device))
+                known_ids.add(dev_id)
+
+        if new_entities:
+            _LOGGER.debug("Dynamically adding %d Play Sound button(s)", len(new_entities))
+            async_add_entities(new_entities, True)
+
+    # Listen for coordinator updates and try to add any new devices
+    unsub = coordinator.async_add_listener(_add_new_devices)
+    config_entry.async_on_unload(unsub)
 
 
 class GoogleFindMyPlaySoundButton(CoordinatorEntity, ButtonEntity):
-    """Representation of a Google Find My Device play sound button."""
+    """Button to trigger 'Play Sound' on a Google Find My Device."""
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:volume-high"
 
     def __init__(
         self,
@@ -43,23 +82,78 @@ class GoogleFindMyPlaySoundButton(CoordinatorEntity, ButtonEntity):
         """Initialize the button."""
         super().__init__(coordinator)
         self._device = device
-        self._attr_unique_id = f"{DOMAIN}_{device['id']}_play_sound"
-        self._attr_name = f"{device['name']} Play Sound"
-        self._attr_icon = "mdi:volume-high"
-        self._attr_has_entity_name = True
+        dev_id = device["id"]
+        name = device["name"]
+        self._attr_unique_id = f"{DOMAIN}_{dev_id}_play_sound"
+        self._attr_name = f"{name} Play Sound"
 
+    # ---------------- Availability ----------------
+    @property
+    def available(self) -> bool:
+        """Button is available only if the coordinator allows Play Sound.
+
+        Primary source of truth:
+        - coordinator.can_play_sound(device_id) -> bool | None
+          (None = unknown yet)
+
+        Backward compatibility:
+        - If the coordinator doesn't have this method yet (older versions),
+          default to True (optimistic), so the button is not incorrectly greyed out.
+        """
+        dev_id = self._device["id"]
+        can_play = getattr(self.coordinator, "can_play_sound", None)
+
+        if callable(can_play):
+            try:
+                verdict = can_play(dev_id)  # may be True/False/None
+                _LOGGER.debug(
+                    "PlaySound availability for %s (%s): can_play_sound -> %r",
+                    self._device.get("name", dev_id),
+                    dev_id,
+                    verdict,
+                )
+                if verdict is None:
+                    return True  # optimistic while capability is unknown
+                return bool(verdict)
+            except Exception as err:
+                _LOGGER.debug(
+                    "PlaySound availability check for %s (%s) raised %s; defaulting to True",
+                    self._device.get("name", dev_id),
+                    dev_id,
+                    err,
+                )
+                return True
+
+        _LOGGER.debug(
+            "PlaySound availability for %s (%s): legacy coordinator (no can_play_sound) -> default True",
+            self._device.get("name", dev_id),
+            dev_id,
+        )
+        return True
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """React to coordinator updates (availability may change)."""
+        _LOGGER.debug("Coordinator update received for %s", self._attr_unique_id)
+        self.async_write_ha_state()
+
+    # ---------------- Device Info + Map Link ----------------
     @property
     def device_info(self) -> dict[str, Any]:
-        """Return device info."""
-        # Get Home Assistant base URL using proper HA methods
+        """Return device info with a configuration_url to the map view.
+
+        The base URL is resolved via get_url(...) with prefer_external=True so
+        the link also works when the UI is opened through Nabu Casa Cloud or
+        an external URL. We then append the relative path built by
+        _build_map_path(...).
+
+        Runs outside an HTTP request; we intentionally do NOT require the
+        current request context. Home Assistant will choose a stable base URL
+        according to the configured internal/external/cloud URLs.
+        """
         from homeassistant.helpers.network import get_url
 
         try:
-            # Resolve a single absolute base URL for the device registry entry.
-            # Runs outside an HTTP request, so we intentionally do NOT use require_current_request.
-            # Home Assistant selects between internal/external/cloud based on configured URLs
-            # and the 'prefer_external' hint; the stored value remains until the device/integration
-            # is reloaded or HA restarts.
             base_url = get_url(
                 self.hass,
                 prefer_external=True,
@@ -70,9 +164,7 @@ class GoogleFindMyPlaySoundButton(CoordinatorEntity, ButtonEntity):
         except Exception:
             base_url = "http://homeassistant.local:8123"
 
-        # Generate auth token for map access
         auth_token = self._get_map_token()
-        # Build relative map path (consistent with sensor.py)
         path = self._build_map_path(self._device["id"], auth_token, redirect=False)
 
         return {
@@ -80,61 +172,72 @@ class GoogleFindMyPlaySoundButton(CoordinatorEntity, ButtonEntity):
             "name": self._device["name"],
             "manufacturer": "Google",
             "model": "Find My Device",
-            # Minimal change: return **relative** configuration_url.
-            # Open inside the current HA origin (works local/cloud, avoids IP/http-Mix).
             "configuration_url": f"{base_url}{path}",
             "hw_version": self._device["id"],
         }
 
     def _build_map_path(self, device_id: str, token: str, *, redirect: bool = False) -> str:
-        """Return the map URL *path* (no scheme/host)."""
+        """Return the map URL *path* (no scheme/host).
+
+        Keep the path construction here so we can switch to redirect endpoints
+        without touching base URL resolution elsewhere.
+        """
         if redirect:
             return f"/api/googlefindmy/redirect_map/{device_id}?token={token}"
         return f"/api/googlefindmy/map/{device_id}?token={token}"
 
     def _get_map_token(self) -> str:
-        """Generate a simple token for map authentication.
+        """Generate a simple map token (options-first; weekly/static).
 
-        Weekly-rotating token when enabled; otherwise a static token.
+        - Prefer config_entry.options over entry.data to reflect recent option changes.
+        - Weekly-rotating token when enabled; otherwise static token.
         """
         import hashlib
         import time
         from .const import DEFAULT_MAP_VIEW_TOKEN_EXPIRATION
 
-        # Check if token expiration is enabled - prefer options over data
         config_entry = getattr(self.coordinator, "config_entry", None)
         if config_entry:
             token_expiration_enabled = config_entry.options.get(
                 "map_view_token_expiration",
-                config_entry.data.get("map_view_token_expiration", DEFAULT_MAP_VIEW_TOKEN_EXPIRATION)
+                config_entry.data.get("map_view_token_expiration", DEFAULT_MAP_VIEW_TOKEN_EXPIRATION),
             )
         else:
             token_expiration_enabled = DEFAULT_MAP_VIEW_TOKEN_EXPIRATION
 
         ha_uuid = str(self.hass.data.get("core.uuid", "ha"))
-
         if token_expiration_enabled:
-            # Weekly-rolling token (7-day bucket)
-            week = str(int(time.time() // 604800))
+            week = str(int(time.time() // 604800))  # 7-day bucket
             token_src = f"{ha_uuid}:{week}"
         else:
-            # Static token (no rotation)
             token_src = f"{ha_uuid}:static"
 
         return hashlib.md5(token_src.encode()).hexdigest()[:16]
 
+    # ---------------- Action ----------------
     async def async_press(self) -> None:
-        """Handle the button press."""
+        """Handle the button press.
+
+        We perform a pre-check using availability to avoid hitting the API
+        when Push/FCM is not ready or the device isn't ring-capable.
+        """
         device_id = self._device["id"]
         device_name = self._device["name"]
 
-        _LOGGER.debug(f"Play sound button pressed for {device_name} ({device_id})")
+        if not self.available:
+            _LOGGER.warning(
+                "Play Sound not available for %s (%s) — push not ready or device not capable",
+                device_name,
+                device_id,
+            )
+            return
 
+        _LOGGER.debug("Play Sound: attempting on %s (%s)", device_name, device_id)
         try:
             result = await self.coordinator.async_play_sound(device_id)
             if result:
-                _LOGGER.info(f"Successfully played sound on {device_name}")
+                _LOGGER.info("Successfully played sound on %s", device_name)
             else:
-                _LOGGER.warning(f"Failed to play sound on {device_name}")
+                _LOGGER.warning("Failed to play sound on %s", device_name)
         except Exception as err:
-            _LOGGER.error(f"Error playing sound on {device_name}: {err}")
+            _LOGGER.error("Error playing sound on %s: %s", device_name, err)

--- a/custom_components/googlefindmy/button.py
+++ b/custom_components/googlefindmy/button.py
@@ -73,7 +73,7 @@ class GoogleFindMyPlaySoundButton(CoordinatorEntity, ButtonEntity):
         # Generate auth token for map access
         auth_token = self._get_map_token()
         # Build relative map path (consistent with sensor.py)
-        path = self._build_map_path(self._device["id"], auth_token, redirect=True)
+        path = self._build_map_path(self._device["id"], auth_token, redirect=False)
 
         return {
             "identifiers": {(DOMAIN, self._device["id"])},

--- a/custom_components/googlefindmy/device_tracker.py
+++ b/custom_components/googlefindmy/device_tracker.py
@@ -160,7 +160,7 @@ class GoogleFindMyDeviceTracker(CoordinatorEntity, TrackerEntity, RestoreEntity)
             hw_version=self._device["id"],  # Show device ID as hardware version for easy copying
         )
 
-    def _build_map_path(self, device_id: str, token: str, *, redirect: bool = True) -> str:
+    def _build_map_path(self, device_id: str, token: str, *, redirect: bool = False) -> str:
         """Return the map URL *path* (no scheme/host)."""
         if redirect:
             return f"/api/googlefindmy/redirect_map/{device_id}?token={token}"

--- a/custom_components/googlefindmy/device_tracker.py
+++ b/custom_components/googlefindmy/device_tracker.py
@@ -136,7 +136,7 @@ class GoogleFindMyDeviceTracker(CoordinatorEntity, TrackerEntity, RestoreEntity)
         """
         # Generate auth token and build path first
         auth_token = self._get_map_token()
-        path = self._build_map_path(self._device["id"], auth_token, redirect=True)
+        path = self._build_map_path(self._device["id"], auth_token, redirect=False)
 
         # Today: still return absolute URL; redirect endpoint handles origin correctly
         try:

--- a/custom_components/googlefindmy/sensor.py
+++ b/custom_components/googlefindmy/sensor.py
@@ -13,10 +13,11 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DOMAIN, DEFAULT_MAP_VIEW_TOKEN_EXPIRATION
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,10 +30,10 @@ async def async_setup_entry(
     """Set up Google Find My Device sensor entities."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
 
-    # Explicit typing for readability and IDE support
     entities: list[SensorEntity] = []
+    known_ids: set[str] = set()
 
-    # Add global statistics sensors (for the integration itself) if enabled
+    # Global statistics sensors (diagnostic)
     if entry.data.get("enable_stats_entities", True):
         entities.extend(
             [
@@ -42,46 +43,79 @@ async def async_setup_entry(
             ]
         )
 
-    # Add per-device last_seen sensors
+    # Per-device last_seen sensors
     if coordinator.data:
-        # Normal path: we already have live device list
         for device in coordinator.data:
-            # Guard against malformed device dicts
             dev_id = device.get("id")
             dev_name = device.get("name")
             if dev_id and dev_name:
                 entities.append(GoogleFindMyLastSeenSensor(coordinator, device))
+                known_ids.add(dev_id)
             else:
                 _LOGGER.warning("Skipping device due to missing 'id' or 'name': %s", device)
     else:
-        # --- FIX: Ensure sensors exist at startup even without live data (enables Restore) ---
+        # Startup restore path: create skeletons from tracked_devices so Restore works immediately
         tracked_ids: list[str] = getattr(coordinator, "tracked_devices", []) or []
         name_map: dict[str, str] = getattr(coordinator, "_device_names", {})  # noqa: SLF001
         for dev_id in tracked_ids:
             name = name_map.get(dev_id) or f"Find My - {dev_id}"
             entities.append(GoogleFindMyLastSeenSensor(coordinator, {"id": dev_id, "name": name}))
+            known_ids.add(dev_id)
         if tracked_ids:
             _LOGGER.debug(
                 "Created %d skeleton last_seen sensors for restore (no live data yet)",
                 len(tracked_ids),
             )
-        # --- end FIX ---
 
-    async_add_entities(entities)
+    # Immediate state push so restored/native values are written right away
+    if entities:
+        async_add_entities(entities, True)
+
+    # Dynamic entity creation: add sensors when new devices appear later
+    @callback
+    def _add_new_sensors_on_update() -> None:
+        try:
+            new_entities: list[SensorEntity] = []
+            for device in getattr(coordinator, "data", []) or []:
+                dev_id = device.get("id")
+                dev_name = device.get("name")
+                if not dev_id or not dev_name:
+                    continue
+                if dev_id in known_ids:
+                    continue
+                new_entities.append(GoogleFindMyLastSeenSensor(coordinator, device))
+                known_ids.add(dev_id)
+
+            if new_entities:
+                _LOGGER.info("Discovered %d new devices; adding last_seen sensors", len(new_entities))
+                async_add_entities(new_entities, True)
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug("Dynamic sensor add failed: %s", err)
+
+    coordinator.async_add_listener(_add_new_sensors_on_update)
 
 
 class GoogleFindMyStatsSensor(CoordinatorEntity, SensorEntity):
     """Sensor for Google Find My Device statistics."""
 
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
     def __init__(self, coordinator, stat_key: str, stat_name: str) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
         self._stat_key = stat_key
-        self._stat_name = stat_name
         self._attr_name = f"Google Find My {stat_name}"
         self._attr_unique_id = f"{DOMAIN}_{stat_key}"
         self._attr_state_class = SensorStateClass.TOTAL_INCREASING
         self._attr_native_unit_of_measurement = "updates"
+
+        # Variante A: icon einmalig setzen (stabil, performant)
+        icon_map = {
+            "skipped_duplicates": "mdi:cancel",
+            "background_updates": "mdi:cloud-download",
+            "crowd_sourced_updates": "mdi:account-group",
+        }
+        self._attr_icon = icon_map.get(stat_key, "mdi:counter")
 
     @property
     def state(self) -> int | None:
@@ -90,30 +124,19 @@ class GoogleFindMyStatsSensor(CoordinatorEntity, SensorEntity):
         if stats is None:
             return None
         value = stats.get(self._stat_key, 0)
-        _LOGGER.debug("Sensor %s returning value %s", self._stat_name, value)
+        _LOGGER.debug("Sensor %s returning value %s", self._attr_name, value)
         return value
 
     @property
-    def icon(self) -> str:
-        """Return the icon for the sensor."""
-        if "duplicate" in self._stat_key:
-            return "mdi:cancel"
-        elif "background" in self._stat_key:
-            return "mdi:cloud-download"
-        elif "crowd" in self._stat_key:
-            return "mdi:account-group"
-        return "mdi:counter"
-
-    @property
-    def device_info(self) -> dict[str, Any]:
-        """Return device info for integration device."""
-        return {
-            "identifiers": {(DOMAIN, "integration")},
-            "name": "Google Find My Integration",
-            "manufacturer": "BSkando",
-            "model": "Find My Device Integration",
-            "configuration_url": "https://github.com/BSkando/GoogleFindMy-HA",
-        }
+    def device_info(self) -> DeviceInfo:
+        """Return device info for the integration device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, "integration")},
+            name="Google Find My Integration",
+            manufacturer="BSkando",
+            model="Find My Device Integration",
+            configuration_url="https://github.com/BSkando/GoogleFindMy-HA",
+        )
 
 
 class GoogleFindMyLastSeenSensor(CoordinatorEntity, RestoreSensor):
@@ -128,21 +151,25 @@ class GoogleFindMyLastSeenSensor(CoordinatorEntity, RestoreSensor):
         self._device_name: str = device.get("name", f"Unknown Device {safe_id}")
         self._attr_name = "Last Seen"
         self._attr_unique_id = f"{DOMAIN}_{safe_id}_last_seen"
-        # Use native timestamp semantics so HA can persist/restore properly
-        self._attr_device_class = SensorDeviceClass.TIMESTAMP
+        self._attr_device_class = SensorDeviceClass.TIMESTAMP  # native timestamp semantics
         self._attr_has_entity_name = True
         self._attr_native_value: datetime | None = None
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        """Update native timestamp from coordinator.
+        """Update native timestamp and handle device name drift."""
+        # Best-effort: update display name from coordinator's name map (if changed)
+        try:
+            name_map: dict[str, str] = getattr(self.coordinator, "_device_names", {})  # noqa: SLF001
+            new_name = name_map.get(self._device_id or "")
+            if new_name and new_name != self._device.get("name"):
+                self._device["name"] = new_name
+        except Exception as e:  # noqa: BLE001
+            _LOGGER.debug("Name refresh failed for %s: %s", self._device_id, e)
 
-        Prefer a public coordinator API if available; otherwise fall back
-        to the legacy internal cache for backward compatibility.
-        """
+        # Source last_seen from public API (if present) -> fallback to internal cache
         try:
             if hasattr(self.coordinator, "get_device_last_seen") and self._device_id:
-                # Expected signature: get_device_last_seen(device_id) -> datetime | None
                 value = self.coordinator.get_device_last_seen(self._device_id)  # type: ignore[attr-defined]
                 self._attr_native_value = value
             else:
@@ -201,13 +228,12 @@ class GoogleFindMyLastSeenSensor(CoordinatorEntity, RestoreSensor):
         # Seed coordinator cache so native_value is available immediately after restart.
         try:
             if hasattr(self.coordinator, "seed_device_last_seen"):
-                # Expected signature: seed_device_last_seen(device_id, timestamp: float) -> None
+                # Expected: seed_device_last_seen(device_id, timestamp: float) -> None
                 self.coordinator.seed_device_last_seen(self._device_id, ts)  # type: ignore[attr-defined]
             else:
                 mapping = getattr(self.coordinator, "_device_location_data", {})
                 slot = mapping.setdefault(self._device_id, {})
-                # Guard: do not override fresh data if coordinator already has last_seen
-                slot.setdefault("last_seen", ts)
+                slot.setdefault("last_seen", ts)  # don't overwrite fresh data
                 setattr(self.coordinator, "_device_location_data", mapping)
         except Exception as e:  # noqa: BLE001
             _LOGGER.debug("Failed to seed coordinator cache for %s: %s", self._device_name, e)
@@ -222,19 +248,14 @@ class GoogleFindMyLastSeenSensor(CoordinatorEntity, RestoreSensor):
         return "mdi:clock-outline"
 
     @property
-    def device_info(self) -> dict[str, Any]:
-        """Return device info.
-        """
+    def device_info(self) -> DeviceInfo:
+        """Return device info."""
         path = self._build_map_path(self._device["id"], self._get_map_token(), redirect=False)
 
         from homeassistant.helpers.network import get_url
 
         try:
-            # Resolve a single absolute base URL for the device registry entry.
-            # Runs outside an HTTP request, so we intentionally do NOT use require_current_request.
-            # Home Assistant selects between internal/external/cloud based on configured URLs
-            # and the 'prefer_external' hint; the stored value remains until the device/integration
-            # is reloaded or HA restarts.
+            # Absolute base URL so the "Visit" link in device registry works from anywhere.
             base_url = get_url(
                 self.hass,
                 prefer_external=True,
@@ -245,32 +266,26 @@ class GoogleFindMyLastSeenSensor(CoordinatorEntity, RestoreSensor):
         except Exception:
             base_url = "http://homeassistant.local:8123"  # noqa: F841
 
-        return {
-            "identifiers": {(DOMAIN, self._device["id"])},
-            "name": self._device["name"],
-            "manufacturer": "Google",
-            "model": "Find My Device",
-            "configuration_url": f"{base_url}{path}",
-            "hw_version": self._device["id"],
-        }
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._device["id"])},
+            name=self._device["name"],
+            manufacturer="Google",
+            model="Find My Device",
+            configuration_url=f"{base_url}{path}",
+            hw_version=self._device["id"],
+        )
 
     def _build_map_path(self, device_id: str, token: str, *, redirect: bool = False) -> str:
-        """Return the map URL *path* (no scheme/host).
-        """
+        """Return the map URL *path* (no scheme/host)."""
         if redirect:
             return f"/api/googlefindmy/redirect_map/{device_id}?token={token}"
         return f"/api/googlefindmy/map/{device_id}?token={token}"
 
     def _get_map_token(self) -> str:
-        """Generate a simple token for map authentication.
-
-        Weekly-rotating token when enabled; otherwise a static token.
-        """
+        """Generate a simple token for map authentication (options-first)."""
         import hashlib
         import time
-        from .const import DEFAULT_MAP_VIEW_TOKEN_EXPIRATION
 
-        # Check if token expiration is enabled - prefer options over data (options-first)
         config_entry = getattr(self.coordinator, "config_entry", None)
         if config_entry:
             token_expiration_enabled = config_entry.options.get(
@@ -283,11 +298,9 @@ class GoogleFindMyLastSeenSensor(CoordinatorEntity, RestoreSensor):
         ha_uuid = str(self.hass.data.get("core.uuid", "ha"))
 
         if token_expiration_enabled:
-            # Weekly-rolling token (7-day bucket)
-            week = str(int(time.time() // 604800))
+            week = str(int(time.time() // 604800))  # weekly-rolling bucket
             token_src = f"{ha_uuid}:{week}"
         else:
-            # Static token (no rotation)
             token_src = f"{ha_uuid}:static"
 
         return hashlib.md5(token_src.encode()).hexdigest()[:16]


### PR DESCRIPTION
## Motivation

Many users access Home Assistant from multiple origins (local URL, external URL via reverse proxy/DuckDNS, or Nabu Casa Cloud).
Before this PR:

* Opening the Map View from a device’s **“Visit”** link could yield a URL that didn’t match the *current* origin, leading to mixed http/https, internal IPs, or wrong host.
* Some entities built `configuration_url` values with relative paths or with a base URL that didn’t work when the UI was opened via the Cloud URL.

This PR fixes both sides:

1. **Browser navigation** to Map View uses a **relative redirect**, which always resolves against the *current* origin (whatever the user is using right now).
2. The **device registry** now receives a **valid, absolute HTTP(S) URL** using a predictable base, so HA’s registry validation is happy and the “Visit” link is stable.

## What changed (high level)

* **map_view.py**

  * `GoogleFindMyMapRedirectView.get()` now returns **`Location: /api/...`** (relative path) via `web.HTTPFound`.
    *Result*: the browser always lands on the Map under the same origin it currently uses (local, external, or Cloud). No host/port guessing, no proxies needed.
  * **No functional change** to the token mechanism or to the HTML/JS UI (kept intentionally out of scope).

* **device_tracker.py / sensor.py / button.py**

  * All `device_info().configuration_url` values now use a **strict absolute URL**:
    `configuration_url = f"{base_url}{path}"` with:

    ```py
    base_url = get_url(
        self.hass,
        prefer_external=True,   # see rationale below
        allow_cloud=True,
        allow_external=True,
        allow_internal=True,
    )
    path = self._build_map_path(device_id, token, redirect=False)
    ```
  * For the registry we **do not** use relative paths nor custom schemes (e.g. `homeassistant://`), because the device registry validator requires a valid absolute HTTP(S) URL.
  * `redirect=False` is used for registry links to avoid an extra hop and because the base URL is chosen once (per boot) and is not tied to a current HTTP request.

## Rationale / tiny design doc

### Why a **relative** redirect in `map_view.py`?

* A relative `Location` header lets the browser resolve the target against the **current origin** automatically (scheme/host/port/sub-path).
* This is the most robust approach behind reverse proxies, sub-paths, and when switching between local/external/Cloud URLs.
* Per RFC 9110, a `Location` header may contain a **URI reference** (relative is valid).

### Why an **absolute** `configuration_url` in the device registry?

* The registry insists on a validated absolute HTTP(S) URL. Relative URLs (or `homeassistant://`) are rejected.
* There is **no current HTTP request** context when the registry is populated, so we can’t derive the active origin. Therefore we build a stable base once per boot via `get_url`.

### Why `prefer_external=True` for the registry link?

* Users commonly open HA via the **Cloud URL** and then click **“Visit”**. If we preferred internal, the registry might store an internal IP/http link which **breaks** for Cloud users.
* Preferring external yields a “publicly reachable” link by default. It also works locally, even if it means leaving the LAN for that click—which is still better than a broken link from Cloud.

### Notes on `get_url()` options (for future contributors)

* `prefer_external=True` — if an external URL exists, prefer it for the returned base. Useful for links meant to be opened from *anywhere*.
* `allow_cloud=True` — permits using the Nabu Casa Cloud base URL when available.
* `allow_internal=True` / `allow_external=True` — allow HA to consider those kinds of URLs.
* **We intentionally do not** use `require_current_request=True` here because the device registry code path usually runs **without** a current HTTP request; it would raise. The relative redirect in `map_view.py` already handles the “use the current origin” requirement at navigation time.

## File-by-file

### `custom_components/googlefindmy/map_view.py`

* **Change**: Redirect endpoint sends `Location: /api/googlefindmy/map/{device_id}?token=...` (relative).
* **Kept**: Token logic, history queries, front-end HTML/JS; no cosmetic/broad refactors.

### `custom_components/googlefindmy/device_tracker.py`

* **Change**:

  * `device_info().configuration_url` now uses:

    * `base_url = get_url(... prefer_external=True, allow_cloud=True, allow_external=True, allow_internal=True)`
    * `path = _build_map_path(..., redirect=False)`
    * `configuration_url = f"{base_url}{path}"`
  * `_build_map_path(..., redirect: bool = False)` default updated to **False**; call site changed accordingly.
* **Reason**: Registry requires absolute URL; no need for a redirect when the base is fixed.

### `custom_components/googlefindmy/sensor.py`

* **Change**: Same `configuration_url` pattern as above (`prefer_external=True`, `redirect=False`, absolute URL).

### `custom_components/googlefindmy/button.py`

* **Change**: Same `configuration_url` pattern as above (`prefer_external=True`, `redirect=False`, absolute URL).

## Backwards compatibility

* The Map View endpoint URLs (`/api/googlefindmy/map/...`) remain unchanged.
* Tokens and their (optional) expiration behavior are **unchanged**.
* Only the redirect view now returns a relative `Location`, which is accepted by modern browsers and reverse proxies.

## Risks & mitigations

* **Registry link always external**: With `prefer_external=True`, users in LAN will still get an external base URL in the “Visit” link. This is intentional to keep the link working for Cloud-opened UIs. The separate **relative** redirect path ensures in-app navigation behaves correctly for *current* origin; the registry link is purposely stable.
* **Sub-path setups**: Covered by the relative redirect (browser resolves sub-path automatically).

## How I tested

1. Open HA via **Cloud URL**, click **Visit** → Map opens correctly; no internal IPs.
2. Open HA via **internal URL**, click **Visit** → Map opens locally.
3. Verified device registry accepts `configuration_url` (no `ValueError: invalid configuration_url`).

## Out of scope / follow-ups (separate PRs)

* Replace ad-hoc token with **Signed Paths** for stronger security.
* Optional Jinja2 templating for the HTML to reduce inline JS/HTML in Python.
* Performance improvements for entity lookup via indexed registry calls.

## Checklist

* [x] Changes are minimal and documented in-code where logic changed.
* [x] No broad cosmetic refactors.
* [x] Tested with local and Cloud entry points.
* [x] Preserves existing options and token behavior.

