### PR TITLE
Bugfixes, Best Practices and new Features for 1.6 beta2

### DIFF
--- a/custom_components/googlefindmy/FMDNCrypto/foreign_tracker_cryptor.py
+++ b/custom_components/googlefindmy/FMDNCrypto/foreign_tracker_cryptor.py
@@ -1,139 +1,290 @@
+# custom_components/googlefindmy/FMDNCrypto/foreign_tracker_cryptor.py
 #
 #  GoogleFindMyTools - A set of tools to interact with the Google Find My API
 #  Copyright © 2024 Leon Böttger. All rights reserved.
 #
+"""
+Crypto primitives used to encrypt/decrypt Find My Device payloads on the NIST
+SECP160r1 curve with AES-EAX for authenticated encryption.
 
+Design goals (feature-neutral, HA-friendly):
+- Keep public function signatures unchanged.
+- Add clear docstrings, type hints and defensive checks.
+- Avoid undefined behavior (e.g., s == 0, invalid lengths).
+- Prefer explicitness and readability over micro-optimizations.
+
+Notes:
+- SECP160r1 has a 160-bit field; x/y coordinates are 20 bytes.
+- For primes p ≡ 3 (mod 4), modular square roots can be computed as
+  y = a^((p+1)/4) mod p (used by rx_to_ry).  See references in docs.
+"""
+
+from __future__ import annotations
+
+import asyncio
 import secrets
 from binascii import unhexlify
+from typing import Tuple
 
 from Cryptodome.Cipher import AES
 from ecdsa import SECP160r1
-from cryptography.hazmat.primitives.kdf.hkdf import HKDF
-from cryptography.hazmat.primitives import hashes
 from ecdsa.ellipticcurve import Point
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
-from custom_components.googlefindmy.FMDNCrypto.eid_generator import generate_eid, calculate_r
+from custom_components.googlefindmy.FMDNCrypto.eid_generator import (
+    generate_eid,
+    calculate_r,
+)
 from custom_components.googlefindmy.example_data_provider import get_example_data
 
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# AES-EAX authenticates with a 16-byte tag by default in PyCryptodome.
+_AES_TAG_LEN: int = 16
+# SECP160r1 coordinate length in bytes (160 bits)
+_COORD_LEN: int = 20
+# Nonce is constructed as LRx(8) || LSx(8) = 16 bytes (see spec used here)
+_NONCE_LEN: int = 16
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 def rx_to_ry(Rx: int, curve) -> int:
-    # Calculate y^2 = x^3 + ax + b (mod p)
+    """Recover the even Y coordinate for a given X on a short Weierstrass curve.
+
+    This reconstructs a point from a compressed representation by solving
+    y^2 = x^3 + a·x + b (mod p) and returning the *even* root (as customary
+    for "even-y" decompression).
+
+    Args:
+        Rx: X coordinate as integer.
+        curve: The underlying finite field curve (ecdsa.ellipticcurve.CurveFp).
+
+    Returns:
+        The even Y coordinate as integer.
+
+    Raises:
+        ValueError: If the provided X does not yield a valid point on the curve.
+    """
+    # Compute y^2 = x^3 + a·x + b (mod p)
     Ryy = (Rx ** 3 + curve.a() * Rx + curve.b()) % curve.p()
 
-    # Calculate modular square root
+    # For p ≡ 3 (mod 4): y = (y^2)^((p+1)//4) mod p is a square root
     Ry = pow(Ryy, (curve.p() + 1) // 4, curve.p())
 
-    # Verify the result
-    if (Ry ** 2 % curve.p()) != Ryy:
-        raise ValueError("The provided EID isn't a valid E2EE public key.")
+    # Verify root
+    if (Ry * Ry) % curve.p() != Ryy:
+        raise ValueError("The provided X coordinate is not on the curve.")
 
-    # Ensure y is even
+    # Ensure even y (standardized choice)
     if Ry % 2 != 0:
         Ry = curve.p() - Ry
 
     return Ry
 
 
-def encrypt_aes_eax(data: bytes, nonce: bytes, key: bytes) -> (bytes, bytes):
-    # Ensure the key is 32 bytes for AES-256
+def _require_len(name: str, b: bytes, expected: int) -> None:
+    """Validate a fixed length for bytes-like inputs."""
+    if len(b) != expected:
+        raise ValueError(f"{name} must be exactly {expected} bytes (got {len(b)})")
+
+
+# ---------------------------------------------------------------------------
+# AES-EAX wrappers (authenticated encryption)
+# ---------------------------------------------------------------------------
+
+def encrypt_aes_eax(data: bytes, nonce: bytes, key: bytes) -> Tuple[bytes, bytes]:
+    """Encrypt and authenticate with AES-EAX-256.
+
+    Args:
+        data: Plaintext bytes.
+        nonce: 16-byte nonce used for EAX.
+        key: 32-byte AES key (AES-256).
+
+    Returns:
+        (ciphertext, tag) — tag is 16 bytes.
+
+    Raises:
+        ValueError: If key/nonce lengths are invalid.
+    """
     if len(key) != 32:
-        raise ValueError("Key must be 32 bytes long for AES-256")
+        raise ValueError("Key must be 32 bytes (AES-256).")
+    if len(nonce) != _NONCE_LEN:
+        raise ValueError("Nonce must be 16 bytes for this construction.")
 
-    # Create AES cipher in EAX mode
     cipher = AES.new(key, AES.MODE_EAX, nonce=nonce)
-
-    # Encrypt the data
     ciphertext, tag = cipher.encrypt_and_digest(data)
-
     return ciphertext, tag
 
 
 def decrypt_aes_eax(data: bytes, tag: bytes, nonce: bytes, key: bytes) -> bytes:
-    # Ensure the key is 32 bytes for AES-256
+    """Decrypt and verify AES-EAX-256.
+
+    Args:
+        data: Ciphertext bytes.
+        tag: 16-byte authentication tag from encryption.
+        nonce: 16-byte nonce.
+        key: 32-byte AES key.
+
+    Returns:
+        Decrypted plaintext.
+
+    Raises:
+        ValueError: If key/nonce/tag lengths are invalid or tag verification fails.
+    """
     if len(key) != 32:
-        raise ValueError("Key must be 32 bytes long for AES-256")
+        raise ValueError("Key must be 32 bytes (AES-256).")
+    if len(nonce) != _NONCE_LEN:
+        raise ValueError("Nonce must be 16 bytes for this construction.")
+    if len(tag) != _AES_TAG_LEN:
+        raise ValueError("Tag must be 16 bytes for AES-EAX.")
 
-    # Create AES cipher in EAX mode
     cipher = AES.new(key, AES.MODE_EAX, nonce=nonce)
-
-    # Decrypt the data
     return cipher.decrypt_and_verify(data, tag)
 
 
-def encrypt(message: bytes, random: bytes, eid: bytes) -> (bytes, bytes):
-    # Step 1: Choose a random number s in Fp
-    curve = SECP160r1
-    s = int.from_bytes(random, byteorder='big', signed=True) % curve.order
+# ---------------------------------------------------------------------------
+# ECIES-like envelope (domain-specific construction)
+# ---------------------------------------------------------------------------
 
-    # Step 2: Compute S = s * G
+def encrypt(message: bytes, random: bytes, eid: bytes) -> Tuple[bytes, bytes]:
+    """Encrypt a payload to an ephemeral EID on SECP160r1 using AES-EAX-256.
+
+    Construction (as implemented in the original code and preserved):
+    1) Reduce a random scalar s mod n (guard s != 0); S = s·G.
+    2) Rebuild R from eid (x-only); choose even y via rx_to_ry.
+    3) Derive k = HKDF-SHA256( (s·R).x ) → 32 bytes.
+    4) nonce = LRx(8) || LSx(8).
+    5) m' || tag = AES-EAX-256_ENC(k, nonce, message).
+    6) Output: (m' || tag, Sx).
+
+    Args:
+        message: Plaintext payload.
+        random: Caller-provided random bytes (entropy source for s).
+        eid: 20-byte X coordinate (compressed point) for the receiver.
+
+    Returns:
+        (encrypted_with_tag, Sx) where encrypted_with_tag = m' || tag (tag=16B),
+        and Sx is 20-byte X coordinate of S.
+
+    Raises:
+        ValueError: On invalid inputs (lengths) or curve mismatch.
+    """
+    # Curve parameters
+    curve = SECP160r1
+    order = curve.order
+
+    # Validate EID length (x coordinate on SECP160r1)
+    _require_len("eid", eid, _COORD_LEN)
+
+    # Derive scalar s from caller-provided randomness; guard s != 0
+    s = int.from_bytes(random, byteorder="big", signed=False) % order
+    if s == 0:
+        # Extremely unlikely; avoid the point at infinity by bumping to 1
+        s = 1
+
+    # S = s·G
     S = s * curve.generator
 
-    # Step 3: Compute R = (Rx, Ry) by substitution in the curve equation
-    # and picking an arbitrary Ry value out of the possible results
-    Rx = int.from_bytes(eid, byteorder='big')
+    # Rebuild R from EID (x only) and choose even Y
+    Rx = int.from_bytes(eid, byteorder="big")
     Ry = rx_to_ry(Rx, curve.curve)
     R = Point(curve.curve, Rx, Ry)
 
-    # Step 4: Compute the 256-bit AES key k = HKDF-SHA256((s * R)x)
-    # where (s * R)x is the x coordinate of the curve multiplication result.
-    # Salt isn't specified.
-    hkdf = HKDF(
-        algorithm=hashes.SHA256(),
-        length=32,
-        salt=None,
-        info=b'',
-    )
-    k = hkdf.derive((s * R).x().to_bytes(20, 'big'))
+    # Derive AES-256 key via HKDF-SHA256 over (s·R).x (20 bytes)
+    hkdf = HKDF(algorithm=hashes.SHA256(), length=32, salt=None, info=b"")
+    k = hkdf.derive((s * R).x().to_bytes(_COORD_LEN, "big"))
 
-    # Step 5: Split Rx and Sx into lower 8 bytes
-    LRx = Rx.to_bytes(20, 'big')[12:]
-    LSx = S.x().to_bytes(20, 'big')[12:]
+    # Nonce = LRx(8) || LSx(8)
+    LRx = Rx.to_bytes(_COORD_LEN, "big")[-8:]
+    LSx = S.x().to_bytes(_COORD_LEN, "big")[-8:]
+    nonce = LRx + LSx  # 16 bytes
 
-    # Step 6: Compute nonce
-    nonce = LRx + LSx
-
-    # Step 7: Encrypt the message m using AES-EAX-256
+    # Encrypt (AES-EAX-256) → m' || tag
     m_dash, tag = encrypt_aes_eax(message, nonce, k)
-
-    # Step 8: Result (m' || tag, Sx)
-    return m_dash + tag, S.x().to_bytes(20, 'big')
+    return m_dash + tag, S.x().to_bytes(_COORD_LEN, "big")
 
 
 def decrypt(identity_key: bytes, encryptedAndTag: bytes, Sx: bytes, beacon_time_counter: int) -> bytes:
-    # Split into encrypted message and 16-byte tag
-    m_dash = encryptedAndTag[:-16]
-    tag = encryptedAndTag[-16:]
+    """Decrypt a payload sent to a tracker identity on SECP160r1 with AES-EAX-256.
 
-    # Given the beacon time counter value on which URx is based, compute the anticipated value of r
+    Construction (mirrors `encrypt` above):
+    1) Compute r from (identity_key, beacon_time_counter); R = r·G.
+    2) Rebuild S from Sx (x-only); choose even y via rx_to_ry.
+    3) Derive k = HKDF-SHA256( (r·S).x ) → 32 bytes.
+    4) nonce = LRx(8) || LSx(8).
+    5) Split m' || tag and AES-EAX-256_DEC(k, nonce, m', tag).
+
+    Args:
+        identity_key: 20-byte tracker identity/private key material (domain-specific).
+        encryptedAndTag: Ciphertext concatenated with 16-byte tag.
+        Sx: 20-byte X coordinate of ephemeral S.
+        beacon_time_counter: Time counter used to derive r.
+
+    Returns:
+        Decrypted plaintext.
+
+    Raises:
+        ValueError: On invalid input lengths or verification failure.
+    """
+    # Basic validations
+    _require_len("identity_key", identity_key, _COORD_LEN)
+    _require_len("Sx", Sx, _COORD_LEN)
+    if len(encryptedAndTag) < _AES_TAG_LEN:
+        raise ValueError("encryptedAndTag must be at least 16 bytes (contains tag).")
+
+    # Split ciphertext and tag
+    m_dash = encryptedAndTag[:-_AES_TAG_LEN]
+    tag = encryptedAndTag[-_AES_TAG_LEN:]
+
+    # Curve and scalar r
     curve = SECP160r1
     r = calculate_r(identity_key, beacon_time_counter)
 
-    # Compute R = r * G
+    # R = r·G
     R = r * curve.generator
 
-    # Compute S = (Sx, Sy) by substitution in the curve equation and picking an arbitrary Sy value out of the
-    # possible results.
-    Sx = int.from_bytes(Sx, byteorder='big')
-    Sy = rx_to_ry(Sx, curve.curve)
-    S = Point(curve.curve, Sx, Sy)
+    # Rebuild S from Sx (x-only) and choose even Y
+    Sx_int = int.from_bytes(Sx, byteorder="big")
+    Sy = rx_to_ry(Sx_int, curve.curve)
+    S = Point(curve.curve, Sx_int, Sy)
 
-    # Compute k = HKDF-SHA256((r * S)x) where (r * S)x is the x coordinate of the curve multiplication result.
-    hkdf = HKDF(
-        algorithm=hashes.SHA256(),
-        length=32,
-        salt=None,
-        info=b''
-    )
-    k = hkdf.derive((r * S).x().to_bytes(20, 'big'))
+    # Derive AES-256 key via HKDF-SHA256 over (r·S).x
+    hkdf = HKDF(algorithm=hashes.SHA256(), length=32, salt=None, info=b"")
+    k = hkdf.derive((r * S).x().to_bytes(_COORD_LEN, "big"))
 
-    # Compute nonce = LRx || LSx.
-    LRx = R.x().to_bytes(20, 'big')[12:]
-    LSx = S.x().to_bytes(20, 'big')[12:]
-    nonce = LRx + LSx
+    # Nonce = LRx(8) || LSx(8)
+    LRx = R.x().to_bytes(_COORD_LEN, "big")[-8:]
+    LSx = S.x().to_bytes(_COORD_LEN, "big")[-8:]
+    nonce = LRx + LSx  # 16 bytes
 
-    # Compute m = AES-EAX-256-DEC(k, nonce, m’, tag)
+    # AES-EAX-256 decrypt & verify
     return decrypt_aes_eax(m_dash, tag, nonce, k)
 
+
+# ---------------------------------------------------------------------------
+# Optional async wrapper (non-breaking): offload CPU work to a worker thread
+# ---------------------------------------------------------------------------
+
+async def async_decrypt(identity_key: bytes, encryptedAndTag: bytes, Sx: bytes, beacon_time_counter: int) -> bytes:
+    """Async convenience wrapper for `decrypt(...)` using `asyncio.to_thread`.
+
+    This preserves the original sync API while allowing async call sites
+    (e.g., inside Home Assistant event loop) to avoid blocking.
+    """
+    return await asyncio.to_thread(
+        decrypt, identity_key, encryptedAndTag, Sx, beacon_time_counter
+    )
+
+
+# ---------------------------------------------------------------------------
+# Self-test with example vectors
+# ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
     # 4-byte timestamp
@@ -142,10 +293,8 @@ if __name__ == "__main__":
     sample_identity_key = unhexlify(get_example_data("sample_identity_key"))
     sample_location_data = unhexlify(get_example_data("sample_location_data"))
 
-    # Generate EID
+    # Generate EID (x-only) and 32-byte randomness for s
     eid = generate_eid(sample_identity_key, timestamp)
-
-    # generate 32-byte random number
     random = secrets.token_bytes(32)
 
     encryptedAndTag, Sx = encrypt(sample_location_data, random, eid)

--- a/custom_components/googlefindmy/KeyBackup/cloud_key_decryptor.py
+++ b/custom_components/googlefindmy/KeyBackup/cloud_key_decryptor.py
@@ -1,186 +1,347 @@
+# custom_components/googlefindmy/KeyBackup/cloud_key_decryptor.py
 #
 #  GoogleFindMyTools - A set of tools to interact with the Google Find My API
 #  Copyright © 2024 Leon Böttger. All rights reserved.
 #
+"""
+Key backup / cryptographic helpers for Google Find My Device.
+
+This module provides a small set of cryptographic utilities that are used to
+derive keys (HKDF-SHA256), perform authenticated encryption/decryption with
+AES-GCM, and decrypt a few specific key blobs used by the integration
+(recovery/application/security-domain/shared/owner/account keys, and EIK).
+
+Design goals (HA Best Practices / Platinum Quality targets):
+- Keep the Home Assistant event loop responsive. The core primitives here are
+  synchronous by design; higher layers may offload them via `asyncio.to_thread`
+  if needed.
+- Strong, explicit typing and clear docstrings (Args/Returns/Raises).
+- Defensive input validation (IV lengths, ciphertext framing, block-size checks).
+- No logging/printing of secrets at import time.
+- Backwards-compatible behavior: no public API changes versus previous versions.
+
+NOTE: Do not import this module just to run the sample block below. The
+`if __name__ == "__main__":` section is only for local/manual testing.
+"""
+from __future__ import annotations
+
 import secrets
+from binascii import unhexlify
+from typing import Optional
 
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-from binascii import unhexlify
-from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from cryptography.hazmat.primitives.hashes import SHA256
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from cryptography.hazmat.primitives.asymmetric import ec
-from cryptography.hazmat.backends import default_backend
 
-from custom_components.googlefindmy.KeyBackup.lskf_hasher import ascii_to_bytes, get_lskf_hash
+from custom_components.googlefindmy.KeyBackup.lskf_hasher import (
+    ascii_to_bytes,
+    get_lskf_hash,
+)
 from custom_components.googlefindmy.example_data_provider import get_example_data
 
+# ---------------------------------------------------------------------------
 # Constants
-VERSION = b'\x02\x00'
-SECUREBOX = b'SECUREBOX'
-SHARED_HKDF_AES_GCM = b'SHARED HKDF-SHA-256 AES-128-GCM'
-P256_HKDF_AES_GCM = b'P256 HKDF-SHA-256 AES-128-GCM'
+# ---------------------------------------------------------------------------
+VERSION = b"\x02\x00"
+SECUREBOX = b"SECUREBOX"
+SHARED_HKDF_AES_GCM = b"SHARED HKDF-SHA-256 AES-128-GCM"
+P256_HKDF_AES_GCM = b"P256 HKDF-SHA-256 AES-128-GCM"
+
+# AES-GCM standard IV size (bytes). CBC IV size is always 16 bytes for AES.
+GCM_IV_LEN_DEFAULT = 12
+CBC_IV_LEN = 16
 
 
+# ---------------------------------------------------------------------------
+# HKDF (SHA-256)
+# ---------------------------------------------------------------------------
 def derive_key_using_hkdf_sha256(input_key: bytes, salt: bytes, info: bytes) -> bytes:
+    """Derive a 16-byte key using HKDF-SHA256.
 
-    # Create 16-byte HKDF instance
+    Args:
+        input_key: Input keying material (IKM).
+        salt: HKDF salt (non-secret).
+        info: HKDF context/application info.
+
+    Returns:
+        A 16-byte derived key (suitable for AES-128-GCM).
+
+    Raises:
+        ValueError: If input types are invalid (implicitly via cryptography).
+    """
     hkdf = HKDF(
         algorithm=SHA256(),
-        length=16,
+        length=16,  # 128-bit AES key
         salt=salt,
         info=info,
-        backend=default_backend(),
     )
-
-    # Derive key using HKDF
     return hkdf.derive(input_key)
 
 
-def decrypt_aes_gcm_with_derived_key(encrypted_data: bytes, private_key: bytes, key_type_string: bytes,
-                                     derive_with_public_key=False) -> bytes:
+# ---------------------------------------------------------------------------
+# AES-GCM / AES-CBC helpers
+# ---------------------------------------------------------------------------
+def _split_iv_and_ciphertext(
+    encrypted_data_and_iv: bytes, iv_length: int
+) -> tuple[bytes, bytes]:
+    """Split IV and ciphertext from a blob where the IV is prepended.
 
-    # Only supporting specified version, else return
+    Args:
+        encrypted_data_and_iv: Concatenation of IV || CIPHERTEXT[(|| TAG)].
+        iv_length: Expected IV length in bytes.
+
+    Returns:
+        A tuple (iv, ciphertext_with_tag_or_plain).
+
+    Raises:
+        ValueError: If the provided buffer is shorter than the IV.
+    """
+    if iv_length <= 0:
+        raise ValueError("IV length must be positive")
+
+    if len(encrypted_data_and_iv) < iv_length:
+        raise ValueError("Encrypted buffer shorter than IV length")
+
+    iv = encrypted_data_and_iv[:iv_length]
+    ciphertext = encrypted_data_and_iv[iv_length:]
+    if not ciphertext:
+        raise ValueError("Ciphertext is empty (no payload after IV)")
+    return iv, ciphertext
+
+
+def decrypt_aes_gcm(
+    key: bytes,
+    encrypted_data_and_iv: bytes,
+    additional_data: Optional[bytes] = None,
+    iv_length: int = GCM_IV_LEN_DEFAULT,
+) -> bytes:
+    """Decrypt AES-GCM where the IV is prepended to the payload.
+
+    Args:
+        key: AES-GCM key (16/24/32 bytes for 128/192/256-bit).
+        encrypted_data_and_iv: IV || CIPHERTEXT||TAG (TAG appended by AESGCM).
+        additional_data: Optional AAD bound to the ciphertext.
+        iv_length: Length of the IV prefix (defaults to 12 for GCM).
+
+    Returns:
+        The decrypted plaintext bytes.
+
+    Raises:
+        ValueError: If framing is invalid or key length is unsupported.
+        cryptography.exceptions.InvalidTag: If authentication fails.
+    """
+    if len(key) not in (16, 24, 32):
+        raise ValueError("AESGCM key must be 16, 24, or 32 bytes")
+
+    iv, ciphertext = _split_iv_and_ciphertext(encrypted_data_and_iv, iv_length)
+
+    # AESGCM expects ciphertext+tag in a single buffer.
+    aes_gcm = AESGCM(key)
+    return aes_gcm.decrypt(iv, ciphertext, additional_data)
+
+
+def encrypt_aes_gcm(
+    key: bytes,
+    plaintext: bytes,
+    additional_data: Optional[bytes] = None,
+    iv_length: int = GCM_IV_LEN_DEFAULT,
+) -> bytes:
+    """Encrypt with AES-GCM and prepend the IV to the ciphertext+tag.
+
+    Args:
+        key: AES-GCM key (16/24/32 bytes).
+        plaintext: Plaintext to encrypt.
+        additional_data: Optional AAD bound to the ciphertext.
+        iv_length: Length of the randomly generated IV (default: 12).
+
+    Returns:
+        IV || CIPHERTEXT||TAG
+
+    Raises:
+        ValueError: If key length or IV length is invalid.
+    """
+    if len(key) not in (16, 24, 32):
+        raise ValueError("AESGCM key must be 16, 24, or 32 bytes")
+    if iv_length <= 0:
+        raise ValueError("IV length must be positive")
+
+    iv = secrets.token_bytes(iv_length)
+    aes_gcm = AESGCM(key)
+    ciphertext = aes_gcm.encrypt(iv, plaintext, additional_data)
+    return iv + ciphertext
+
+
+def decrypt_aes_cbc_no_padding(
+    key: bytes, encrypted_data_and_iv: bytes, iv_length: int = CBC_IV_LEN
+) -> bytes:
+    """Decrypt AES-CBC without padding where the IV is prepended.
+
+    Args:
+        key: AES key (16/24/32 bytes).
+        encrypted_data_and_iv: IV || CIPHERTEXT (must be block-size aligned).
+        iv_length: IV size (AES-CBC uses 16 bytes).
+
+    Returns:
+        Decrypted bytes (may include padding bytes if present in the source).
+
+    Raises:
+        ValueError: If framing is invalid or ciphertext not block-size aligned.
+    """
+    iv, ciphertext = _split_iv_and_ciphertext(encrypted_data_and_iv, iv_length)
+    if len(ciphertext) % algorithms.AES.block_size // 8 != 0:
+        raise ValueError("AES-CBC ciphertext is not block-size aligned")
+
+    cipher = Cipher(algorithms.AES(key), modes.CBC(iv))
+    decryptor = cipher.decryptor()
+    return decryptor.update(ciphertext) + decryptor.finalize()
+
+
+# ---------------------------------------------------------------------------
+# Higher-level decrypt/derive helpers (feature-neutral)
+# ---------------------------------------------------------------------------
+def decrypt_aes_gcm_with_derived_key(
+    encrypted_data: bytes,
+    private_key: bytes,
+    key_type_string: bytes,
+    derive_with_public_key: bool = False,
+) -> bytes:
+    """Decrypt a blob using HKDF-derived AES-GCM key.
+
+    Two modes are supported:
+    - Shared-secret mode (derive_with_public_key=False): derive AES key from
+      `private_key` using `SECUREBOX||VERSION` salt and `SHARED_HKDF_AES_GCM`
+      info.
+    - ECDH mode (derive_with_public_key=True): the first 65 bytes after VERSION
+      are treated as an uncompressed P-256 public key. An ECDH shared secret is
+      computed using `private_key` and that public key; HKDF derives the AES key
+      using `P256_HKDF_AES_GCM` as info.
+
+    Args:
+        encrypted_data: VERSION || [pubkey?] || IV || CIPHERTEXT||TAG
+        private_key: Private key material (raw bytes; see ECDH mode note).
+        key_type_string: AAD passed to AES-GCM (binds context).
+        derive_with_public_key: If True, use ECDH with embedded public key.
+
+    Returns:
+        Decrypted plaintext bytes.
+
+    Raises:
+        ValueError: If VERSION header is invalid or framing is malformed.
+        cryptography.exceptions.InvalidTag: If authentication fails.
+    """
     if len(encrypted_data) < 2 or encrypted_data[:2] != VERSION:
         raise ValueError("Invalid version or data length")
 
     version_length = len(VERSION)
-
-    # Get ciphertext and iv from encrypted key data
     ciphertext_offset = 65 if derive_with_public_key else 0
-    ciphertext_and_iv = encrypted_data[version_length + ciphertext_offset:]
+    ciphertext_and_iv = encrypted_data[version_length + ciphertext_offset :]
 
-    # Create HKDF salt and info
     hkdf_salt = SECUREBOX + VERSION
     hkdf_info = P256_HKDF_AES_GCM if derive_with_public_key else SHARED_HKDF_AES_GCM
 
     if derive_with_public_key:
-        # Perform key exchange and derive shared secret
-        shared_public_key = encrypted_data[version_length:version_length + ciphertext_offset]
+        shared_public_key = encrypted_data[version_length : version_length + ciphertext_offset]
         private_key = derive_shared_secret(private_key, shared_public_key)
 
-    # Derive key using HKDF
     derived_key = derive_key_using_hkdf_sha256(private_key, hkdf_salt, hkdf_info)
-
-    # Decrypt data with AES-GCM
     return decrypt_aes_gcm(derived_key, ciphertext_and_iv, key_type_string)
 
 
 def derive_shared_secret(private_key_jwt: bytes, public_key: bytes) -> bytes:
+    """Compute ECDH shared secret on P-256.
 
-    # Extract EC private curve from JWT format
+    Args:
+        private_key_jwt: Buffer whose first 32 bytes contain the raw private key.
+        public_key: Uncompressed P-256 public key (65 bytes), SEC1 format.
+
+    Returns:
+        ECDH shared secret bytes.
+
+    Raises:
+        ValueError: If input lengths are invalid or key decoding fails.
+    """
+    if len(private_key_jwt) < 32:
+        raise ValueError("Private key buffer too short (need at least 32 bytes)")
+    if len(public_key) != 65:
+        raise ValueError("Public key must be 65 bytes (uncompressed SEC1)")
+
     private_key_bytes = private_key_jwt[:32]
-    private_key = ec.derive_private_key(int.from_bytes(private_key_bytes, "big"), ec.SECP256R1(), default_backend())
-
-    # Create public key from bytes
-    public_key = ec.EllipticCurvePublicKey.from_encoded_point(ec.SECP256R1(), public_key)
-
-    # Perform ECDH key exchange to calculate shared secret
-    return private_key.exchange(ec.ECDH(), public_key)
-
-
-def decrypt_aes_gcm(key: bytes, encrypted_data_and_iv: bytes, additional_data: bytes = None, iv_length = 12) -> bytes:
-
-    # IV is prepended to encrypted data
-    iv = encrypted_data_and_iv[:iv_length]
-    ciphertext = encrypted_data_and_iv[iv_length:]
-
-    # Perform AES-GCM
-    aes_gcm = AESGCM(key)
-    decrypted_data = aes_gcm.decrypt(iv, ciphertext, additional_data)
-
-    # Return result
-    return decrypted_data
-
-
-def encrypt_aes_gcm(key: bytes, plaintext: bytes, additional_data=None, iv_length=12) -> bytes:
-    # Generate a random IV
-    iv = secrets.token_bytes(iv_length)
-
-    # Perform AES-GCM
-    aes_gcm = AESGCM(key)
-    ciphertext = aes_gcm.encrypt(iv, plaintext, additional_data)
-
-    # Prepend IV to the ciphertext
-    return iv + ciphertext
-
-
-def decrypt_aes_cbc_no_padding(key: bytes, encrypted_data_and_iv: bytes, iv_length = 16) -> bytes:
-
-    # IV is prepended to encrypted data
-    iv = encrypted_data_and_iv[:iv_length]
-    ciphertext = encrypted_data_and_iv[iv_length:]
-
-    cipher = Cipher(
-        algorithms.AES(key),
-        modes.CBC(iv),
-        backend=default_backend()
-    )
-
-    decryptor = cipher.decryptor()
-    decrypted_data = decryptor.update(ciphertext) + decryptor.finalize()
-
-    return decrypted_data
+    priv = ec.derive_private_key(int.from_bytes(private_key_bytes, "big"), ec.SECP256R1())
+    pub = ec.EllipticCurvePublicKey.from_encoded_point(ec.SECP256R1(), public_key)
+    return priv.exchange(ec.ECDH(), pub)
 
 
 def decrypt_recovery_key(lskf_hash: bytes, encrypted_recovery_key: bytes) -> bytes:
-
-    # The recovery key is encrypted using the hash of the LSKF
-    return decrypt_aes_gcm_with_derived_key(encrypted_recovery_key, lskf_hash,
-                                            ascii_to_bytes("V1 locally_encrypted_recovery_key"))
+    """Decrypt locally encrypted recovery key using the LSKF hash."""
+    return decrypt_aes_gcm_with_derived_key(
+        encrypted_recovery_key,
+        lskf_hash,
+        ascii_to_bytes("V1 locally_encrypted_recovery_key"),
+    )
 
 
 def decrypt_application_key(recovery_key: bytes, encrypted_application_key: bytes) -> bytes:
-
-    # The application key is encrypted using the recovery key
-    return decrypt_aes_gcm_with_derived_key(encrypted_application_key, recovery_key,
-                                            ascii_to_bytes("V1 encrypted_application_key"))
+    """Decrypt application key using the recovery key."""
+    return decrypt_aes_gcm_with_derived_key(
+        encrypted_application_key, recovery_key, ascii_to_bytes("V1 encrypted_application_key")
+    )
 
 
 def decrypt_security_domain_key(application_key: bytes, encrypted_security_domain_key: bytes) -> bytes:
-
-    # The security domain key is encrypted using the application key
+    """Decrypt security domain key using the application key."""
     return decrypt_aes_gcm(application_key, encrypted_security_domain_key)
 
 
 def decrypt_shared_key(security_domain_key: bytes, encrypted_shared_key: bytes) -> bytes:
-
-    # The shared key is encrypted using the security domain key
-    return decrypt_aes_gcm_with_derived_key(encrypted_shared_key, security_domain_key,
-                                            ascii_to_bytes("V1 shared_key"), True)
+    """Decrypt shared key using the security domain key (ECDH/HKDF mode)."""
+    return decrypt_aes_gcm_with_derived_key(
+        encrypted_shared_key, security_domain_key, ascii_to_bytes("V1 shared_key"), True
+    )
 
 
 def decrypt_owner_key(shared_key: bytes, encrypted_owner_key: bytes) -> bytes:
-
-    # The owner key is encrypted using the shared key. The owner key is valid for all trackers
+    """Decrypt owner key using the shared key."""
     return decrypt_aes_gcm(shared_key, encrypted_owner_key)
 
 
 def decrypt_eik(owner_key: bytes, encrypted_eik: bytes) -> bytes:
+    """Decrypt EIK (ephemeral identity key) using the owner key.
 
-    # The EIK is encrypted using the owner key. The EIK is only valid for a certain tracker
-    if len(encrypted_eik) == 48:
-        return decrypt_aes_cbc_no_padding(owner_key, encrypted_eik)
+    Note:
+        The EIK format may be AES-CBC (no padding) or AES-GCM; we select based
+        on total length of the blob.
 
-    if len(encrypted_eik) == 60:
-        return decrypt_aes_gcm(owner_key, encrypted_eik)
-
-    raise ValueError("The encrypted EIK has invalid length!")
+    Raises:
+        ValueError: If the EIK blob length is unexpected.
+    """
+    if len(encrypted_eik) == 48:  # 16 IV + 32 CIPHERTEXT (CBC, no tag)
+        return decrypt_aes_cbc_no_padding(owner_key, encrypted_eik, CBC_IV_LEN)
+    if len(encrypted_eik) == 60:  # 12 IV + 48 CT||TAG (GCM)
+        return decrypt_aes_gcm(owner_key, encrypted_eik, iv_length=GCM_IV_LEN_DEFAULT)
+    raise ValueError("The encrypted EIK has invalid length")
 
 
 def decrypt_account_key(owner_key: bytes, encrypted_account_key: bytes) -> bytes:
+    """Decrypt per-tracker account key using the owner key.
 
-    # The account key is encrypted using the owner key. The account key is only valid for a certain tracker
-    if len(encrypted_account_key) == 32:
-        return decrypt_aes_cbc_no_padding(owner_key, encrypted_account_key)
+    Raises:
+        ValueError: If the account key blob length is unexpected.
+    """
+    if len(encrypted_account_key) == 32:  # 16 IV + 16 CT (CBC)
+        return decrypt_aes_cbc_no_padding(owner_key, encrypted_account_key, CBC_IV_LEN)
+    if len(encrypted_account_key) == 44:  # 12 IV + 32 CT||TAG (GCM)
+        return decrypt_aes_gcm(owner_key, encrypted_account_key, iv_length=GCM_IV_LEN_DEFAULT)
+    raise ValueError("The encrypted Account Key has invalid length")
 
-    if len(encrypted_account_key) == 44:
-        return decrypt_aes_gcm(owner_key, encrypted_account_key)
 
-    raise ValueError("The encrypted Account Key has invalid length!")
-
-
-if __name__ == '__main__':
+# ---------------------------------------------------------------------------
+# Local/manual test only (not executed on import)
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    # WARNING: This section is for local testing only. Do not run in production
+    # and never commit real keys. Output goes to stdout for developer inspection.
 
     # Load sample data
     pin = get_example_data("sample_pin")
@@ -203,25 +364,18 @@ if __name__ == '__main__':
     eik = decrypt_eik(owner_key, encrypted_eik)
     account_key = decrypt_account_key(owner_key, encrypted_account_key)
 
-    # Print results
+    # Print results (developer-only)
     print("Recovery Key:")
     print(recovery_key.hex())
-
     print("Application Key:")
     print(application_key.hex())
-
     print("Security Domain Key:")
     print(security_domain_key.hex())
-
     print("Shared Key:")
     print(shared_key.hex())
-
     print("Owner Key:")
     print(owner_key.hex())
-
     print("EIK:")
     print(eik.hex())
-
     print("Account Key:")
     print(account_key.hex())
-

--- a/custom_components/googlefindmy/ProtoDecoders/decoder.py
+++ b/custom_components/googlefindmy/ProtoDecoders/decoder.py
@@ -1,172 +1,486 @@
+# custom_components/googlefindmy/ProtoDecoders/decoder.py
 #
 #  GoogleFindMyTools - A set of tools to interact with the Google Find My API
 #  Copyright © 2024 Leon Böttger. All rights reserved.
 #
 
+from __future__ import annotations
+
 import binascii
 import subprocess
+from typing import Any, Dict, List, Optional, Tuple
 
 from google.protobuf import text_format
 import datetime
+import math
 import pytz
 
-from custom_components.googlefindmy.ProtoDecoders import DeviceUpdate_pb2, LocationReportsUpload_pb2
+from custom_components.googlefindmy.ProtoDecoders import (
+    DeviceUpdate_pb2,
+    LocationReportsUpload_pb2,
+)
 from custom_components.googlefindmy.example_data_provider import get_example_data
 
 
-# Custom message formatter to print the Protobuf byte fields as hex strings
+# --------------------------------------------------------------------------------------
+# Pretty printer helpers (dev tooling)
+# --------------------------------------------------------------------------------------
+
 def custom_message_formatter(message, indent, as_one_line):
+    """Format protobuf messages with bytes fields as hex strings (dev convenience).
+
+    Note:
+        This is a developer-facing utility and is intentionally tolerant to schema changes.
+        Time fields (named 'Time') are rendered in local time for readability.
+    """
     lines = []
     indent = f"{indent}"
     indent = indent.removeprefix("0")
 
     for field, value in message.ListFields():
         if field.type == field.TYPE_BYTES:
-            hex_value = binascii.hexlify(value).decode('utf-8')
-            lines.append(f"{indent}{field.name}: \"{hex_value}\"")
+            hex_value = binascii.hexlify(value).decode("utf-8")
+            lines.append(f'{indent}{field.name}: "{hex_value}"')
         elif field.type == field.TYPE_MESSAGE:
             if field.label == field.LABEL_REPEATED:
                 for sub_message in value:
                     if field.message_type.name == "Time":
-                        # Convert Unix time to human-readable format
                         unix_time = sub_message.seconds
-                        local_time = datetime.datetime.fromtimestamp(unix_time, pytz.timezone('Europe/Berlin'))
-                        lines.append(f"{indent}{field.name} {{\n{indent}  {local_time}\n{indent}}}")
+                        local_time = datetime.datetime.fromtimestamp(
+                            unix_time, pytz.timezone("Europe/Berlin")
+                        )
+                        lines.append(
+                            f"{indent}{field.name} {{\n{indent}  {local_time}\n{indent}}}"
+                        )
                     else:
-                        nested_message = custom_message_formatter(sub_message, f"{indent}  ", as_one_line)
-                        lines.append(f"{indent}{field.name} {{\n{nested_message}\n{indent}}}")
+                        nested_message = custom_message_formatter(
+                            sub_message, f"{indent}  ", as_one_line
+                        )
+                        lines.append(
+                            f"{indent}{field.name} {{\n{nested_message}\n{indent}}}"
+                        )
             else:
                 if field.message_type.name == "Time":
-                    # Convert Unix time to human-readable format
                     unix_time = value.seconds
-                    local_time = datetime.datetime.fromtimestamp(unix_time, pytz.timezone('Europe/Berlin'))
-                    lines.append(f"{indent}{field.name} {{\n{indent}  {local_time}\n{indent}}}")
+                    local_time = datetime.datetime.fromtimestamp(
+                        unix_time, pytz.timezone("Europe/Berlin")
+                    )
+                    lines.append(
+                        f"{indent}{field.name} {{\n{indent}  {local_time}\n{indent}}}"
+                    )
                 else:
-                    nested_message = custom_message_formatter(value, f"{indent}  ", as_one_line)
-                    lines.append(f"{indent}{field.name} {{\n{nested_message}\n{indent}}}")
+                    nested_message = custom_message_formatter(
+                        value, f"{indent}  ", as_one_line
+                    )
+                    lines.append(
+                        f"{indent}{field.name} {{\n{nested_message}\n{indent}}}"
+                    )
         else:
             lines.append(f"{indent}{field.name}: {value}")
     return "\n".join(lines)
 
 
-def parse_location_report_upload_protobuf(hex_string):
+# --------------------------------------------------------------------------------------
+# Protobuf parse helpers (stable API)
+# --------------------------------------------------------------------------------------
+
+def parse_location_report_upload_protobuf(hex_string: str):
+    """Parse LocationReportsUpload from a hex string."""
     location_reports = LocationReportsUpload_pb2.LocationReportsUpload()
     location_reports.ParseFromString(bytes.fromhex(hex_string))
     return location_reports
 
 
-def parse_device_update_protobuf(hex_string):
+def parse_device_update_protobuf(hex_string: str):
+    """Parse DeviceUpdate from a hex string."""
     device_update = DeviceUpdate_pb2.DeviceUpdate()
     device_update.ParseFromString(bytes.fromhex(hex_string))
     return device_update
 
 
-def parse_device_list_protobuf(hex_string):
+def parse_device_list_protobuf(hex_string: str):
+    """Parse DevicesList from a hex string."""
     device_list = DeviceUpdate_pb2.DevicesList()
     device_list.ParseFromString(bytes.fromhex(hex_string))
     return device_list
 
 
-def get_canonic_ids(device_list):
-    result = []
-    for device in device_list.deviceMetadata:
-        if device.identifierInformation.type == DeviceUpdate_pb2.IDENTIFIER_ANDROID: 
-            canonic_ids = device.identifierInformation.phoneInformation.canonicIds.canonicId
-        else:
-            canonic_ids = device.identifierInformation.canonicIds.canonicId
-        device_name = device.userDefinedDeviceName
+# --------------------------------------------------------------------------------------
+# Canonical ID extraction
+# --------------------------------------------------------------------------------------
+
+def get_canonic_ids(device_list) -> List[Tuple[str, str]]:
+    """Return (device_name, canonic_id) for all devices in the list.
+
+    Defensive policy:
+        * Handle Android and non-Android identifier shapes.
+        * Skip non-string/empty IDs to avoid downstream surprises.
+    """
+    result: List[Tuple[str, str]] = []
+    for device in getattr(device_list, "deviceMetadata", []):
+        try:
+            if device.identifierInformation.type == DeviceUpdate_pb2.IDENTIFIER_ANDROID:
+                canonic_ids = (
+                    device.identifierInformation.phoneInformation.canonicIds.canonicId
+                )
+            else:
+                canonic_ids = device.identifierInformation.canonicIds.canonicId
+        except Exception:
+            # Fallback: no canonic IDs available for this device
+            canonic_ids = []
+
+        device_name = getattr(device, "userDefinedDeviceName", None) or ""
+
         for canonic_id in canonic_ids:
-            result.append((device_name, canonic_id.id))
+            cid = getattr(canonic_id, "id", None)
+            if isinstance(cid, str) and cid:
+                result.append((device_name, cid))
     return result
 
 
-def get_devices_with_location(device_list):
-    """Extract devices with location data from device list protobuf."""
+# --------------------------------------------------------------------------------------
+# Location extraction with contamination shielding
+# --------------------------------------------------------------------------------------
+
+# Tunables to keep behavior explicit and easily auditable
+_NEAR_TS_TOLERANCE_S: float = 5.0  # semantic merge tolerance (seconds)
+
+_DEVICE_STUB_KEYS: Tuple[str, ...] = (
+    "name",
+    "id",
+    "device_id",
+    "latitude",
+    "longitude",
+    "altitude",
+    "accuracy",
+    "last_seen",
+    "status",
+    "is_own_report",
+    "semantic_name",
+    "battery_level",
+)
+
+def _build_device_stub(device_name: str, canonic_id: str) -> Dict[str, Any]:
+    """Return a normalized, predictable stub for a device row.
+
+    The stub ensures consistent keys across call sites and prevents
+    accidental overwrites caused by missing keys.
+    """
+    return {
+        "name": device_name,
+        "id": canonic_id,
+        "device_id": canonic_id,
+        "latitude": None,
+        "longitude": None,
+        "altitude": None,
+        "accuracy": None,
+        "last_seen": None,
+        "status": None,
+        "is_own_report": None,
+        "semantic_name": None,
+        "battery_level": None,
+    }
+
+
+def _normalize_location_dict(loc: Dict[str, Any]) -> Dict[str, Any]:
+    """Coerce numeric fields to floats (when present) and drop NaN/Inf.
+
+    Only mutates a shallow copy. Unknown keys are preserved (e.g., `_report_hint`).
+    """
+    out = dict(loc)
+    for num_key in ("latitude", "longitude", "accuracy", "last_seen", "altitude"):
+        val = out.get(num_key)
+        if val is None:
+            continue
+        try:
+            f = float(val)
+            if not math.isfinite(f):
+                out.pop(num_key, None)
+            else:
+                out[num_key] = f
+        except (TypeError, ValueError):
+            out.pop(num_key, None)
+    return out
+
+
+def _select_best_location(
+    cands: List[Dict[str, Any]]
+) -> Tuple[Optional[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Choose the most useful location from a list of candidates.
+
+    This function normalizes all candidates once, then sorts them based on a
+    clear priority hierarchy to find the single most relevant location report.
+
+    Priority (high → low):
+        1) Has numeric coordinates (lat/lon)
+        2) Newer `last_seen` timestamp
+        3) Better accuracy (smaller radius)
+        4) `is_own_report` (used as a soft, final tiebreaker)
+
+    Rationale:
+        A fresh, precise crowdsourced fix is typically more helpful than an old,
+        coarse own-report. This ordering reflects that practical preference.
+
+    Returns:
+        A tuple containing:
+        - The single best location as a normalized dictionary, or None.
+        - The complete list of all normalized candidates, which can be reused
+          by downstream functions like semantic merging without re-processing.
+    """
+    if not cands:
+        return None, []
+
+    # Normalize once up front
+    normed_cands: List[Dict[str, Any]] = [_normalize_location_dict(c or {}) for c in cands]
+
+    for n in normed_cands:
+        has_coords = isinstance(n.get("latitude"), (int, float)) and isinstance(
+            n.get("longitude"), (int, float)
+        )
+        n["_rank_has_coords"] = 1 if has_coords else 0
+        try:
+            n["_rank_seen"] = float(n.get("last_seen") or 0.0)
+        except (TypeError, ValueError):
+            n["_rank_seen"] = 0.0
+        try:
+            acc = float(n.get("accuracy")) if n.get("accuracy") is not None else float("inf")
+            n["_rank_acc"] = -acc  # negative => smaller accuracy ranks higher
+        except (TypeError, ValueError):
+            n["_rank_acc"] = float("-inf")
+        n["_rank_is_own"] = 1 if bool(n.get("is_own_report")) else 0
+
+    # Coords → recency → accuracy → own-report
+    normed_cands.sort(
+        key=lambda x: (
+            x["_rank_has_coords"],
+            x["_rank_seen"],
+            x["_rank_acc"],
+            x["_rank_is_own"],
+        ),
+        reverse=True,
+    )
+
+    # Micro-optimization: remove temp rank keys in-place on the winner, then copy.
+    best_candidate = normed_cands[0]
+    for k in ("_rank_has_coords", "_rank_seen", "_rank_acc", "_rank_is_own"):
+        best_candidate.pop(k, None)
+
+    return dict(best_candidate), normed_cands
+
+
+def _merge_semantics_if_near_ts(
+    best: Dict[str, Any],
+    normed_cands: List[Dict[str, Any]],
+    *,
+    tolerance_s: float = _NEAR_TS_TOLERANCE_S,
+) -> Dict[str, Any]:
+    """Attach a semantic label from a candidate with the closest timestamp.
+
+    Behavior:
+        * If `best` already has a `semantic_name`, nothing changes.
+        * Otherwise, it searches for a candidate with a `semantic_name` whose
+          timestamp is within the `tolerance_s` window.
+        * If multiple matches exist, it deterministically chooses the one with the
+          smallest absolute time delta to the `best` location.
+
+    Rationale:
+        Sometimes the API provides a highly accurate GPS fix and a separate
+        semantic report ("Home") at almost the same time. This function merges
+        these two pieces of information, enriching the precise coordinate with
+        a human-readable place name.
+
+    Args:
+        best: The already-selected best location (assumed normalized).
+        normed_cands: The already-normalized list of all available candidates.
+        tolerance_s: The maximum time delta in seconds to consider timestamps "near".
+
+    Returns:
+        A (shallow) copy of `best` with the `semantic_name` field potentially filled.
+    """
+    out = dict(best)
+    if out.get("semantic_name"):
+        return out
+
     try:
-        from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import decrypt_location_response_locations
-    except Exception:
-        return []
-    
-    result = []
-    for device in device_list.deviceMetadata:
-        # Get canonic IDs
-        if device.identifierInformation.type == DeviceUpdate_pb2.IDENTIFIER_ANDROID: 
-            canonic_ids = device.identifierInformation.phoneInformation.canonicIds.canonicId
-        else:
-            canonic_ids = device.identifierInformation.canonicIds.canonicId
-        
-        device_name = device.userDefinedDeviceName
-        
-        for canonic_id in canonic_ids:
-            device_info = {
-                "name": device_name,
-                "id": canonic_id.id,
-                "device_id": canonic_id.id,
-                "latitude": None,
-                "longitude": None,
-                "altitude": None,
-                "accuracy": None,
-                "last_seen": None,
-                "status": None,
-                "is_own_report": None,
-                "semantic_name": None,
-                "battery_level": None
-            }
-            
-            # Try to extract location data if available
+        t_best = float(out.get("last_seen") or 0.0)
+    except (TypeError, ValueError):
+        t_best = 0.0
+
+    best_label: Optional[str] = None
+    min_delta = float("inf")
+
+    if t_best > 0:
+        for n in normed_cands:
+            label = n.get("semantic_name")
+            if not label:
+                continue
             try:
-                if device.HasField("information") and device.information.HasField("locationInformation"):
-                    if hasattr(device.information.locationInformation, 'reports') and device.information.locationInformation.reports:
-                        from custom_components.googlefindmy.ProtoDecoders import DeviceUpdate_pb2
+                t = float(n.get("last_seen") or 0.0)
+            except (TypeError, ValueError):
+                t = 0.0
+            if t <= 0:
+                continue
+            delta = abs(t - t_best)
+            if delta <= tolerance_s and delta < min_delta:
+                best_label = str(label)
+                min_delta = delta
+
+    if best_label:
+        out["semantic_name"] = best_label
+    return out
+
+
+def get_devices_with_location(device_list) -> List[Dict[str, Any]]:
+    """Extract one consolidated row per canonic device ID from a device list.
+
+    This function serves as a robust barrier against data contamination by
+    ensuring its output is always clean, consistent, and predictable.
+
+    Guarantees:
+        * **One Row Per ID**: Returns exactly one dictionary per unique canonic ID,
+          preventing duplicate entries from overwriting valid data downstream.
+        * **Deterministic Selection**: If multiple location reports are embedded
+          for a single device, it deterministically selects the single best one.
+        * **Consistent Shape**: Returned dictionaries always contain the same set of
+          keys (defined in `_DEVICE_STUB_KEYS`), preventing `KeyError` exceptions
+          in consumer code.
+        * **Data Hygiene**: All numeric fields are coerced to `float`, validated
+          for finiteness (no `NaN`/`Inf`), and sanitized before being returned.
+
+    Returns:
+        A list of device data dictionaries. Fields may be `None` if no valid
+        data was found, but the key structure is always consistent.
+    """
+    # Lazy import keeps module import-time light and avoids heavy dependencies if unused.
+    try:
+        from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (  # noqa: E501
+            decrypt_location_response_locations,
+        )
+    except Exception:
+        # If the decrypt layer is unavailable, return stubs only.
+        decrypt_location_response_locations = None  # type: ignore[assignment]
+
+    results: List[Dict[str, Any]] = []
+
+    for device in getattr(device_list, "deviceMetadata", []):
+        # Resolve canonic IDs for this device (Android vs. generic path)
+        try:
+            if device.identifierInformation.type == DeviceUpdate_pb2.IDENTIFIER_ANDROID:
+                canonic_ids = (
+                    device.identifierInformation.phoneInformation.canonicIds.canonicId
+                )
+            else:
+                canonic_ids = device.identifierInformation.canonicIds.canonicId
+        except Exception:
+            canonic_ids = []
+
+        device_name = getattr(device, "userDefinedDeviceName", None) or ""
+
+        # Try decryption ONCE per device; share across all its canonic IDs
+        location_candidates: List[Dict[str, Any]] = []
+        if decrypt_location_response_locations is not None:
+            try:
+                if device.HasField("information") and device.information.HasField(
+                    "locationInformation"
+                ):
+                    has_reports = bool(
+                        getattr(device.information.locationInformation, "reports", [])
+                    )
+                    if has_reports:
                         mock_device_update = DeviceUpdate_pb2.DeviceUpdate()
                         mock_device_update.deviceMetadata.CopyFrom(device)
-                        
-                        try:
-                            location_data = decrypt_location_response_locations(mock_device_update)
-                            
-                            if location_data and len(location_data) > 0:
-                                for loc in location_data:
-                                    loc["device_name"] = device_name
-                                    loc["canonic_id"] = canonic_id.id
-                                    loc["device_id"] = canonic_id.id
-                                    
-                                    result.append({
-                                        "name": device_name,
-                                        "id": canonic_id.id,
-                                        "device_id": canonic_id.id,
-                                        **loc
-                                    })
-                        except Exception:
-                            pass
+                        location_candidates = (
+                            decrypt_location_response_locations(mock_device_update) or []
+                        )
             except Exception:
-                pass
-            
-            result.append(device_info)
-    
-    return result
+                # Defensive: decryption issues must not break the whole list.
+                location_candidates = []
+
+        # If decryption yielded results, select the best one and keep normalized list.
+        if location_candidates:
+            best, normed = _select_best_location(location_candidates)
+            if best:
+                best = _merge_semantics_if_near_ts(best, normed)
+        else:
+            best, normed = None, []
+
+        # Emit **exactly one** row per canonic ID.
+        for canonic in canonic_ids:
+            cid = getattr(canonic, "id", None)
+            if not (isinstance(cid, str) and cid):
+                continue
+
+            row = _build_device_stub(device_name, cid)
+
+            if best:
+                # best already normalized by selection; merge only known keys
+                for k in _DEVICE_STUB_KEYS:
+                    if k in best and best[k] is not None:
+                        row[k] = best[k]
+                # Ensure device identity fields are not overwritten by nested payloads
+                row["name"] = device_name
+                row["id"] = cid
+                row["device_id"] = cid
+
+            results.append(row)
+
+    return results
 
 
-def print_location_report_upload_protobuf(hex_string):
-    print(text_format.MessageToString(parse_location_report_upload_protobuf(hex_string), message_formatter=custom_message_formatter))
+# --------------------------------------------------------------------------------------
+# Dev print helpers
+# --------------------------------------------------------------------------------------
+
+def print_location_report_upload_protobuf(hex_string: str):
+    print(
+        text_format.MessageToString(
+            parse_location_report_upload_protobuf(hex_string),
+            message_formatter=custom_message_formatter,
+        )
+    )
 
 
-def print_device_update_protobuf(hex_string):
-    print(text_format.MessageToString(parse_device_update_protobuf(hex_string), message_formatter=custom_message_formatter))
+def print_device_update_protobuf(hex_string: str):
+    print(
+        text_format.MessageToString(
+            parse_device_update_protobuf(hex_string),
+            message_formatter=custom_message_formatter,
+        )
+    )
 
 
-def print_device_list_protobuf(hex_string):
-    print(text_format.MessageToString(parse_device_list_protobuf(hex_string), message_formatter=custom_message_formatter))
+def print_device_list_protobuf(hex_string: str):
+    print(
+        text_format.MessageToString(
+            parse_device_list_protobuf(hex_string),
+            message_formatter=custom_message_formatter,
+        )
+    )
 
 
-if __name__ == '__main__':
+# --------------------------------------------------------------------------------------
+# Developer entry point (protobuf regen + sample dumps)
+# --------------------------------------------------------------------------------------
+
+if __name__ == "__main__":
     # Recompile
     subprocess.run(["protoc", "--python_out=.", "ProtoDecoders/Common.proto"], cwd="../")
-    subprocess.run(["protoc", "--python_out=.", "ProtoDecoders/DeviceUpdate.proto"], cwd="../")
-    subprocess.run(["protoc", "--python_out=.", "ProtoDecoders/LocationReportsUpload.proto"], cwd="../")
+    subprocess.run(
+        ["protoc", "--python_out=.", "ProtoDecoders/DeviceUpdate.proto"], cwd="../"
+    )
+    subprocess.run(
+        ["protoc", "--python_out=.", "ProtoDecoders/LocationReportsUpload.proto"],
+        cwd="../",
+    )
 
     subprocess.run(["protoc", "--pyi_out=.", "ProtoDecoders/Common.proto"], cwd="../")
-    subprocess.run(["protoc", "--pyi_out=.", "ProtoDecoders/DeviceUpdate.proto"], cwd="../")
-    subprocess.run(["protoc", "--pyi_out=.", "ProtoDecoders/LocationReportsUpload.proto"], cwd="../")
+    subprocess.run(
+        ["protoc", "--pyi_out=.", "ProtoDecoders/DeviceUpdate.proto"], cwd="../"
+    )
+    subprocess.run(
+        ["protoc", "--pyi_out=.", "ProtoDecoders/LocationReportsUpload.proto"],
+        cwd="../",
+    )
 
     print("\n ------------------- \n")
 

--- a/custom_components/googlefindmy/__init__.py
+++ b/custom_components/googlefindmy/__init__.py
@@ -224,36 +224,42 @@ async def _async_acquire_shared_fcm(hass: HomeAssistant) -> FcmReceiverHA:
         - Maintains a reference counter to support multiple entries.
     """
     bucket = hass.data.setdefault(DOMAIN, {})
-    refcount = int(bucket.get("fcm_refcount", 0))
-    fcm: FcmReceiverHA | None = bucket.get("fcm_receiver")
+    fcm_lock = bucket.setdefault("fcm_lock", asyncio.Lock())
+    async with fcm_lock:
+        refcount = int(bucket.get("fcm_refcount", 0))
+        fcm: FcmReceiverHA | None = bucket.get("fcm_receiver")
 
-    if fcm is None:
-        fcm = FcmReceiverHA()
-        _LOGGER.debug("Initializing shared FCM receiver...")
-        ok = await fcm.async_initialize()
-        if not ok:
-            raise ConfigEntryNotReady("Failed to initialize FCM receiver")
-        bucket["fcm_receiver"] = fcm
-        _LOGGER.info("Shared FCM receiver initialized")
+        if fcm is None:
+            fcm = FcmReceiverHA()
+            _LOGGER.debug("Initializing shared FCM receiver...")
+            ok = await fcm.async_initialize()
+            if not ok:
+                raise ConfigEntryNotReady("Failed to initialize FCM receiver")
+            bucket["fcm_receiver"] = fcm
+            _LOGGER.info("Shared FCM receiver initialized")
 
-        # Register provider for both consumer modules (exactly once on first acquire)
-        loc_register_fcm_provider(lambda: hass.data[DOMAIN].get("fcm_receiver"))
-        api_register_fcm_provider(lambda: hass.data[DOMAIN].get("fcm_receiver"))
+            # Register provider for both consumer modules (exactly once on first acquire)
+            loc_register_fcm_provider(lambda: hass.data[DOMAIN].get("fcm_receiver"))
+            api_register_fcm_provider(lambda: hass.data[DOMAIN].get("fcm_receiver"))
 
-    bucket["fcm_refcount"] = refcount + 1
-    _LOGGER.debug("FCM refcount -> %s", bucket["fcm_refcount"])
-    return fcm
+        bucket["fcm_refcount"] = refcount + 1
+        _LOGGER.debug("FCM refcount -> %s", bucket["fcm_refcount"])
+        return fcm
 
 
 async def _async_release_shared_fcm(hass: HomeAssistant) -> None:
     """Decrease refcount; stop and unregister provider when it reaches zero."""
     bucket = hass.data.setdefault(DOMAIN, {})
-    refcount = int(bucket.get("fcm_refcount", 0)) - 1
-    refcount = max(refcount, 0)
-    bucket["fcm_refcount"] = refcount
-    _LOGGER.debug("FCM refcount -> %s", refcount)
+    fcm_lock = bucket.setdefault("fcm_lock", asyncio.Lock())
+    async with fcm_lock:
+        refcount = int(bucket.get("fcm_refcount", 0)) - 1
+        refcount = max(refcount, 0)
+        bucket["fcm_refcount"] = refcount
+        _LOGGER.debug("FCM refcount -> %s", refcount)
 
-    if refcount == 0:
+        if refcount != 0:
+            return
+
         fcm: FcmReceiverHA | None = bucket.pop("fcm_receiver", None)
 
         # Unregister providers first (consumers will see provider=None immediately)
@@ -535,310 +541,332 @@ def _get_local_ip_sync() -> str:
 
 
 async def _async_register_services(hass: HomeAssistant, coordinator: GoogleFindMyCoordinator) -> None:
-    """Register services for the integration (idempotent per-HA instance)."""
-    # Guard: register services only once per HA instance
+    """Register services for the integration (idempotent per-HA instance, race-free)."""
     domain_bucket = hass.data.setdefault(DOMAIN, {})
-    if domain_bucket.get("services_registered"):
-        return
+    services_lock = domain_bucket.setdefault("services_lock", asyncio.Lock())
+    async with services_lock:
+        if domain_bucket.get("services_registered"):
+            return
 
-    def _resolve_canonical_from_any(arg: str) -> tuple[str, str]:
-        """Resolve any device identifier to (canonical_id, friendly_name)."""
-        # 1) Treat as HA device_id
-        dev = dr.async_get(hass).async_get(arg)
-        if dev:
-            for domain, ident in dev.identifiers:
-                if domain == DOMAIN:
-                    name = dev.name_by_user or dev.name or ident
-                    return ident, name
+        def _resolve_canonical_from_any(arg: str) -> tuple[str, str]:
+            """Resolve any device identifier to (canonical_id, friendly_name)."""
+            # 1) Treat as HA device_id
+            dev = dr.async_get(hass).async_get(arg)
+            if dev:
+                for domain, ident in dev.identifiers:
+                    if domain == DOMAIN:
+                        name = dev.name_by_user or dev.name or ident
+                        return ident, name
 
-        # 2) Treat as entity_id
-        if "." in arg:
-            ent = er.async_get(hass).async_get(arg)
-            if ent and ent.platform == DOMAIN and ent.device_id:
-                dev = dr.async_get(hass).async_get(ent.device_id)
-                if dev:
-                    for domain, ident in dev.identifiers:
-                        if domain == DOMAIN:
-                            name = dev.name_by_user or dev.name or ident
-                            return ident, name
+            # 2) Treat as entity_id
+            if "." in arg:
+                ent = er.async_get(hass).async_get(arg)
+                if ent and ent.platform == DOMAIN and ent.device_id:
+                    dev = dr.async_get(hass).async_get(ent.device_id)
+                    if dev:
+                        for domain, ident in dev.identifiers:
+                            if domain == DOMAIN:
+                                name = dev.name_by_user or dev.name or ident
+                                return ident, name
 
-        # 3) Fallback: assume arg is the canonical Google ID
-        name = coordinator.get_device_display_name(arg) or arg
-        if name != arg:
-            return arg, name
-        raise ValueError(f"Identifier '{arg}' could not be resolved to a known device")
+            # 3) Fallback: assume arg is the canonical Google ID (no coordinator dependency here)
+            return arg, arg
 
-    async def async_locate_device_service(call: ServiceCall) -> None:
-        """Handle locate device service call."""
-        raw = call.data["device_id"]
-        try:
-            canonical_id, friendly = _resolve_canonical_from_any(str(raw))
-            # Early gating for better UX/logging (mirrors button/coordinator checks)
-            if not coordinator.can_request_location(canonical_id):
-                _LOGGER.warning(
-                    "Locate request for %s (%s) ignored: not allowed right now (in-flight, cooldown, push not ready, or polling).",
-                    friendly,
-                    canonical_id,
-                )
-                return
-            _LOGGER.info("Locate request for %s (%s)", friendly, canonical_id)
-            await coordinator.async_locate_device(canonical_id)
-        except ValueError as err:
-            _LOGGER.error("Failed to locate device: %s", err)
-        except Exception as err:  # Catch potential API errors from coordinator
-            _LOGGER.error("Failed to locate device '%s': %s", raw, err)
+        def _get_coordinator_for_canonical_id(canonical_id: str) -> GoogleFindMyCoordinator | None:
+            """Resolve the owning coordinator for a canonical device id via Device Registry."""
+            dev_reg = dr.async_get(hass)
+            for dev in dev_reg.devices.values():
+                if any(domain == DOMAIN and ident == canonical_id for domain, ident in dev.identifiers):
+                    for entry_id in dev.config_entries:
+                        entry = hass.config_entries.async_get_entry(entry_id)
+                        if entry and entry.domain == DOMAIN:
+                            coord = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+                            if coord:
+                                return coord
+            return None
 
-    async def async_play_sound_service(call: ServiceCall) -> None:
-        """Handle play sound service call."""
-        raw = call.data["device_id"]
-        try:
-            canonical_id, friendly = _resolve_canonical_from_any(str(raw))
-            _LOGGER.info("Play Sound request for %s (%s)", friendly, canonical_id)
-            ok = await coordinator.async_play_sound(canonical_id)
-            if not ok:
-                _LOGGER.warning(
-                    "Failed to play sound on %s (request may have been rejected by API)", friendly
-                )
-        except ValueError as err:
-            _LOGGER.error("Failed to play sound: %s", err)
-        except Exception as err:
-            _LOGGER.error("Failed to play sound on '%s': %s", raw, err)
+        async def async_locate_device_service(call: ServiceCall) -> None:
+            """Handle locate device service call."""
+            raw = call.data["device_id"]
+            try:
+                canonical_id, friendly = _resolve_canonical_from_any(str(raw))
+                coord = _get_coordinator_for_canonical_id(canonical_id)
+                if coord is None:
+                    raise ValueError(f"No coordinator found for device '{canonical_id}'")
+                # Early gating for better UX/logging (mirrors button/coordinator checks)
+                if not coord.can_request_location(canonical_id):
+                    _LOGGER.warning(
+                        "Locate request for %s (%s) ignored: not allowed right now (in-flight, cooldown, push not ready, or polling).",
+                        friendly,
+                        canonical_id,
+                    )
+                    return
+                _LOGGER.info("Locate request for %s (%s)", friendly, canonical_id)
+                await coord.async_locate_device(canonical_id)
+            except ValueError as err:
+                _LOGGER.error("Failed to locate device: %s", err)
+            except Exception as err:  # Catch potential API errors from coordinator
+                _LOGGER.error("Failed to locate device '%s': %s", raw, err)
 
-    async def async_stop_sound_service(call: ServiceCall) -> None:
-        """Handle stop sound service call."""
-        raw = call.data["device_id"]
-        try:
-            canonical_id, friendly = _resolve_canonical_from_any(str(raw))
-            _LOGGER.info("Stop Sound request for %s (%s)", friendly, canonical_id)
-            ok = await coordinator.async_stop_sound(canonical_id)
-            if not ok:
-                _LOGGER.warning(
-                    "Failed to stop sound on %s (request may have been rejected by API)", friendly
-                )
-        except ValueError as err:
-            _LOGGER.error("Failed to stop sound: %s", err)
-        except Exception as err:
-            _LOGGER.error("Failed to stop sound on '%s': %s", raw, err)
+        async def async_play_sound_service(call: ServiceCall) -> None:
+            """Handle play sound service call."""
+            raw = call.data["device_id"]
+            try:
+                canonical_id, friendly = _resolve_canonical_from_any(str(raw))
+                coord = _get_coordinator_for_canonical_id(canonical_id)
+                if coord is None:
+                    raise ValueError(f"No coordinator found for device '{canonical_id}'")
+                _LOGGER.info("Play Sound request for %s (%s)", friendly, canonical_id)
+                ok = await coord.async_play_sound(canonical_id)
+                if not ok:
+                    _LOGGER.warning(
+                        "Failed to play sound on %s (request may have been rejected by API)", friendly
+                    )
+            except ValueError as err:
+                _LOGGER.error("Failed to play sound: %s", err)
+            except Exception as err:
+                _LOGGER.error("Failed to play sound on '%s': %s", raw, err)
 
-    async def async_locate_external_service(call: ServiceCall) -> None:
-        """External locate device service (delegates to locate)."""
-        raw = call.data["device_id"]
-        provided_name = call.data.get("device_name")
-        try:
-            canonical_id, friendly = _resolve_canonical_from_any(str(raw))
-            device_name = provided_name or friendly or canonical_id
-            # Early gating for better UX/logging (mirrors button/coordinator checks)
-            if not coordinator.can_request_location(canonical_id):
-                _LOGGER.warning(
-                    "External locate request for %s (%s) ignored: not allowed right now (in-flight, cooldown, push not ready, or polling).",
+        async def async_stop_sound_service(call: ServiceCall) -> None:
+            """Handle stop sound service call."""
+            raw = call.data["device_id"]
+            try:
+                canonical_id, friendly = _resolve_canonical_from_any(str(raw))
+                coord = _get_coordinator_for_canonical_id(canonical_id)
+                if coord is None:
+                    raise ValueError(f"No coordinator found for device '{canonical_id}'")
+                _LOGGER.info("Stop Sound request for %s (%s)", friendly, canonical_id)
+                ok = await coord.async_stop_sound(canonical_id)
+                if not ok:
+                    _LOGGER.warning(
+                        "Failed to stop sound on %s (request may have been rejected by API)", friendly
+                    )
+            except ValueError as err:
+                _LOGGER.error("Failed to stop sound: %s", err)
+            except Exception as err:
+                _LOGGER.error("Failed to stop sound on '%s': %s", raw, err)
+
+        async def async_locate_external_service(call: ServiceCall) -> None:
+            """External locate device service (delegates to locate)."""
+            raw = call.data["device_id"]
+            provided_name = call.data.get("device_name")
+            try:
+                canonical_id, friendly = _resolve_canonical_from_any(str(raw))
+                coord = _get_coordinator_for_canonical_id(canonical_id)
+                if coord is None:
+                    raise ValueError(f"No coordinator found for device '{canonical_id}'")
+                device_name = provided_name or friendly or canonical_id
+                # Early gating for better UX/logging (mirrors button/coordinator checks)
+                if not coord.can_request_location(canonical_id):
+                    _LOGGER.warning(
+                        "External locate request for %s (%s) ignored: not allowed right now (in-flight, cooldown, push not ready, or polling).",
+                        device_name,
+                        canonical_id,
+                    )
+                    return
+                _LOGGER.info(
+                    "External location request for %s (%s) - delegating to normal locate",
                     device_name,
                     canonical_id,
                 )
-                return
-            _LOGGER.info(
-                "External location request for %s (%s) - delegating to normal locate",
-                device_name,
-                canonical_id,
-            )
-            await coordinator.async_locate_device(canonical_id)
-        except ValueError as err:
-            _LOGGER.error("Failed to execute external locate: %s", err)
-        except Exception as err:
-            _LOGGER.error("Failed to execute external locate for '%s': %s", raw, err)
-
-    async def async_refresh_device_urls_service(call: ServiceCall) -> None:
-        """Refresh configuration URLs for integration devices (absolute URL)."""
-        try:
-            base_url = get_url(
-                hass, prefer_external=True, allow_cloud=True, allow_external=True, allow_internal=True
-            )
-        except HomeAssistantError as err:
-            _LOGGER.error("Could not determine base URL for device refresh: %s", err)
-            return
-
-        # Token mode: options-first
-        ha_uuid = str(hass.data.get("core.uuid", "ha"))
-        config_entries = hass.config_entries.async_entries(DOMAIN)
-        token_expiration_enabled = DEFAULT_MAP_VIEW_TOKEN_EXPIRATION
-        if config_entries:
-            e0 = config_entries[0]
-            token_expiration_enabled = _opt(
-                e0, OPT_MAP_VIEW_TOKEN_EXPIRATION, DEFAULT_MAP_VIEW_TOKEN_EXPIRATION
-            )
-
-        if token_expiration_enabled:
-            week = str(int(time.time() // 604800))  # weekly rotation bucket
-            auth_token = hashlib.md5(f"{ha_uuid}:{week}".encode()).hexdigest()[:16]
-        else:
-            auth_token = hashlib.md5(f"{ha_uuid}:static".encode()).hexdigest()[:16]
-
-        dev_reg = dr.async_get(hass)
-        updated_count = 0
-        for device in dev_reg.devices.values():
-            if any(identifier[0] == DOMAIN for identifier in device.identifiers):
-                dev_id = next((ident for domain, ident in device.identifiers if domain == DOMAIN), None)
-                if dev_id:
-                    new_config_url = f"{base_url}/api/googlefindmy/map/{dev_id}?token={auth_token}"
-                    dev_reg.async_update_device(device_id=device.id, configuration_url=new_config_url)
-                    updated_count += 1
-                    _LOGGER.debug(
-                        "Updated URL for device %s: %s",
-                        device.name_by_user or device.name,
-                        _redact_url_token(new_config_url),
-                    )
-
-        _LOGGER.info("Refreshed URLs for %d Google Find My devices", updated_count)
-
-    async def async_rebuild_registry_service(call: ServiceCall) -> None:
-        """Migrate soft settings or rebuild the registry (optionally scoped to device_ids).
-
-        Logic:
-            1. Determine target devices (all or a subset).
-            2. Remove all entities associated with these devices.
-            3. Remove orphaned devices (those with no entities left).
-            4. Reload the config entries associated with the affected devices.
-        """
-        mode: str = str(call.data.get(ATTR_MODE, MODE_REBUILD)).lower()
-        raw_ids = call.data.get(ATTR_DEVICE_IDS)
-
-        if isinstance(raw_ids, str):
-            target_device_ids = {raw_ids}
-        elif isinstance(raw_ids, (list, tuple, set)):
-            target_device_ids = {str(x) for x in raw_ids}
-        else:
-            target_device_ids = set()
-
-        dev_reg = dr.async_get(hass)
-        ent_reg = er.async_get(hass)
-        entries = hass.config_entries.async_entries(DOMAIN)
-
-        _LOGGER.info(
-            "googlefindmy.rebuild_registry requested: mode=%s, device_ids=%s",
-            mode,
-            "none" if not raw_ids else (raw_ids if isinstance(raw_ids, str) else f"{len(target_device_ids)} ids"),
-        )
-
-        if mode == MODE_MIGRATE:
-            for entry in entries:
-                try:
-                    await _async_soft_migrate_data_to_options(hass, entry)
-                except Exception as err:
-                    _LOGGER.error("Soft-migrate failed for entry %s: %s", entry.entry_id, err)
-            _LOGGER.info(
-                "googlefindmy.rebuild_registry: soft-migrate completed for %d config entrie(s).",
-                len(entries),
-            )
-            return
-
-        if mode != MODE_REBUILD:
-            _LOGGER.error(
-                "Unsupported mode '%s' for rebuild_registry; use one of: %s",
-                mode,
-                ", ".join(REBUILD_REGISTRY_MODES),
-            )
-            return
-
-        affected_entry_ids: set[str] = set()
-        if target_device_ids:
-            candidate_devices = set()
-            for d in target_device_ids:
-                dev = dev_reg.async_get(d)
-                if dev is not None:
-                    candidate_devices.add(dev.id)
-                    affected_entry_ids.update(dev.config_entries)
-        else:
-            candidate_devices = set()
-            for dev in dev_reg.devices.values():
-                if any(domain == DOMAIN for domain, _ in dev.identifiers):
-                    candidate_devices.add(dev.id)
-                    affected_entry_ids.update(dev.config_entries)
-
-        if not candidate_devices:
-            _LOGGER.info("googlefindmy.rebuild_registry: no matching devices to rebuild.")
-            return
-
-        removed_entities = 0
-        removed_devices = 0
-
-        for ent in list(ent_reg.entities.values()):
-            if ent.platform == DOMAIN and ent.device_id in candidate_devices:
-                try:
-                    ent_reg.async_remove(ent.entity_id)
-                    removed_entities += 1
-                except Exception as err:
-                    _LOGGER.error("Failed to remove entity %s: %s", ent.entity_id, err)
-
-        for dev_id in list(candidate_devices):
-            dev = dev_reg.async_get(dev_id)
-            if dev is None:
-                continue
-            has_entities = any(e.device_id == dev_id for e in ent_reg.entities.values())
-            if not has_entities:
-                try:
-                    dev_reg.async_remove_device(dev_id)
-                    removed_devices += 1
-                except Exception as err:
-                    _LOGGER.error("Failed to remove device %s: %s", dev_id, err)
-
-        to_reload = [e for e in entries if e.entry_id in affected_entry_ids] or list(entries)
-        for entry in to_reload:
-            try:
-                await hass.config_entries.async_reload(entry.entry_id)
+                await coord.async_locate_device(canonical_id)
+            except ValueError as err:
+                _LOGGER.error("Failed to execute external locate: %s", err)
             except Exception as err:
-                _LOGGER.error("Reload failed for entry %s: %s", entry.entry_id, err)
+                _LOGGER.error("Failed to execute external locate for '%s': %s", raw, err)
 
-        _LOGGER.info(
-            "googlefindmy.rebuild_registry: rebuild finished: removed %d entit(y/ies), %d device(s), entries reloaded=%d",
-            removed_entities,
-            removed_devices,
-            len(to_reload),
+        async def async_refresh_device_urls_service(call: ServiceCall) -> None:
+            """Refresh configuration URLs for integration devices (absolute URL)."""
+            try:
+                base_url = get_url(
+                    hass, prefer_external=True, allow_cloud=True, allow_external=True, allow_internal=True
+                )
+            except HomeAssistantError as err:
+                _LOGGER.error("Could not determine base URL for device refresh: %s", err)
+                return
+
+            # Token mode: options-first
+            ha_uuid = str(hass.data.get("core.uuid", "ha"))
+            config_entries = hass.config_entries.async_entries(DOMAIN)
+            token_expiration_enabled = DEFAULT_MAP_VIEW_TOKEN_EXPIRATION
+            if config_entries:
+                e0 = config_entries[0]
+                token_expiration_enabled = _opt(
+                    e0, OPT_MAP_VIEW_TOKEN_EXPIRATION, DEFAULT_MAP_VIEW_TOKEN_EXPIRATION
+                )
+
+            if token_expiration_enabled:
+                week = str(int(time.time() // 604800))  # weekly rotation bucket
+                auth_token = hashlib.md5(f"{ha_uuid}:{week}".encode()).hexdigest()[:16]
+            else:
+                auth_token = hashlib.md5(f"{ha_uuid}:static".encode()).hexdigest()[:16]
+
+            dev_reg = dr.async_get(hass)
+            updated_count = 0
+            for device in dev_reg.devices.values():
+                if any(identifier[0] == DOMAIN for identifier in device.identifiers):
+                    dev_id = next((ident for domain, ident in device.identifiers if domain == DOMAIN), None)
+                    if dev_id:
+                        new_config_url = f"{base_url}/api/googlefindmy/map/{dev_id}?token={auth_token}"
+                        dev_reg.async_update_device(device_id=device.id, configuration_url=new_config_url)
+                        updated_count += 1
+                        _LOGGER.debug(
+                            "Updated URL for device %s: %s",
+                            device.name_by_user or device.name,
+                            _redact_url_token(new_config_url),
+                        )
+
+            _LOGGER.info("Refreshed URLs for %d Google Find My devices", updated_count)
+
+        async def async_rebuild_registry_service(call: ServiceCall) -> None:
+            """Migrate soft settings or rebuild the registry (optionally scoped to device_ids).
+
+            Logic:
+                1. Determine target devices (all or a subset).
+                2. Remove all entities associated with these devices.
+                3. Remove orphaned devices (those with no entities left).
+                4. Reload the config entries associated with the affected devices.
+            """
+            mode: str = str(call.data.get(ATTR_MODE, MODE_REBUILD)).lower()
+            raw_ids = call.data.get(ATTR_DEVICE_IDS)
+
+            if isinstance(raw_ids, str):
+                target_device_ids = {raw_ids}
+            elif isinstance(raw_ids, (list, tuple, set)):
+                target_device_ids = {str(x) for x in raw_ids}
+            else:
+                target_device_ids = set()
+
+            dev_reg = dr.async_get(hass)
+            ent_reg = er.async_get(hass)
+            entries = hass.config_entries.async_entries(DOMAIN)
+
+            _LOGGER.info(
+                "googlefindmy.rebuild_registry requested: mode=%s, device_ids=%s",
+                mode,
+                "none" if not raw_ids else (raw_ids if isinstance(raw_ids, str) else f"{len(target_device_ids)} ids"),
+            )
+
+            if mode == MODE_MIGRATE:
+                for entry in entries:
+                    try:
+                        await _async_soft_migrate_data_to_options(hass, entry)
+                    except Exception as err:
+                        _LOGGER.error("Soft-migrate failed for entry %s: %s", entry.entry_id, err)
+                _LOGGER.info(
+                    "googlefindmy.rebuild_registry: soft-migrate completed for %d config entrie(s).",
+                    len(entries),
+                )
+                return
+
+            if mode != MODE_REBUILD:
+                _LOGGER.error(
+                    "Unsupported mode '%s' for rebuild_registry; use one of: %s",
+                    mode,
+                    ", ".join(REBUILD_REGISTRY_MODES),
+                )
+                return
+
+            affected_entry_ids: set[str] = set()
+            if target_device_ids:
+                candidate_devices = set()
+                for d in target_device_ids:
+                    dev = dev_reg.async_get(d)
+                    if dev is not None:
+                        candidate_devices.add(dev.id)
+                        affected_entry_ids.update(dev.config_entries)
+            else:
+                candidate_devices = set()
+                for dev in dev_reg.devices.values():
+                    if any(domain == DOMAIN for domain, _ in dev.identifiers):
+                        candidate_devices.add(dev.id)
+                        affected_entry_ids.update(dev.config_entries)
+
+            if not candidate_devices:
+                _LOGGER.info("googlefindmy.rebuild_registry: no matching devices to rebuild.")
+                return
+
+            removed_entities = 0
+            removed_devices = 0
+
+            for ent in list(ent_reg.entities.values()):
+                if ent.platform == DOMAIN and ent.device_id in candidate_devices:
+                    try:
+                        ent_reg.async_remove(ent.entity_id)
+                        removed_entities += 1
+                    except Exception as err:
+                        _LOGGER.error("Failed to remove entity %s: %s", ent.entity_id, err)
+
+            for dev_id in list(candidate_devices):
+                dev = dev_reg.async_get(dev_id)
+                if dev is None:
+                    continue
+                has_entities = any(e.device_id == dev_id for e in ent_reg.entities.values())
+                if not has_entities:
+                    try:
+                        dev_reg.async_remove_device(dev_id)
+                        removed_devices += 1
+                    except Exception as err:
+                        _LOGGER.error("Failed to remove device %s: %s", dev_id, err)
+
+            to_reload = [e for e in entries if e.entry_id in affected_entry_ids] or list(entries)
+            for entry in to_reload:
+                try:
+                    await hass.config_entries.async_reload(entry.entry_id)
+                except Exception as err:
+                    _LOGGER.error("Reload failed for entry %s: %s", entry.entry_id, err)
+
+            _LOGGER.info(
+                "googlefindmy.rebuild_registry: rebuild finished: removed %d entit(y/ies), %d device(s), entries reloaded=%d",
+                removed_entities,
+                removed_devices,
+                len(to_reload),
+            )
+
+        # Register all services for the integration under the lock.
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_LOCATE_DEVICE,
+            async_locate_device_service,
+            schema=vol.Schema({vol.Required("device_id"): cv.string}),
+        )
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_PLAY_SOUND,
+            async_play_sound_service,
+            schema=vol.Schema({vol.Required("device_id"): cv.string}),
+        )
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_STOP_SOUND,
+            async_stop_sound_service,
+            schema=vol.Schema({vol.Required("device_id"): cv.string}),
+        )
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_LOCATE_EXTERNAL,
+            async_locate_external_service,
+            schema=vol.Schema({vol.Required("device_id"): cv.string, vol.Optional("device_name"): cv.string}),
+        )
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_REFRESH_DEVICE_URLS,
+            async_refresh_device_urls_service,
+            schema=vol.Schema({}),
+        )
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_REBUILD_REGISTRY,
+            async_rebuild_registry_service,
+            schema=vol.Schema(
+                {
+                    vol.Optional(ATTR_MODE, default=MODE_REBUILD): vol.In(REBUILD_REGISTRY_MODES),
+                    vol.Optional(ATTR_DEVICE_IDS): vol.Any(cv.string, [cv.string]),
+                }
+            ),
         )
 
-    # Register all services for the integration.
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_LOCATE_DEVICE,
-        async_locate_device_service,
-        schema=vol.Schema({vol.Required("device_id"): cv.string}),
-    )
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_PLAY_SOUND,
-        async_play_sound_service,
-        schema=vol.Schema({vol.Required("device_id"): cv.string}),
-    )
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_STOP_SOUND,
-        async_stop_sound_service,
-        schema=vol.Schema({vol.Required("device_id"): cv.string}),
-    )
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_LOCATE_EXTERNAL,
-        async_locate_external_service,
-        schema=vol.Schema({vol.Required("device_id"): cv.string, vol.Optional("device_name"): cv.string}),
-    )
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_REFRESH_DEVICE_URLS,
-        async_refresh_device_urls_service,
-        schema=vol.Schema({}),
-    )
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_REBUILD_REGISTRY,
-        async_rebuild_registry_service,
-        schema=vol.Schema(
-            {
-                vol.Optional(ATTR_MODE, default=MODE_REBUILD): vol.In(REBUILD_REGISTRY_MODES),
-                vol.Optional(ATTR_DEVICE_IDS): vol.Any(cv.string, [cv.string]),
-            }
-        ),
-    )
-
-    domain_bucket = hass.data.setdefault(DOMAIN, {})
-    domain_bucket["services_registered"] = True
+        domain_bucket["services_registered"] = True
 
 
 # ------------------- Device removal (HA "Delete device" hook) -------------------

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -452,6 +452,23 @@ class GoogleFindMyAPI:
                 err,
             )
             return {}
+        except RuntimeError as err:
+            # Startup safety net: during cold boot, the FCM provider may not yet be registered.
+            # Downgrade this expected transient to DEBUG and retry on the next cycle.
+            if "FCM receiver provider has not been registered" in str(err):
+                _LOGGER.debug(
+                    "Startup race: FCM provider not ready for %s (%s). Will retry on next cycle.",
+                    device_name,
+                    device_id,
+                )
+                return {}
+            _LOGGER.error(
+                "Runtime error while getting async location for %s (%s): %s",
+                device_name,
+                device_id,
+                err,
+            )
+            return {}
         except Exception as err:
             _LOGGER.error(
                 "Failed to get async location for %s (%s): %s",

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -36,12 +36,14 @@ _LOGGER = logging.getLogger(__name__)
 @runtime_checkable
 class FcmReceiverProtocol(Protocol):
     """Minimal protocol for the shared FCM receiver used by this module."""
+
     def get_fcm_token(self) -> Optional[str]: ...
 
 
 @runtime_checkable
 class CacheProtocol(Protocol):
     """Entry-scoped cache protocol (TokenCache instance)."""
+
     async def async_get_cached_value(self, key: str) -> Any: ...
     async def async_set_cached_value(self, key: str, value: Any) -> None: ...
 
@@ -52,6 +54,10 @@ _FCM_ReceiverGetter: Optional[Callable[[], FcmReceiverProtocol]] = None
 
 def register_fcm_receiver_provider(getter: Callable[[], FcmReceiverProtocol]) -> None:
     """Register a getter that returns the shared FCM receiver (HA-managed).
+
+    The provider is a zero-arg callable that returns the current receiver instance.
+    We keep this indirection to avoid importing heavy modules at import time and
+    to stay resilient to reloads (the callable resolves the live object on access).
 
     Args:
         getter: A callable that returns the singleton FcmReceiverProtocol instance.
@@ -330,6 +336,33 @@ class GoogleFindMyAPI:
             return None
         return token
 
+    def _peek_fcm_token_quietly(self) -> Optional[str]:
+        """Best-effort token probe for readiness checks (no ERROR-level log spam).
+
+        Returns:
+            Token string when obtainable; otherwise None. All failures are logged at DEBUG.
+        """
+        if _FCM_ReceiverGetter is None:
+            _LOGGER.debug("FCM readiness probe: no provider registered.")
+            return None
+        try:
+            receiver = _FCM_ReceiverGetter()
+        except Exception as err:
+            _LOGGER.debug("FCM readiness probe: provider callable failed: %s", err)
+            return None
+        if receiver is None:
+            _LOGGER.debug("FCM readiness probe: provider returned None.")
+            return None
+        try:
+            token = receiver.get_fcm_token()
+        except Exception as err:
+            _LOGGER.debug("FCM readiness probe: get_fcm_token failed: %s", err)
+            return None
+        if not token or not isinstance(token, str) or len(token) < 10:
+            _LOGGER.debug("FCM readiness probe: token missing or too short.")
+            return None
+        return token
+
     # ----------------------------- Device enumeration ----------------------------
     async def async_get_basic_device_list(
         self, username: Optional[str] = None
@@ -515,8 +548,44 @@ class GoogleFindMyAPI:
 
     # ------------------------ Play/Stop Sound / Push readiness -------------------
     def is_push_ready(self) -> bool:
-        """Return True if the push transport (FCM) is initialized and has a usable token."""
-        return self._get_fcm_token_for_action() is not None
+        """Return True if the push transport (FCM) appears initialized and ready.
+
+        Heuristics (no I/O, no blocking):
+          1) Use receiver-level readiness flags when available (is_ready/ready).
+          2) Inspect push client state on the receiver (pc.run_state == STARTED and pc.do_listen).
+          3) Fall back to token presence via a quiet probe (no ERROR-level spam).
+
+        This keeps API- and coordinator-level gating consistent while avoiding tight
+        coupling to specific FCM client classes and enums.
+        """
+        # No provider registered?
+        if _FCM_ReceiverGetter is None:
+            return False
+
+        # Resolve live receiver (may change across reloads)
+        try:
+            receiver = _FCM_ReceiverGetter()
+        except Exception:
+            return False
+        if receiver is None:
+            return False
+
+        # 1) Receiver-level booleans
+        for attr in ("is_ready", "ready"):
+            val = getattr(receiver, attr, None)
+            if isinstance(val, bool):
+                return val
+
+        # 2) Push client heuristic: tolerate enum or string for run_state
+        pc = getattr(receiver, "pc", None)
+        if pc is not None:
+            state = getattr(pc, "run_state", None)
+            state_name = getattr(state, "name", state)  # enum.name or raw
+            if state_name == "STARTED" and bool(getattr(pc, "do_listen", False)):
+                return True
+
+        # 3) Quiet token probe as last resort
+        return self._peek_fcm_token_quietly() is not None
 
     @property
     def push_ready(self) -> bool:

--- a/custom_components/googlefindmy/binary_sensor.py
+++ b/custom_components/googlefindmy/binary_sensor.py
@@ -1,3 +1,4 @@
+# custom_components/googlefindmy/binary_sensor.py
 """Binary sensor entities for Google Find My Device integration."""
 from __future__ import annotations
 
@@ -13,6 +14,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers import device_registry as dr  # Needed for DeviceEntryType
 
 from .const import DOMAIN, INTEGRATION_VERSION
 from .coordinator import GoogleFindMyCoordinator

--- a/custom_components/googlefindmy/button.py
+++ b/custom_components/googlefindmy/button.py
@@ -141,6 +141,7 @@ class GoogleFindMyPlaySoundButton(CoordinatorEntity, ButtonEntity):
 
     # Best practice: let HA compose "<Device Name> <translated entity name>"
     _attr_has_entity_name = True
+    _attr_entity_registry_enabled_default = False
     _attr_should_poll = False
     entity_description = PLAY_SOUND_DESCRIPTION
 
@@ -303,6 +304,7 @@ class GoogleFindMyStopSoundButton(CoordinatorEntity, ButtonEntity):
     """Button to trigger 'Stop Sound' on a Google Find My Device."""
 
     _attr_has_entity_name = True
+    _attr_entity_registry_enabled_default = False
     _attr_should_poll = False
     entity_description = STOP_SOUND_DESCRIPTION
 
@@ -460,6 +462,7 @@ class GoogleFindMyLocateButton(CoordinatorEntity, ButtonEntity):
     """Button to trigger an immediate 'Locate now' request (manual location update)."""
 
     _attr_has_entity_name = True
+    _attr_entity_registry_enabled_default = False
     _attr_should_poll = False
     entity_description = LOCATE_DEVICE_DESCRIPTION
 

--- a/custom_components/googlefindmy/button.py
+++ b/custom_components/googlefindmy/button.py
@@ -1,9 +1,21 @@
 # custom_components/googlefindmy/button.py
 """Button platform for Google Find My Device.
 
-Changes:
-- Availability now also reflects device presence from the coordinator (absent -> unavailable).
-- DeviceInfo no longer writes placeholder names into the registry; only real labels are used.
+This module exposes per-device buttons that trigger actions on Google Find My
+devices via the integration coordinator:
+
+- **Play Sound**: request the device to play a sound.
+- **Stop Sound**: request the device to stop a playing sound.
+- **Locate now**: trigger an immediate manual locate through the integration's
+  service call.
+
+Quality & design notes (HA Platinum guidelines)
+-----------------------------------------------
+* Async-first: no blocking calls on the event loop.
+* Availability mirrors device presence and capability gates from the coordinator.
+* Device registry naming respects user overrides; we never write placeholders.
+* Entity names are composed by Home Assistant using `has_entity_name=True`;
+  translations are provided via `translation_key`.
 """
 from __future__ import annotations
 
@@ -32,6 +44,13 @@ PLAY_SOUND_DESCRIPTION = ButtonEntityDescription(
     key="play_sound",
     translation_key="play_sound",
     icon="mdi:volume-high",
+)
+
+# New entity description for stopping a sound manually
+STOP_SOUND_DESCRIPTION = ButtonEntityDescription(
+    key="stop_sound",
+    translation_key="stop_sound",
+    icon="mdi:volume-off",
 )
 
 # New entity description for the manual "Locate now" action
@@ -88,6 +107,7 @@ async def async_setup_entry(
         name = device.get("name")
         if dev_id and name and dev_id not in known_ids:
             entities.append(GoogleFindMyPlaySoundButton(coordinator, device))
+            entities.append(GoogleFindMyStopSoundButton(coordinator, device))  # NEW
             entities.append(GoogleFindMyLocateButton(coordinator, device))
             known_ids.add(dev_id)
 
@@ -104,6 +124,7 @@ async def async_setup_entry(
             name = device.get("name")
             if dev_id and name and dev_id not in known_ids:
                 new_entities.append(GoogleFindMyPlaySoundButton(coordinator, device))
+                new_entities.append(GoogleFindMyStopSoundButton(coordinator, device))  # NEW
                 new_entities.append(GoogleFindMyLocateButton(coordinator, device))
                 known_ids.add(dev_id)
 
@@ -141,7 +162,7 @@ class GoogleFindMyPlaySoundButton(CoordinatorEntity, ButtonEntity):
         """
         dev_id = self._device["id"]
         try:
-            # Presence gate (new)
+            # Presence gate
             if hasattr(self.coordinator, "is_device_present") and not self.coordinator.is_device_present(dev_id):
                 return False
             # Capability / push readiness gate (existing)
@@ -221,7 +242,7 @@ class GoogleFindMyPlaySoundButton(CoordinatorEntity, ButtonEntity):
             manufacturer="Google",
             model="Find My Device",
             configuration_url=f"{base_url}{path}",
-            serial_number=self._device["id"],  # technical id in the proper field
+            serial_number=self._device["id"],
             **info_kwargs,
         )
 
@@ -238,7 +259,6 @@ class GoogleFindMyPlaySoundButton(CoordinatorEntity, ButtonEntity):
         if config_entry:
             # Helper defined in __init__.py for options-first reading
             from . import _opt
-
             token_expiration_enabled = _opt(
                 config_entry, "map_view_token_expiration", DEFAULT_MAP_VIEW_TOKEN_EXPIRATION
             )
@@ -274,12 +294,166 @@ class GoogleFindMyPlaySoundButton(CoordinatorEntity, ButtonEntity):
             if result:
                 _LOGGER.info("Successfully submitted Play Sound request for %s", device_name)
             else:
-                _LOGGER.warning(
-                    "Failed to play sound on %s (request may have been rejected)",
-                    device_name,
-                )
-        except Exception as err:  # Avoid crashing the update loop
+                _LOGGER.warning("Failed to play sound on %s (request may have been rejected)", device_name)
+        except Exception as err: # Avoid crashing the update loop
             _LOGGER.error("Error playing sound on %s: %s", device_name, err)
+
+
+class GoogleFindMyStopSoundButton(CoordinatorEntity, ButtonEntity):
+    """Button to trigger 'Stop Sound' on a Google Find My Device."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    entity_description = STOP_SOUND_DESCRIPTION
+
+    def __init__(self, coordinator: GoogleFindMyCoordinator, device: dict[str, Any]) -> None:
+        """Initialize the stop-sound button."""
+        super().__init__(coordinator)
+        self._device = device
+        dev_id = device["id"]
+        self._attr_unique_id = f"{DOMAIN}_{dev_id}_stop_sound"
+
+    @property
+    def available(self) -> bool:
+        """Return True if the device is present; do not couple to Play gating.
+
+        Rationale:
+        - The Play button may be intentionally unavailable during in-flight/cooldown.
+        - Stopping must remain possible in that phase.
+        We therefore:
+          1) require presence, and
+          2) prefer a dedicated `can_stop_sound()` if provided by the coordinator,
+             otherwise assume stopping is allowed when the device is present.
+        """
+        dev_id = self._device["id"]
+        try:
+            if hasattr(self.coordinator, "is_device_present") and not self.coordinator.is_device_present(dev_id):
+                return False
+            can_stop = getattr(self.coordinator, "can_stop_sound", None)
+            if callable(can_stop):
+                return bool(can_stop(dev_id))
+            # Do NOT fall back to can_play_sound(): Stop should stay available even if Play is gated.
+            return True
+        except (AttributeError, TypeError) as err:
+            _LOGGER.debug(
+                "StopSound availability check for %s (%s) raised %s; defaulting to True",
+                self._device.get("name", dev_id),
+                dev_id,
+                err,
+            )
+            return True
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """React to coordinator updates (availability and device name may change)."""
+        try:
+            data = getattr(self.coordinator, "data", None) or []
+            my_id = self._device["id"]
+            for dev in data:
+                if dev.get("id") == my_id:
+                    new_name = dev.get("name")
+                    if (
+                        new_name
+                        and new_name != "Google Find My Device"
+                        and new_name != self._device.get("name")
+                    ):
+                        old = self._device.get("name")
+                        self._device["name"] = new_name
+                        _maybe_update_device_registry_name(self.hass, self.entity_id, new_name)
+                        _LOGGER.debug(
+                            "StopSound button device label refreshed for %s: '%s' -> '%s'",
+                            my_id,
+                            old,
+                            new_name,
+                        )
+                    break
+        except (AttributeError, TypeError):
+            pass
+
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return DeviceInfo identical to Play Sound for consistent grouping."""
+        try:
+            base_url = get_url(
+                self.hass,
+                prefer_external=True,
+                allow_cloud=True,
+                allow_external=True,
+                allow_internal=True,
+            )
+        except HomeAssistantError:
+            base_url = "http://homeassistant.local:8123"
+
+        auth_token = self._get_map_token()
+        path = self._build_map_path(self._device["id"], auth_token, redirect=False)
+
+        raw_name = (self._device.get("name") or "").strip()
+        use_name = raw_name if raw_name and raw_name != "Google Find My Device" else None
+
+        info_kwargs: dict[str, Any] = {}
+        if use_name:
+            info_kwargs["name"] = use_name
+
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._device["id"])},
+            manufacturer="Google",
+            model="Find My Device",
+            configuration_url=f"{base_url}{path}",
+            serial_number=self._device["id"],
+            **info_kwargs,
+        )
+
+    @staticmethod
+    def _build_map_path(device_id: str, token: str, *, redirect: bool = False) -> str:
+        """Return the map URL *path* (no scheme/host)."""
+        if redirect:
+            return f"/api/googlefindmy/redirect_map/{device_id}?token={token}"
+        return f"/api/googlefindmy/map/{device_id}?token={token}"
+
+    def _get_map_token(self) -> str:
+        """Generate a simple map token (options-first; weekly/static)."""
+        config_entry = getattr(self.coordinator, "config_entry", None)
+        if config_entry:
+            from . import _opt
+            token_expiration_enabled = _opt(
+                config_entry, "map_view_token_expiration", DEFAULT_MAP_VIEW_TOKEN_EXPIRATION
+            )
+        else:
+            token_expiration_enabled = DEFAULT_MAP_VIEW_TOKEN_EXPIRATION
+
+        ha_uuid = str(self.hass.data.get("core.uuid", "ha"))
+        if token_expiration_enabled:
+            week = str(int(time.time() // 604800))  # 7-day bucket
+            token_src = f"{ha_uuid}:{week}"
+        else:
+            token_src = f"{ha_uuid}:static"
+
+        return hashlib.md5(token_src.encode()).hexdigest()[:16]
+
+    async def async_press(self) -> None:
+        """Handle the button press (stop sound)."""
+        device_id = self._device["id"]
+        device_name = self._device.get("name", device_id)
+
+        if not self.available:
+            _LOGGER.warning(
+                "Stop Sound not available for %s (%s) — device absent or not eligible",
+                device_name,
+                device_id,
+            )
+            return
+
+        _LOGGER.debug("Stop Sound: attempting on %s (%s)", device_name, device_id)
+        try:
+            result = await self.coordinator.async_stop_sound(device_id)
+            if result:
+                _LOGGER.info("Successfully submitted Stop Sound request for %s", device_name)
+            else:
+                _LOGGER.warning("Failed to stop sound on %s (request may have been rejected)", device_name)
+        except Exception as err:
+            _LOGGER.error("Error stopping sound on %s: %s", device_name, err)
 
 
 class GoogleFindMyLocateButton(CoordinatorEntity, ButtonEntity):
@@ -397,7 +571,6 @@ class GoogleFindMyLocateButton(CoordinatorEntity, ButtonEntity):
         config_entry = getattr(self.coordinator, "config_entry", None)
         if config_entry:
             from . import _opt  # lazy import to avoid HA startup overhead
-
             token_expiration_enabled = _opt(
                 config_entry, "map_view_token_expiration", DEFAULT_MAP_VIEW_TOKEN_EXPIRATION
             )

--- a/custom_components/googlefindmy/config_flow.py
+++ b/custom_components/googlefindmy/config_flow.py
@@ -81,13 +81,16 @@ _EMAIL_RE = re.compile(
 # Allow JWT-like tokens and URL-safe/base64 variants; reject whitespace; min length.
 _TOKEN_RE = re.compile(r"^[A-Za-z0-9\-._~+/=]{24,}$")
 
+
 def _email_valid(value: str) -> bool:
     """Return True if value looks like a real email address."""
     return bool(_EMAIL_RE.match(value or ""))
 
+
 def _token_plausible(value: str) -> bool:
     """Return True if value looks like an OAuth/JWT-ish token (no spaces, long enough)."""
     return bool(_TOKEN_RE.match(value or ""))
+
 
 # ---------------------------
 # Auth method list
@@ -202,9 +205,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # Use multiline text input for secrets.json to improve UX
         schema = STEP_SECRETS_DATA_SCHEMA
         if selector is not None:
-            schema = vol.Schema({
-                vol.Required("secrets_json"): selector({"text": {"multiline": True}})
-            })
+            schema = vol.Schema(
+                {vol.Required("secrets_json"): selector({"text": {"multiline": True}})}
+            )
 
         if user_input is not None:
             raw = (user_input.get("secrets_json") or "").strip()
@@ -221,7 +224,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     email = _extract_email_from_secrets(secrets_data) or ""
                     oauth = _extract_oauth_from_secrets(secrets_data) or ""
                     if not (_email_valid(email) and _token_plausible(oauth)):
-                        _LOGGER.debug("secrets.json validation failed; email/token not plausible")
+                        _LOGGER.debug(
+                            "secrets.json validation failed; email/token not plausible"
+                        )
                         errors["base"] = "invalid_token"
                     else:
                         # Store only minimal credentials transiently for next step
@@ -237,9 +242,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="secrets_json",
             data_schema=schema,
             errors=errors,
-            description_placeholders={
-                "hint": "Please paste the full file contents; both email and OAuth token must be present.",
-            },
         )
 
     # ---------- Manual tokens path ----------
@@ -267,9 +269,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="individual_tokens",
             data_schema=STEP_INDIVIDUAL_DATA_SCHEMA,
             errors=errors,
-            description_placeholders={
-                "hint": "Provide both fields. This method should be used if the secrets.json method fails.",
-            },
         )
 
     # ---------- Shared helper to create API from stored auth_data ----------
@@ -315,7 +314,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         # If we could not fetch anything, show a form with just the error.
         if errors:
-            return self.async_show_form(step_id="device_selection", data_schema=vol.Schema({}), errors=errors)
+            return self.async_show_form(
+                step_id="device_selection", data_schema=vol.Schema({}), errors=errors
+            )
 
         # Build a multi-select; keep cv.multi_select for wide compatibility
         options_map = {dev_id: dev_name for (dev_name, dev_id) in self._available_devices}
@@ -324,15 +325,15 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Optional(OPT_TRACKED_DEVICES, default=list(options_map.keys())): vol.All(
                     cv.multi_select(options_map), vol.Length(min=1)
                 ),
-                vol.Optional(OPT_LOCATION_POLL_INTERVAL, default=DEFAULT_LOCATION_POLL_INTERVAL): vol.All(
-                    vol.Coerce(int), vol.Range(min=60, max=3600)
-                ),
+                vol.Optional(
+                    OPT_LOCATION_POLL_INTERVAL, default=DEFAULT_LOCATION_POLL_INTERVAL
+                ): vol.All(vol.Coerce(int), vol.Range(min=60, max=3600)),
                 vol.Optional(OPT_DEVICE_POLL_DELAY, default=DEFAULT_DEVICE_POLL_DELAY): vol.All(
                     vol.Coerce(int), vol.Range(min=1, max=60)
                 ),
-                vol.Optional(OPT_MIN_ACCURACY_THRESHOLD, default=DEFAULT_MIN_ACCURACY_THRESHOLD): vol.All(
-                    vol.Coerce(int), vol.Range(min=25, max=500)
-                ),
+                vol.Optional(
+                    OPT_MIN_ACCURACY_THRESHOLD, default=DEFAULT_MIN_ACCURACY_THRESHOLD
+                ): vol.All(vol.Coerce(int), vol.Range(min=25, max=500)),
                 vol.Optional(OPT_MOVEMENT_THRESHOLD, default=DEFAULT_MOVEMENT_THRESHOLD): vol.All(
                     vol.Coerce(int), vol.Range(min=10, max=200)
                 ),
@@ -481,9 +482,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="reauth_confirm",
             data_schema=schema,
             errors=errors,
-            description_placeholders={
-                "reason": "Your credentials are invalid or expired. Please provide new ones using exactly one method.",
-            },
         )
 
 
@@ -782,9 +780,6 @@ class OptionsFlowHandler(config_entries.OptionsFlowWithReload):
             step_id="credentials",
             data_schema=schema,
             errors=errors,
-            description_placeholders={
-                "hint": "Provide exactly one method to update your credentials.",
-            },
         )
 
 

--- a/custom_components/googlefindmy/config_flow.py
+++ b/custom_components/googlefindmy/config_flow.py
@@ -763,7 +763,7 @@ class OptionsFlowHandler(config_entries.OptionsFlowWithReload):
 
             if new_options != entry.options:
                 self.hass.config_entries.async_update_entry(entry, options=new_options)
-            return self.async_abort(reason="visibility_restored")
+            return self.async_abort(reason="reconfigure_successful")
 
         return self.async_show_form(step_id="visibility", data_schema=schema)
 

--- a/custom_components/googlefindmy/config_flow.py
+++ b/custom_components/googlefindmy/config_flow.py
@@ -761,9 +761,8 @@ class OptionsFlowHandler(config_entries.OptionsFlowWithReload):
             new_options[OPT_IGNORED_DEVICES] = ignored_map
             new_options[OPT_OPTIONS_SCHEMA_VERSION] = 2
 
-            if new_options != entry.options:
-                self.hass.config_entries.async_update_entry(entry, options=new_options)
-            return self.async_abort(reason="reconfigure_successful")
+            # Trigger automatic reload via OptionsFlowWithReload by returning a create_entry result.
+            return self.async_create_entry(title="", data=new_options)
 
         return self.async_show_form(step_id="visibility", data_schema=schema)
 

--- a/custom_components/googlefindmy/config_flow.py
+++ b/custom_components/googlefindmy/config_flow.py
@@ -15,6 +15,11 @@ Invariants (why this looks the way it does):
   logging secrets.
 - For `secrets.json`, we support multiple token sources and **fail over**:
   prefer `aas_token`, then `fcm_credentials.installation.token`, then legacy keys.
+
+Change (Step 1): Remove legacy `tracked_devices` UI from both the initial setup
+and the options flow, without altering authentication behaviour or the online
+connection test. Device inclusion/exclusion will be handled by native HA device
+enable/disable in later steps.
 """
 from __future__ import annotations
 
@@ -50,7 +55,7 @@ from .const import (
     DATA_SECRET_BUNDLE,  # kept for compatibility in translations; not stored anymore
     DATA_AUTH_METHOD,
     # Options (user-changeable)
-    OPT_TRACKED_DEVICES,
+    # OPT_TRACKED_DEVICES,  # (removed from UI in Step 1; left import commented for clarity)
     OPT_LOCATION_POLL_INTERVAL,
     OPT_DEVICE_POLL_DELAY,
     OPT_MIN_ACCURACY_THRESHOLD,
@@ -414,9 +419,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         api = GoogleFindMyAPI(oauth_token=oauth, google_email=email)
         return api, email
 
-    # ---------- Device selection ----------
+    # ---------- Device selection (now: connection test + non-secret settings) ----------
     async def async_step_device_selection(self, user_input: dict[str, Any] | None = None) -> FlowResult:
-        """Select tracked devices and set poll intervals (initial create)."""
+        """Finalize initial setup.
+
+        Step 1 change: This form no longer contains the `tracked_devices` multi-select.
+        We keep the **online validation** (device list fetch) and the remaining options.
+        """
         errors: Dict[str, str] = {}
 
         # Ensure unique_id per Google account to avoid duplicate entries
@@ -425,7 +434,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(f"{DOMAIN}:{email_for_uid}")
             self._abort_if_unique_id_configured()
 
-        # Populate device choices once (also serves as online validation)
+        # Online validation: fetch devices once (fail → cannot_connect)
         if not self._available_devices:
             try:
                 api, username = await self._async_build_api_and_username()
@@ -433,22 +442,19 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 if not devices:
                     errors["base"] = "no_devices"
                 else:
-                    # store as (name, id)
+                    # store as (name, id) for potential future use (kept for parity)
                     self._available_devices = [(d["name"], d["id"]) for d in devices]
             except Exception as err:  # noqa: BLE001 - API/transport errors
                 _LOGGER.error("Failed to fetch devices during setup: %s", err)
                 errors["base"] = "cannot_connect"
 
         if errors:
+            # Keep the step to show an error, but with an empty schema.
             return self.async_show_form(step_id="device_selection", data_schema=vol.Schema({}), errors=errors)
 
-        # Build a multi-select; keep cv.multi_select for wide compatibility
-        options_map = {dev_id: dev_name for (dev_name, dev_id) in self._available_devices}
+        # Schema **without** OPT_TRACKED_DEVICES (removed in Step 1)
         schema = vol.Schema(
             {
-                vol.Optional(OPT_TRACKED_DEVICES, default=list(options_map.keys())): vol.All(
-                    cv.multi_select(options_map), vol.Length(min=1)
-                ),
                 vol.Optional(OPT_LOCATION_POLL_INTERVAL, default=DEFAULT_LOCATION_POLL_INTERVAL): vol.All(
                     vol.Coerce(int), vol.Range(min=60, max=3600)
                 ),
@@ -476,9 +482,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_GOOGLE_EMAIL: self._auth_data.get(CONF_GOOGLE_EMAIL),
             }
 
-            # Options
+            # Options (no OPT_TRACKED_DEVICES anymore)
             options_payload: Dict[str, Any] = {
-                OPT_TRACKED_DEVICES: user_input.get(OPT_TRACKED_DEVICES, []),
                 OPT_LOCATION_POLL_INTERVAL: user_input.get(
                     OPT_LOCATION_POLL_INTERVAL, DEFAULT_LOCATION_POLL_INTERVAL
                 ),
@@ -584,11 +589,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 class OptionsFlowHandler(config_entries.OptionsFlowWithReload):
     """Options flow to update non-secret settings and optionally refresh credentials.
 
-    NOTE: Home Assistant injects the config entry automatically.
-    Do NOT set self.config_entry manually.
+    NOTE: Step 1 change: `tracked_devices` has been removed from the Settings UI.
+    Home Assistant's native device enable/disable will control tracking going forward.
     """
-
-    # no __init__: HA provides self.config_entry
 
     # ---------- Menu entry ----------
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> FlowResult:
@@ -646,15 +649,14 @@ class OptionsFlowHandler(config_entries.OptionsFlowWithReload):
 
     # ---------- Settings (non-secret) ----------
     async def async_step_settings(self, user_input: dict[str, Any] | None = None) -> FlowResult:
-        """Update non-secret options."""
+        """Update non-secret options (without `tracked_devices`)."""
         errors: Dict[str, str] = {}
 
         entry = self.config_entry
         opt = entry.options
         dat = entry.data
 
-        # Current values with safe fallbacks
-        current_tracked = opt.get(OPT_TRACKED_DEVICES, dat.get(OPT_TRACKED_DEVICES, []))
+        # Current values with safe fallbacks (tracked_devices removed in Step 1)
         current_interval = opt.get(
             OPT_LOCATION_POLL_INTERVAL,
             dat.get(OPT_LOCATION_POLL_INTERVAL, DEFAULT_LOCATION_POLL_INTERVAL),
@@ -679,26 +681,9 @@ class OptionsFlowHandler(config_entries.OptionsFlowWithReload):
             dat.get(OPT_MAP_VIEW_TOKEN_EXPIRATION, DEFAULT_MAP_VIEW_TOKEN_EXPIRATION),
         )
 
-        # Build device options (robust against temporary API failures)
-        device_options: Dict[str, str] = {}
-        try:
-            api = await self._async_build_api_from_entry(entry)
-            devices = await api.async_get_basic_device_list(entry.data.get(CONF_GOOGLE_EMAIL))
-            device_options = {dev["id"]: dev["name"] for dev in devices}
-        except Exception as err:  # noqa: BLE001 - keep options usable
-            _LOGGER.warning(
-                "Could not fetch a fresh device list for options; using existing tracked devices as fallback. Error: %s",
-                err,
-            )
-
-        # Ensure already-tracked IDs remain valid choices even if fetch failed
-        for dev_id in current_tracked or []:
-            device_options.setdefault(dev_id, dev_id)
-
-        # Base schema without defaults; suggested values will be injected
+        # Base schema *without* tracked_devices
         base_schema = vol.Schema(
             {
-                vol.Optional(OPT_TRACKED_DEVICES): vol.All(cv.multi_select(device_options), vol.Length(min=0)),
                 vol.Optional(OPT_LOCATION_POLL_INTERVAL): vol.All(vol.Coerce(int), vol.Range(min=60, max=3600)),
                 vol.Optional(OPT_DEVICE_POLL_DELAY): vol.All(vol.Coerce(int), vol.Range(min=1, max=60)),
                 vol.Optional(OPT_MIN_ACCURACY_THRESHOLD): vol.All(vol.Coerce(int), vol.Range(min=25, max=500)),
@@ -712,7 +697,6 @@ class OptionsFlowHandler(config_entries.OptionsFlowWithReload):
 
         if user_input is not None:
             new_options = {
-                OPT_TRACKED_DEVICES: user_input.get(OPT_TRACKED_DEVICES, current_tracked),
                 OPT_LOCATION_POLL_INTERVAL: user_input.get(OPT_LOCATION_POLL_INTERVAL, current_interval),
                 OPT_DEVICE_POLL_DELAY: user_input.get(OPT_DEVICE_POLL_DELAY, current_delay),
                 OPT_MIN_ACCURACY_THRESHOLD: user_input.get(OPT_MIN_ACCURACY_THRESHOLD, current_min_acc),
@@ -727,7 +711,6 @@ class OptionsFlowHandler(config_entries.OptionsFlowWithReload):
             return self.async_create_entry(title="", data=new_options)
 
         suggested_values = {
-            OPT_TRACKED_DEVICES: current_tracked,
             OPT_LOCATION_POLL_INTERVAL: current_interval,
             OPT_DEVICE_POLL_DELAY: current_delay,
             OPT_MIN_ACCURACY_THRESHOLD: current_min_acc,

--- a/custom_components/googlefindmy/config_flow.py
+++ b/custom_components/googlefindmy/config_flow.py
@@ -317,8 +317,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(config_entry: ConfigEntry) -> config_entries.OptionsFlow:
-        """Create the options flow."""
-        return OptionsFlowHandler(config_entry)
+        """Create the options flow (HA injects the config entry automatically)."""
+        return OptionsFlowHandler()
 
     # ---------- User entry point ----------
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
@@ -582,11 +582,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 
 class OptionsFlowHandler(config_entries.OptionsFlowWithReload):
-    """Options flow to update non-secret settings and optionally refresh credentials."""
+    """Options flow to update non-secret settings and optionally refresh credentials.
 
-    def __init__(self, config_entry: ConfigEntry) -> None:
-        """Store the config entry (OptionsFlowWithReload does not require super init)."""
-        self.config_entry = config_entry
+    NOTE: Home Assistant injects the config entry automatically.
+    Do NOT set self.config_entry manually.
+    """
+
+    # no __init__: HA provides self.config_entry
 
     # ---------- Menu entry ----------
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> FlowResult:

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -35,10 +35,12 @@ OPT_ENABLE_STATS_ENTITIES: str = "enable_stats_entities"
 OPT_GOOGLE_HOME_FILTER_ENABLED: str = "google_home_filter_enabled"
 OPT_GOOGLE_HOME_FILTER_KEYWORDS: str = "google_home_filter_keywords"
 OPT_MAP_VIEW_TOKEN_EXPIRATION: str = "map_view_token_expiration"
+OPT_IGNORED_DEVICES: str = "ignored_devices"
 
 # Canonical list of option keys supported by the integration
 OPTION_KEYS: tuple[str, ...] = (
     OPT_TRACKED_DEVICES,
+    OPT_IGNORED_DEVICES,
     OPT_LOCATION_POLL_INTERVAL,
     OPT_DEVICE_POLL_DELAY,
     OPT_MIN_POLL_INTERVAL,
@@ -88,6 +90,7 @@ DEFAULT_MAP_VIEW_TOKEN_EXPIRATION: bool = False
 # Aggregate defaults dictionary for option-first reading patterns
 DEFAULT_OPTIONS: dict[str, object] = {
     OPT_TRACKED_DEVICES: [],
+    OPT_IGNORED_DEVICES: [],
     OPT_LOCATION_POLL_INTERVAL: DEFAULT_LOCATION_POLL_INTERVAL,
     OPT_DEVICE_POLL_DELAY: DEFAULT_DEVICE_POLL_DELAY,
     OPT_MIN_POLL_INTERVAL: DEFAULT_MIN_POLL_INTERVAL,
@@ -160,6 +163,7 @@ __all__ = [
     "DATA_SECRET_BUNDLE",
     "DATA_AUTH_METHOD",
     "OPT_TRACKED_DEVICES",
+    "OPT_IGNORED_DEVICES",
     "OPT_LOCATION_POLL_INTERVAL",
     "OPT_DEVICE_POLL_DELAY",
     "OPT_MIN_POLL_INTERVAL",

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -1,4 +1,4 @@
-# /custom_components/googlefindmy/const.py
+# custom_components/googlefindmy/const.py
 """Constants for Google Find My Device integration.
 
 All constants defined here are intended to be import-safe across the integration.
@@ -24,7 +24,7 @@ DATA_SECRET_BUNDLE: str = "secrets_data"       # full GoogleFindMyTools secrets.
 DATA_AUTH_METHOD: str = "auth_method"          # "secrets_json" | "individual_tokens"
 
 # Options (user-changeable): stored in config_entry.options
-OPT_TRACKED_DEVICES: str = "tracked_devices"
+# (tracked_devices removed in Step 2; device inclusion is managed via HA device enable/disable)
 OPT_LOCATION_POLL_INTERVAL: str = "location_poll_interval"
 OPT_DEVICE_POLL_DELAY: str = "device_poll_delay"
 OPT_MIN_POLL_INTERVAL: str = "min_poll_interval"
@@ -37,9 +37,8 @@ OPT_GOOGLE_HOME_FILTER_KEYWORDS: str = "google_home_filter_keywords"
 OPT_MAP_VIEW_TOKEN_EXPIRATION: str = "map_view_token_expiration"
 OPT_IGNORED_DEVICES: str = "ignored_devices"
 
-# Canonical list of option keys supported by the integration
+# Canonical list of option keys supported by the integration (without tracked_devices)
 OPTION_KEYS: tuple[str, ...] = (
-    OPT_TRACKED_DEVICES,
     OPT_IGNORED_DEVICES,
     OPT_LOCATION_POLL_INTERVAL,
     OPT_DEVICE_POLL_DELAY,
@@ -89,7 +88,7 @@ DEFAULT_MAP_VIEW_TOKEN_EXPIRATION: bool = False
 
 # Aggregate defaults dictionary for option-first reading patterns
 DEFAULT_OPTIONS: dict[str, object] = {
-    OPT_TRACKED_DEVICES: [],
+    # OPT_IGNORED_DEVICES is intentionally not pre-populated here to avoid bloating storage.
     OPT_IGNORED_DEVICES: [],
     OPT_LOCATION_POLL_INTERVAL: DEFAULT_LOCATION_POLL_INTERVAL,
     OPT_DEVICE_POLL_DELAY: DEFAULT_DEVICE_POLL_DELAY,
@@ -101,6 +100,61 @@ DEFAULT_OPTIONS: dict[str, object] = {
     OPT_GOOGLE_HOME_FILTER_ENABLED: DEFAULT_GOOGLE_HOME_FILTER_ENABLED,
     OPT_GOOGLE_HOME_FILTER_KEYWORDS: DEFAULT_GOOGLE_HOME_FILTER_KEYWORDS,
     OPT_MAP_VIEW_TOKEN_EXPIRATION: DEFAULT_MAP_VIEW_TOKEN_EXPIRATION,
+}
+
+# --------------------------------------------------------------------------------------
+# CONFIG_FIELDS — server-side validation contract for config/options flows
+# --------------------------------------------------------------------------------------
+# Used by config_flow.py to apply strong validators (type/min/max/step) for known keys.
+# Keep keys in sync with OPTION_KEYS and default ranges used in schemas.
+CONFIG_FIELDS: dict[str, dict[str, object]] = {
+    OPT_LOCATION_POLL_INTERVAL: {
+        "type": "int",
+        "min": 60,
+        "max": 3600,
+        "step": 1,
+    },
+    OPT_DEVICE_POLL_DELAY: {
+        "type": "int",
+        "min": 1,
+        "max": 60,
+        "step": 1,
+    },
+    OPT_MIN_POLL_INTERVAL: {
+        "type": "int",
+        "min": 30,
+        "max": 3600,
+        "step": 1,
+    },
+    OPT_MIN_ACCURACY_THRESHOLD: {
+        "type": "int",
+        "min": 25,
+        "max": 500,
+        "step": 1,
+    },
+    OPT_MOVEMENT_THRESHOLD: {
+        "type": "int",
+        "min": 10,
+        "max": 200,
+        "step": 1,
+    },
+    OPT_ALLOW_HISTORY_FALLBACK: {
+        "type": "bool",
+    },
+    OPT_ENABLE_STATS_ENTITIES: {
+        "type": "bool",
+    },
+    OPT_GOOGLE_HOME_FILTER_ENABLED: {
+        "type": "bool",
+    },
+    OPT_GOOGLE_HOME_FILTER_KEYWORDS: {
+        "type": "str",
+    },
+    OPT_MAP_VIEW_TOKEN_EXPIRATION: {
+        "type": "bool",
+    },
+    # OPT_IGNORED_DEVICES is intentionally omitted: it is managed by a dedicated
+    # visibility flow and not edited as a raw field (list of ids).
 }
 
 # --------------------------------------------------------------------------------------
@@ -163,7 +217,6 @@ __all__ = [
     "CONF_GOOGLE_EMAIL",
     "DATA_SECRET_BUNDLE",
     "DATA_AUTH_METHOD",
-    "OPT_TRACKED_DEVICES",
     "OPT_IGNORED_DEVICES",
     "OPT_LOCATION_POLL_INTERVAL",
     "OPT_DEVICE_POLL_DELAY",
@@ -191,6 +244,7 @@ __all__ = [
     "GOOGLE_HOME_SPAM_THRESHOLD_MINUTES",
     "DEFAULT_MAP_VIEW_TOKEN_EXPIRATION",
     "DEFAULT_OPTIONS",
+    "CONFIG_FIELDS",
     "SERVICE_LOCATE_DEVICE",
     "SERVICE_PLAY_SOUND",
     "SERVICE_STOP_SOUND",

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 # Core identifiers
 # --------------------------------------------------------------------------------------
 DOMAIN: str = "googlefindmy"
-INTEGRATION_VERSION: str = "1.5.6-1"
+INTEGRATION_VERSION: str = "1.6"
 
 # --------------------------------------------------------------------------------------
 # Configuration keys (data vs. options separation)

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -108,6 +108,7 @@ DEFAULT_OPTIONS: dict[str, object] = {
 # --------------------------------------------------------------------------------------
 SERVICE_LOCATE_DEVICE: str = "locate_device"
 SERVICE_PLAY_SOUND: str = "play_sound"
+SERVICE_STOP_SOUND: str = "stop_sound"
 SERVICE_LOCATE_EXTERNAL: str = "locate_device_external"
 
 SERVICE_REFRESH_DEVICE_URLS: str = "refresh_device_urls"
@@ -192,6 +193,7 @@ __all__ = [
     "DEFAULT_OPTIONS",
     "SERVICE_LOCATE_DEVICE",
     "SERVICE_PLAY_SOUND",
+    "SERVICE_STOP_SOUND",
     "SERVICE_LOCATE_EXTERNAL",
     "SERVICE_REFRESH_DEVICE_URLS",
     "SERVICE_REFRESH_URLS",

--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -1265,3 +1265,31 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[List[Dict[str, Any]]]):
             )
             self._note_push_transport_problem()
             return False
+
+    async def async_stop_sound(self, device_id: str) -> bool:
+        """Stop sound on a device using the native async API (no executor).
+
+        Args:
+            device_id: The canonical ID of the device.
+
+        Returns:
+            True if the command was submitted successfully, False otherwise.
+        """
+        # Less strict than can_play_sound(): stopping is harmless but still requires push readiness.
+        if not self._api_push_ready():
+            _LOGGER.debug(
+                "Suppressing stop_sound call for %s: push not ready",
+                device_id,
+            )
+            return False
+        try:
+            ok = await self.api.async_stop_sound(device_id)
+            if not ok:
+                self._note_push_transport_problem()
+            return bool(ok)
+        except Exception as err:
+            _LOGGER.debug(
+                "async_stop_sound raised for %s: %s; entering cooldown", device_id, err
+            )
+            self._note_push_transport_problem()
+            return False

--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -739,9 +739,6 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[List[Dict[str, Any]]]):
                     self._clear_fcm_deferral()
 
             self._is_polling = True
-            # Push a snapshot from cache to signal "polling" state to listeners
-            start_snapshot = self._build_snapshot_from_cache(devices, wall_now=time.time())
-            self.async_set_updated_data(start_snapshot)
             _LOGGER.info("Starting sequential poll of %d devices", len(devices))
 
             try:

--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -897,7 +897,7 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[List[Dict[str, Any]]]):
             _LOGGER.warning(
                 "Tried to increment unknown stat '%s'; available=%s",
                 stat_name,
-                list(self.stats.keys() ),
+                list(self.stats.keys()),
             )
 
     def increment_stat(self, stat_name: str) -> None:

--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -1221,7 +1221,8 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[List[Dict[str, Any]]]):
                     )
                     return
             except (TypeError, ValueError):
-                # If timestamps are malformed, we cannot compare; let significance gate handle it.
+                # If timestamps are malformed, comparison is not possible.
+                # The update will proceed to the significance gate, which will handle it.
                 pass
 
         # Shallow copy to avoid caller-side mutation
@@ -1301,7 +1302,7 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[List[Dict[str, Any]]]):
             if n_seen is not None and e_seen is not None and float(n_seen) > float(e_seen):
                 return True
         except Exception:
-            # If timestamps are non-numeric, fall through to other checks.
+            # If timestamps are malformed, comparison is not possible; fall through.
             pass
 
         # Same timestamp? Check for spatial delta and accuracy improvement.

--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -109,7 +109,7 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[List[Dict[str, Any]]]):
         tracked_devices: Optional[List[str]] = None,
         location_poll_interval: int = 300,
         device_poll_delay: int = 5,
-        min_poll_interval: int = 1,
+        min_poll_interval: int = DEFAULT_MIN_POLL_INTERVAL,
         min_accuracy_threshold: int = 100,
         allow_history_fallback: bool = False,
     ) -> None:
@@ -255,9 +255,9 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[List[Dict[str, Any]]]):
             all_devices = all_devices or []
             ignored = self._get_ignored_set()
 
-            # Record presence from the full list (ignore-filter applied).
+            # Record presence from the full list (unfiltered by ignore for accuracy).
             self._present_device_ids = {
-                d["id"] for d in all_devices if isinstance(d.get("id"), str) and d["id"] not in ignored
+                d["id"] for d in all_devices if isinstance(d.get("id"), str)
             }
 
             # 2) Update internal name/capability caches for ALL devices
@@ -1245,3 +1245,4 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[List[Dict[str, Any]]]):
             )
             self._note_push_transport_problem()
             return False
+

--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -997,14 +997,6 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[List[Dict[str, Any]]]):
             self.safe_update_metric("last_poll_start_mono", time.monotonic())
             _LOGGER.debug("Starting sequential poll of %d devices", len(devices))
 
-            # Push an immediate "baseline" snapshot so UI reflects that a poll cycle began.
-            try:
-                start_snapshot = self._build_snapshot_from_cache(devices, wall_now=time.time())
-                self.async_set_updated_data(start_snapshot)
-            except Exception:
-                # Non-fatal; continue polling.
-                pass
-
             try:
                 for idx, dev in enumerate(devices):
                     dev_id = dev["id"]

--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -458,7 +458,7 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[List[Dict[str, Any]]]):
         """Handle Device Registry changes by rebuilding poll targets (rare)."""
         self._reindex_poll_targets_from_device_registry()
         # After changes, request a refresh so the next tick uses the new target sets.
-        self.async_request_refresh()
+        async self.async_request_refresh()
 
     # ---------------------------- Cooldown helpers (server-aware) -----------
     def _compute_type_cooldown_seconds(self, report_hint: Optional[str]) -> int:

--- a/custom_components/googlefindmy/device_tracker.py
+++ b/custom_components/googlefindmy/device_tracker.py
@@ -75,8 +75,6 @@ async def async_setup_entry(
 
     Design:
     - Entities are created from the coordinator snapshot if available.
-    - On cold start, create "skeleton" entities from tracked IDs to enable RestoreEntity,
-      **without** writing any placeholder name to the device registry.
     - Add entities dynamically for devices discovered later.
     """
     coordinator: GoogleFindMyCoordinator = hass.data[DOMAIN][config_entry.entry_id]
@@ -94,24 +92,6 @@ async def async_setup_entry(
                 entities.append(GoogleFindMyDeviceTracker(coordinator, device))
             else:
                 _LOGGER.debug("Skipping device without id/name: %s", device)
-    else:
-        # No live data yet: create skeletons for configured tracked IDs (restore-friendly).
-        tracked_ids: list[str] = getattr(coordinator, "tracked_devices", []) or []
-        for dev_id in tracked_ids:
-            # Do not create skeletons for ignored devices (cold boot case).
-            try:
-                if hasattr(coordinator, "is_ignored") and coordinator.is_ignored(dev_id):
-                    _LOGGER.debug("Skipping ignored device skeleton: %s", dev_id)
-                    continue
-            except Exception:
-                pass
-            known_ids.add(dev_id)
-            entities.append(GoogleFindMyDeviceTracker(coordinator, {"id": dev_id}))
-        if tracked_ids:
-            _LOGGER.debug(
-                "Created %d skeleton device_tracker entities for restore (no live data yet)",
-                len(tracked_ids),
-            )
 
     if entities:
         async_add_entities(entities, True)
@@ -155,6 +135,8 @@ class GoogleFindMyDeviceTracker(CoordinatorEntity, TrackerEntity, RestoreEntity)
     _attr_has_entity_name = False
     _attr_source_type = SourceType.GPS
     _attr_entity_category = None  # ensure tracker is not diagnostic
+    # Default to disabled in the registry (user must enable the device/entities)
+    _attr_entity_registry_enabled_default = False
 
     # ---- Display-name policy (strip legacy prefixes, no new prefixes) ----
     @staticmethod

--- a/custom_components/googlefindmy/device_tracker.py
+++ b/custom_components/googlefindmy/device_tracker.py
@@ -1,3 +1,4 @@
+# custom_components/googlefindmy/device_tracker.py
 """Device tracker platform for Google Find My Device."""
 from __future__ import annotations
 
@@ -97,7 +98,13 @@ async def async_setup_entry(
         # No live data yet: create skeletons for configured tracked IDs (restore-friendly).
         tracked_ids: list[str] = getattr(coordinator, "tracked_devices", []) or []
         for dev_id in tracked_ids:
-            # IMPORTANT: no placeholder name here (avoids polluting the device registry).
+            # Do not create skeletons for ignored devices (cold boot case).
+            try:
+                if hasattr(coordinator, "is_ignored") and coordinator.is_ignored(dev_id):
+                    _LOGGER.debug("Skipping ignored device skeleton: %s", dev_id)
+                    continue
+            except Exception:
+                pass
             known_ids.add(dev_id)
             entities.append(GoogleFindMyDeviceTracker(coordinator, {"id": dev_id}))
         if tracked_ids:

--- a/custom_components/googlefindmy/diagnostics.py
+++ b/custom_components/googlefindmy/diagnostics.py
@@ -1,5 +1,12 @@
 # custom_components/googlefindmy/diagnostics.py
-"""Diagnostics for the Google Find My Device integration."""
+"""Diagnostics for the Google Find My Device integration.
+
+Design goals (HA quality scale / Platinum-ready):
+- Never leak secrets or personal data (tokens, emails, device IDs, coordinates, names).
+- Provide enough structured, anonymized context to debug typical issues (polling, counts, timings).
+- Prefer runtime_data (modern pattern) but gracefully fall back to hass.data for older setups.
+- Keep redaction centralized and defensive (include common token/email keys even if we don't expose them now).
+"""
 from __future__ import annotations
 
 import time
@@ -8,9 +15,13 @@ from typing import Any, Optional
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.loader import async_get_integration
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
 
 from .const import (
     DOMAIN,
+    # user-facing options (non-secret)
     OPT_TRACKED_DEVICES,
     OPT_LOCATION_POLL_INTERVAL,
     OPT_DEVICE_POLL_DELAY,
@@ -20,26 +31,63 @@ from .const import (
     OPT_GOOGLE_HOME_FILTER_KEYWORDS,
     OPT_ENABLE_STATS_ENTITIES,
     OPT_MAP_VIEW_TOKEN_EXPIRATION,
+    OPT_IGNORED_DEVICES,
+    # secrets in entry.data (must never be exposed)
+    CONF_OAUTH_TOKEN,
+    CONF_GOOGLE_EMAIL,
 )
 
-# Nothing to redact in our current summary (we avoid secrets entirely),
-# but keep the hook ready in case we add more fields later.
-TO_REDACT: list[str] = []
+# Keys to redact anywhere they appear in the diagnostics payload.
+# Keep this list generous; it is safe to over-redact.
+TO_REDACT: list[str] = [
+    # Our entry.data keys
+    CONF_OAUTH_TOKEN,
+    CONF_GOOGLE_EMAIL,
+    # Common token/email shapes that *might* appear if future fields are added
+    "aas_token",
+    "access_token",
+    "refresh_token",
+    "token",
+    "security_token",
+    "app_id",
+    "android_id",
+    "fid",
+    "email",
+    "username",
+    "user",
+    "Auth",
+    "secret",
+    "private",
+    "public",
+    "p256dh",
+    "auth",
+    "endpoint",
+]
 
 
 def _monotonic_to_wall_seconds(last_mono: Optional[float]) -> Optional[float]:
-    """Convert a stored monotonic timestamp to wall-clock seconds since epoch.
+    """Convert a stored monotonic timestamp to wall-clock seconds since epoch (UTC).
 
-    NOTE:
-    - Our coordinator currently tracks the last poll baseline in a monotonic clock.
-      For diagnostics (best-effort), we infer the wall time using the current deltas.
-    - If the internal field is absent, we return None gracefully.
+    We infer the wall time using the current monotonic delta; this is best-effort
+    and intentionally avoids reading any precise location timestamps from entities.
     """
     if not isinstance(last_mono, (int, float)) or last_mono <= 0:
         return None
     now_wall = time.time()
     now_mono = time.monotonic()
+    # Clamp at 0 to avoid negative values when clocks drift
     return max(0.0, now_wall - (now_mono - float(last_mono)))
+
+
+def _count_keywords(value: Any) -> int:
+    """Count comma-separated keywords without exposing their content."""
+    if not value:
+        return 0
+    try:
+        parts = [p.strip() for p in str(value).split(",")]
+        return sum(1 for p in parts if p)
+    except Exception:
+        return 0
 
 
 async def async_get_config_entry_diagnostics(
@@ -47,74 +95,104 @@ async def async_get_config_entry_diagnostics(
 ) -> dict[str, Any]:
     """Return anonymized diagnostics for a config entry.
 
-    Best practice:
-    - Never include secrets, location coordinates, device IDs, device names or emails.
-    - Keep output useful for debugging: show options summary, stats, counts, timing.
-    - Prefer entry.runtime_data if present; otherwise fall back to hass.data.
+    Best practices:
+    - Do NOT include: coordinates, device IDs, device names, emails, tokens,
+      unique_id, or any raw content from external services.
+    - DO include: anonymized counters, booleans, timings, and versions.
     """
-    # Prefer runtime_data if the integration adopts it; otherwise fall back.
+    # --- Integration metadata (manifest) ---
+    integration_meta: dict[str, Any] = {}
+    try:
+        integ = await async_get_integration(hass, DOMAIN)
+        # Name and version from manifest; both are safe to expose
+        integration_meta = {
+            "name": integ.name,
+            "version": integ.version,
+        }
+    except Exception:
+        # Stay resilient if loader fails in custom environments
+        integration_meta = {}
+
+    # --- Coordinator / runtime_data (preferred) or hass.data fallback ---
     coordinator = None
     runtime = getattr(entry, "runtime_data", None)
     if runtime:
-        # Allow either a direct coordinator or a simple holder object.
+        # Allow either a direct coordinator or a holder object with attribute "coordinator"
         coordinator = getattr(runtime, "coordinator", runtime)
     if coordinator is None:
         coordinator = hass.data.get(DOMAIN, {}).get(entry.entry_id)
 
-    # Build a compact, anonymized config snapshot from options (no secrets).
+    # --- Build a compact, anonymized options snapshot (no raw strings that could contain PII) ---
     opt = entry.options
+    ignored_list = opt.get(OPT_IGNORED_DEVICES) or entry.data.get(OPT_IGNORED_DEVICES) or []
+    if not isinstance(ignored_list, list):
+        ignored_list = []
     config_summary = {
+        # Durations and numeric thresholds
         "location_poll_interval": int(opt.get(OPT_LOCATION_POLL_INTERVAL, 300)),
         "device_poll_delay": int(opt.get(OPT_DEVICE_POLL_DELAY, 5)),
         "min_accuracy_threshold": int(opt.get(OPT_MIN_ACCURACY_THRESHOLD, 100)),
         "movement_threshold": int(opt.get(OPT_MOVEMENT_THRESHOLD, 50)),
+        # Feature toggles
         "google_home_filter_enabled": bool(opt.get(OPT_GOOGLE_HOME_FILTER_ENABLED, False)),
-        # Do NOT include the actual keywords; only their count to avoid revealing user text
-        "google_home_filter_keywords_count": len(
-            [k.strip() for k in str(opt.get(OPT_GOOGLE_HOME_FILTER_KEYWORDS, "")).split(",") if k.strip()]
-        ),
         "enable_stats_entities": bool(opt.get(OPT_ENABLE_STATS_ENTITIES, True)),
         "map_view_token_expiration": bool(opt.get(OPT_MAP_VIEW_TOKEN_EXPIRATION, True)),
-        # tracked devices: only the count, never IDs
+        # Counts only (never expose strings/IDs)
+        "google_home_filter_keywords_count": _count_keywords(opt.get(OPT_GOOGLE_HOME_FILTER_KEYWORDS)),
         "tracked_devices_count": len(opt.get(OPT_TRACKED_DEVICES, [])),
+        "ignored_devices_count": len(ignored_list),
     }
 
-    payload: dict[str, Any] = {
-        "entry": {
-            # sanitize entry meta; do not include unique_id, data, or title if it could be user-provided PII
-            "entry_id": entry.entry_id,
-            "version": entry.version,
-            "domain": entry.domain,
-        },
-        "config": async_redact_data(config_summary, TO_REDACT),
-    }
+    # --- Device & entity registry counts (anonymized) ---
+    device_registry_counts: dict[str, Any] = {}
+    try:
+        dev_reg = dr.async_get(hass)
+        devices_for_entry = [
+            d for d in dev_reg.devices.values() if entry.entry_id in d.config_entries
+        ]
+        device_registry_counts["devices_count"] = len(devices_for_entry)
+    except Exception:
+        device_registry_counts["devices_count"] = None
 
-    # Enrich with coordinator info if available (all anonymized)
+    entity_registry_counts: dict[str, Any] = {}
+    try:
+        ent_reg = er.async_get(hass)
+        entities_for_entry = [
+            e for e in ent_reg.entities.values() if e.config_entry_id == entry.entry_id
+        ]
+        entity_registry_counts["entities_count"] = len(entities_for_entry)
+    except Exception:
+        entity_registry_counts["entities_count"] = None
+
+    # --- Coordinator-derived info (all anonymized/counted) ---
+    coordinator_block: dict[str, Any] = {}
     if coordinator is not None:
-        # counts – never include names or IDs
+        # Boolean flags and counters only; never expose maps with device IDs/names
         try:
             known_devices_count = len(getattr(coordinator, "_device_names", {}) or {})
         except (AttributeError, TypeError):
             known_devices_count = None
+
         try:
             cache_items_count = len(getattr(coordinator, "_device_location_data", {}) or {})
         except (AttributeError, TypeError):
             cache_items_count = None
 
-        # last successful poll (best-effort using monotonic baseline if present)
-        last_poll_wall = None
         try:
             last_poll_wall = _monotonic_to_wall_seconds(getattr(coordinator, "_last_poll_mono", None))
         except (AttributeError, TypeError):
             last_poll_wall = None
 
-        # stats are already anonymized counters
         try:
             stats = dict(getattr(coordinator, "stats", {}) or {})
+            # Stats should already be anonymized counters; still ensure only ints
+            for k, v in list(stats.items()):
+                if not isinstance(v, (int, float)):
+                    stats[k] = None
         except (AttributeError, TypeError):
             stats = {}
 
-        payload["coordinator"] = {
+        coordinator_block = {
             "is_polling": bool(getattr(coordinator, "_is_polling", False)),
             "known_devices_count": known_devices_count,
             "cache_items_count": cache_items_count,
@@ -122,4 +200,24 @@ async def async_get_config_entry_diagnostics(
             "stats": stats,
         }
 
-    return payload
+    # --- Assemble payload (without secrets) ---
+    payload: dict[str, Any] = {
+        "integration": integration_meta,
+        "entry": {
+            # Safe metadata only; DO NOT include entry.unique_id, entry.title, or entry.data (contains secrets)
+            "entry_id": entry.entry_id,
+            "version": entry.version,  # config-entry schema version (safe)
+            "domain": entry.domain,
+        },
+        "config": config_summary,
+        "registries": {
+            "device": device_registry_counts,
+            "entity": entity_registry_counts,
+        },
+    }
+    if coordinator_block:
+        payload["coordinator"] = coordinator_block
+
+    # --- Final safety net: redact known secret-like keys anywhere in the payload ---
+    # (We already avoided including secrets, but this keeps us safe against future extensions.)
+    return async_redact_data(payload, TO_REDACT)

--- a/custom_components/googlefindmy/google_home_filter.py
+++ b/custom_components/googlefindmy/google_home_filter.py
@@ -1,19 +1,45 @@
-"""Google Home device filtering utilities (options-first, v2.2)."""
+# custom_components/googlefindmy/google_home_filter.py
+"""Google Home semantic-location filter (options-first, v2.2).
+
+This module centralizes heuristics to:
+- suppress noisy "home"-like detections from Google/Nest/Chromecast speakers,
+- optionally substitute obvious Google-Home semantic places with the Home zone,
+- debounce repeated "Home" reports within a time window.
+
+Design goals
+------------
+* **Options-first**: Settings are read from `ConfigEntry.options`, with safe
+  fallback to `entry.data` and constants from `const.py`.
+* **No I/O in hot paths**: All operations are event-loop friendly.
+* **Backward compatible**: Accepts a plain Mapping/dict input for legacy use.
+
+Public API (stable)
+-------------------
+- `GoogleHomeFilter(hass, config_like)`
+- `apply_from_entry(entry)`
+- `update_config(config_or_entry)`
+- `is_google_home_device(location_name) -> bool`
+- `get_home_zone_name() -> str | None`
+- `is_device_at_home(device_id) -> bool`
+- `reset_spam_tracking(device_id) -> None`
+- `should_filter_detection(device_id, location_name) -> tuple[bool, str | None]`
+"""
+
 from __future__ import annotations
 
 import logging
 import time
-from typing import Any, Mapping, Optional, Tuple
+from typing import Any, Mapping
 
-from homeassistant.core import HomeAssistant, State
 from homeassistant.components.zone import DOMAIN as ZONE_DOMAIN
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import entity_registry as er
 
 from .const import (
+    DEFAULT_GOOGLE_HOME_FILTER_KEYWORDS,
     DOMAIN,
     GOOGLE_HOME_SPAM_THRESHOLD_MINUTES,
-    DEFAULT_GOOGLE_HOME_FILTER_KEYWORDS,
     OPT_GOOGLE_HOME_FILTER_ENABLED,
     OPT_GOOGLE_HOME_FILTER_KEYWORDS,
 )
@@ -22,83 +48,135 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class GoogleHomeFilter:
-    """Filter Google Home device detections and prevent 'home' spam events.
+    """Filter Google Home device detections and prevent "home" spam events.
 
-    Design goals:
-    - Options-first: read filter settings from entry.options with a safe fallback.
-    - Backward compatible: accept raw dict config as before.
-    - No I/O or blocking calls inside hot paths.
+    Responsibilities:
+      * Keyword matching for semantic places (e.g., "Nest Hub", "Chromecast").
+      * Debounce logic for frequent "Home" detections.
+      * Optional substitution of such places with the actual Home zone.
+
+    Configuration (options-first):
+      * `OPT_GOOGLE_HOME_FILTER_ENABLED` (bool)
+      * `OPT_GOOGLE_HOME_FILTER_KEYWORDS` (str; comma-separated) — also accepts list
+
+    Notes:
+      * Debounce timing uses `time.monotonic()` (robust against system clock changes).
+      * Entity lookups use the registry shortcut `er.async_get_entity_id(...)`
+        for clarity and performance.
     """
+
+    __slots__ = (
+        "hass",
+        "_enabled",
+        "_keywords",
+        "_spam_tracking",
+        "_spam_threshold",
+    )
 
     def __init__(self, hass: HomeAssistant, config_like: Mapping[str, Any] | ConfigEntry) -> None:
         """Initialize the Google Home filter.
 
         Args:
             hass: Home Assistant instance.
-            config_like: Either a plain dict with keys (legacy) or a ConfigEntry.
+            config_like: Either a `ConfigEntry` (preferred) or a Mapping (legacy).
         """
         self.hass = hass
         self._enabled: bool = True
         self._keywords: list[str] = []
-        # Track last detection timestamps per device_id to debounce spam.
+        # Debounce tracking: device_id -> last_seen_monotonic
         self._spam_tracking: dict[str, float] = {}
         self._spam_threshold: float = float(GOOGLE_HOME_SPAM_THRESHOLD_MINUTES) * 60.0
 
-        # Initial configuration load
         self._apply_from_mapping_or_entry(config_like)
 
-    # ------------------------- Configuration helpers -------------------------
+    # ---------------------------------------------------------------------
+    # Configuration helpers
+    # ---------------------------------------------------------------------
 
     def _apply_from_mapping_or_entry(self, source: Mapping[str, Any] | ConfigEntry) -> None:
-        """Load settings from ConfigEntry (options-first) or from a plain mapping."""
-        enabled: Optional[bool] = None
-        keywords_raw: Optional[str] = None
+        """Load settings from ConfigEntry (options-first) or from a plain mapping.
+
+        Accepted keyword formats:
+          * Comma-separated string
+          * Iterable[str] (list/tuple/set)
+        """
+        enabled: bool = True
+        keywords_raw: Any = DEFAULT_GOOGLE_HOME_FILTER_KEYWORDS
 
         if isinstance(source, ConfigEntry):
-            # Options-first: prefer entry.options; fall back to entry.data.
-            enabled = source.options.get(
-                OPT_GOOGLE_HOME_FILTER_ENABLED,
-                source.data.get(OPT_GOOGLE_HOME_FILTER_ENABLED, True),
+            # Options-first, fallback to data
+            enabled = bool(
+                source.options.get(
+                    OPT_GOOGLE_HOME_FILTER_ENABLED,
+                    source.data.get(OPT_GOOGLE_HOME_FILTER_ENABLED, True),
+                )
             )
             keywords_raw = source.options.get(
                 OPT_GOOGLE_HOME_FILTER_KEYWORDS,
                 source.data.get(OPT_GOOGLE_HOME_FILTER_KEYWORDS, DEFAULT_GOOGLE_HOME_FILTER_KEYWORDS),
             )
         else:
-            # Legacy dict: read directly, keep defaults aligned with const.py.
             enabled = bool(source.get(OPT_GOOGLE_HOME_FILTER_ENABLED, True))
             keywords_raw = source.get(OPT_GOOGLE_HOME_FILTER_KEYWORDS, DEFAULT_GOOGLE_HOME_FILTER_KEYWORDS)
 
         self._enabled = bool(enabled)
-        self._keywords = self._parse_keywords(str(keywords_raw or ""))
+        self._keywords = self._normalize_keywords(keywords_raw)
 
-        _LOGGER.debug(
-            "GoogleHomeFilter loaded (enabled=%s, keywords=%s)", self._enabled, self._keywords
-        )
+        _LOGGER.debug("GoogleHomeFilter loaded (enabled=%s, keywords=%s)", self._enabled, self._keywords)
 
     def apply_from_entry(self, entry: ConfigEntry) -> None:
-        """Public helper to (re)load settings from a ConfigEntry."""
+        """(Re)load settings from a ConfigEntry."""
         self._apply_from_mapping_or_entry(entry)
 
     def update_config(self, config_or_entry: Mapping[str, Any] | ConfigEntry) -> None:
-        """Update filter configuration (accepts dict or ConfigEntry for compatibility)."""
+        """Update filter configuration (accepts dict or ConfigEntry)."""
         self._apply_from_mapping_or_entry(config_or_entry)
-        _LOGGER.info(
-            "Updated Google Home filter config: enabled=%s, keywords=%s",
-            self._enabled,
-            self._keywords,
-        )
+        _LOGGER.info("Updated Google Home filter config: enabled=%s, keywords=%s", self._enabled, self._keywords)
 
-    # ------------------------------ Core logic ------------------------------
+    # ---------------------------------------------------------------------
+    # Normalization / parsing
+    # ---------------------------------------------------------------------
 
     @staticmethod
-    def _parse_keywords(keywords_string: str) -> list[str]:
-        """Parse comma-separated keywords into a normalized list."""
-        if not keywords_string:
-            return []
-        # Support commas, newlines, and extra whitespace
-        parts = [p.strip().lower() for p in keywords_string.replace("\n", ",").split(",")]
-        return [p for p in parts if p]
+    def _normalize_keywords(value: Any) -> list[str]:
+        """Normalize keywords to a lowercased, de-duplicated list.
+
+        Accepted formats:
+          - str: comma/newline separated
+          - list|tuple|set of str: each item is one keyword
+        """
+        items: list[str] = []
+
+        if isinstance(value, str):
+            raw = value.replace("\n", ",")
+            items = [p.strip().lower() for p in raw.split(",") if p.strip()]
+        elif isinstance(value, (list, tuple, set)):
+            for v in value:
+                if isinstance(v, str) and v.strip():
+                    items.append(v.strip().lower())
+        elif value is None:
+            items = []
+        else:
+            # Defensive fallback: stringify unknown types
+            items = [str(value).strip().lower()] if str(value).strip() else []
+
+        # De-duplicate while preserving order
+        seen = set()
+        normed: list[str] = []
+        for k in items:
+            if k not in seen:
+                seen.add(k)
+                normed.append(k)
+        return normed
+
+    @staticmethod
+    def _norm_id(device_id: str) -> str:
+        """Create a stable key for per-device bookkeeping."""
+        return (device_id or "").strip()
+
+    # ---------------------------------------------------------------------
+    # Core logic: keyword match, zone name, "am I home?"
+    # ---------------------------------------------------------------------
 
     def is_google_home_device(self, location_name: str | None) -> bool:
         """Return True if the location name matches any configured Google Home keyword."""
@@ -131,28 +209,21 @@ class GoogleHomeFilter:
             _LOGGER.debug("Failed to resolve Home zone name: %s", err)
             return "Home"
 
-    # --------------------------- Entity lookups -----------------------------
-
     def _find_tracker_entity_id(self, device_id: str) -> str | None:
         """Resolve the device_tracker entity_id for a given Find My device ID.
 
-        We match by the unique_id shape used in the integration: f\"{DOMAIN}_{device_id}\".
-        This avoids guessing multiple entity_id formats.
+        Uses the unique_id shape: f"{DOMAIN}_{device_id}" via registry shortcut.
         """
         try:
             reg = er.async_get(self.hass)
-            target_unique_id = f"{DOMAIN}_{device_id}"
-            for ent in reg.entities.values():
-                if (
-                    ent.unique_id == target_unique_id
-                    and ent.platform == DOMAIN
-                    and ent.entity_id.startswith("device_tracker.")
-                ):
-                    return ent.entity_id
+            unique_id = f"{DOMAIN}_{device_id}"
+            entity_id = reg.async_get_entity_id("device_tracker", DOMAIN, unique_id)
+            if entity_id:
+                return entity_id
         except Exception as err:  # noqa: BLE001
             _LOGGER.debug("Entity registry lookup failed for %s: %s", device_id, err)
 
-        # Backward-compatible guesses as a last resort:
+        # Backward-compatible guesses as a last resort (best effort)
         guess = f"device_tracker.{device_id.lower().replace(' ', '_')}"
         if self.hass.states.get(guess):
             return guess
@@ -176,41 +247,53 @@ class GoogleHomeFilter:
             _LOGGER.debug("Error checking if device %s is at home: %s", device_id, err)
             return False
 
-    # --------------------------- Spam debounce ------------------------------
+    # ---------------------------------------------------------------------
+    # Spam debounce (monotonic)
+    # ---------------------------------------------------------------------
 
     def _should_prevent_spam(self, device_id: str) -> bool:
-        """Return True if we should debounce repeated detections for this device."""
-        last = self._spam_tracking.get(device_id)
+        """Return True if another detection should be debounced for this device."""
+        key = self._norm_id(device_id)
+        last = self._spam_tracking.get(key)
         if last is None:
             return False
-        return (time.time() - last) < self._spam_threshold
+        return (time.monotonic() - last) < self._spam_threshold
 
     def _update_spam_tracking(self, device_id: str) -> None:
-        """Record the current moment as the last detection time for this device."""
-        self._spam_tracking[device_id] = time.time()
+        """Record now (monotonic) as last detection for this device."""
+        self._spam_tracking[self._norm_id(device_id)] = time.monotonic()
 
     def reset_spam_tracking(self, device_id: str) -> None:
-        """Clear spam tracking for a device (e.g., when it leaves home)."""
-        if device_id in self._spam_tracking:
-            del self._spam_tracking[device_id]
+        """Clear spam tracking for a device (e.g., when it leaves Home)."""
+        key = self._norm_id(device_id)
+        if key in self._spam_tracking:
+            del self._spam_tracking[key]
             _LOGGER.debug("Reset spam tracking for %s (left Home zone)", device_id)
 
-    # ---------------------------- Filter decision ---------------------------
+    # ---------------------------------------------------------------------
+    # Filter decision
+    # ---------------------------------------------------------------------
 
-    def should_filter_detection(self, device_id: str, location_name: str | None) -> Tuple[bool, str | None]:
-        """Return a tuple (should_filter, replacement_location).
+    def should_filter_detection(self, device_id: str, location_name: str | None) -> tuple[bool, str | None]:
+        """Return (should_filter, replacement_location).
 
         Semantics:
-          - If location is already a 'Home' zone: apply spam debounce only.
-          - If location matches Google Home device keywords:
-              * If device is already at home: apply spam debounce only.
-              * If device is NOT at home: substitute the location with the 'Home' zone name.
+          - If the filter is disabled → (False, None).
+          - If `location_name` already represents a Home zone:
+              * Apply debounce only (i.e., possibly filter, but never substitute).
+          - If `location_name` matches Google-Home device keywords:
+              * If the device is already "home": debounce only.
+              * If the device is NOT "home": substitute with the Home zone name.
           - Otherwise: do not filter and do not substitute.
+
+        Returns:
+            should_filter: True → suppress; False → pass through (optionally substituted).
+            replacement_location: Optional zone name to use instead of `location_name`.
         """
         if not self._enabled:
             return False, None
 
-        # 1) Home zone detection has priority.
+        # 1) Home zone detection has priority
         is_home_zone = False
         home_zone_name = self.get_home_zone_name()
         if location_name:
@@ -226,11 +309,10 @@ class GoogleHomeFilter:
             return False, None
 
         # 2) Google Home device detection?
-        is_google_home = self.is_google_home_device(location_name)
-        if not is_google_home:
+        if not self.is_google_home_device(location_name):
             return False, None
 
-        # 3) If device already at Home → only spam protection.
+        # 3) Device already at Home → debounce only
         if self.is_device_at_home(device_id):
             if self._should_prevent_spam(device_id):
                 _LOGGER.debug("Filtering Google Home spam for %s at %s", device_id, location_name)
@@ -238,7 +320,7 @@ class GoogleHomeFilter:
             self._update_spam_tracking(device_id)
             return False, None
 
-        # 4) Device not at Home → substitute semantic location with the Home zone name.
+        # 4) Device not at Home → substitute semantic location with the Home zone name
         home_zone = home_zone_name or "Home"
         _LOGGER.info(
             "Substituting Google Home detection for %s at '%s' with zone '%s'",

--- a/custom_components/googlefindmy/sensor.py
+++ b/custom_components/googlefindmy/sensor.py
@@ -56,13 +56,8 @@ LAST_SEEN_DESCRIPTION = SensorEntityDescription(
 
 # NOTE: HA Quality Scale (Platinum): entity descriptions define translation_key,
 # icon and state_class; keys must match coordinator.stats counters exactly.
+# `skipped_duplicates` was removed from the coordinator and is intentionally absent here.
 STATS_DESCRIPTIONS: dict[str, SensorEntityDescription] = {
-    "skipped_duplicates": SensorEntityDescription(
-        key="skipped_duplicates",
-        translation_key="stat_skipped_duplicates",
-        icon="mdi:cancel",
-        state_class=SensorStateClass.TOTAL_INCREASING,
-    ),
     "background_updates": SensorEntityDescription(
         key="background_updates",
         translation_key="stat_background_updates",

--- a/custom_components/googlefindmy/sensor.py
+++ b/custom_components/googlefindmy/sensor.py
@@ -146,24 +146,6 @@ async def async_setup_entry(
                 known_ids.add(dev_id)
             else:
                 _LOGGER.debug("Skipping device without id/name: %s", device)
-    else:
-        # Cold boot: create skeletons from tracked IDs without writing placeholder names
-        tracked_ids: list[str] = getattr(coordinator, "tracked_devices", []) or []
-        for dev_id in tracked_ids:
-            # Do not create skeletons for ignored devices
-            try:
-                if hasattr(coordinator, "is_ignored") and coordinator.is_ignored(dev_id):
-                    _LOGGER.debug("Skipping ignored device skeleton sensor: %s", dev_id)
-                    continue
-            except Exception:
-                pass
-            entities.append(GoogleFindMyLastSeenSensor(coordinator, {"id": dev_id}))
-            known_ids.add(dev_id)
-        if tracked_ids:
-            _LOGGER.debug(
-                "Created %d skeleton last_seen sensors for restore (no live data yet)",
-                len(tracked_ids),
-            )
 
     if entities:
         async_add_entities(entities, True)
@@ -262,6 +244,8 @@ class GoogleFindMyLastSeenSensor(CoordinatorEntity, RestoreSensor):
 
     # Best practice: let HA compose "<Device Name> <translated entity name>"
     _attr_has_entity_name = True
+    # Default to disabled in the registry for per-device sensors
+    _attr_entity_registry_enabled_default = False
     entity_description = LAST_SEEN_DESCRIPTION
 
     def __init__(self, coordinator: GoogleFindMyCoordinator, device: dict[str, Any]) -> None:

--- a/custom_components/googlefindmy/sensor.py
+++ b/custom_components/googlefindmy/sensor.py
@@ -137,6 +137,13 @@ async def async_setup_entry(
         # Cold boot: create skeletons from tracked IDs without writing placeholder names
         tracked_ids: list[str] = getattr(coordinator, "tracked_devices", []) or []
         for dev_id in tracked_ids:
+            # Do not create skeletons for ignored devices
+            try:
+                if hasattr(coordinator, "is_ignored") and coordinator.is_ignored(dev_id):
+                    _LOGGER.debug("Skipping ignored device skeleton sensor: %s", dev_id)
+                    continue
+            except Exception:
+                pass
             entities.append(GoogleFindMyLastSeenSensor(coordinator, {"id": dev_id}))
             known_ids.add(dev_id)
         if tracked_ids:

--- a/custom_components/googlefindmy/sensor.py
+++ b/custom_components/googlefindmy/sensor.py
@@ -54,6 +54,8 @@ LAST_SEEN_DESCRIPTION = SensorEntityDescription(
     device_class=SensorDeviceClass.TIMESTAMP,
 )
 
+# NOTE: HA Quality Scale (Platinum): entity descriptions define translation_key,
+# icon and state_class; keys must match coordinator.stats counters exactly.
 STATS_DESCRIPTIONS: dict[str, SensorEntityDescription] = {
     "skipped_duplicates": SensorEntityDescription(
         key="skipped_duplicates",
@@ -71,6 +73,13 @@ STATS_DESCRIPTIONS: dict[str, SensorEntityDescription] = {
         key="crowd_sourced_updates",
         translation_key="stat_crowd_sourced_updates",
         icon="mdi:account-group",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
+    # Unified counter for all updates dropped by the significance filter.
+    "non_significant_dropped": SensorEntityDescription(
+        key="non_significant_dropped",
+        translation_key="stat_non_significant_dropped",
+        icon="mdi:filter-variant-remove",
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
 }
@@ -120,8 +129,12 @@ async def async_setup_entry(
         entry.data.get(OPT_ENABLE_STATS_ENTITIES, DEFAULT_ENABLE_STATS_ENTITIES),
     )
     if enable_stats:
+        created_stats = []
         for stat_key, desc in STATS_DESCRIPTIONS.items():
             entities.append(GoogleFindMyStatsSensor(coordinator, stat_key, desc))
+            created_stats.append(stat_key)
+        # Helpful debug to verify which stats sensors are created at setup time.
+        _LOGGER.debug("Stats sensors created: %s", ", ".join(created_stats))
 
     # Per-device last_seen sensors from current snapshot
     if coordinator.data:
@@ -186,29 +199,30 @@ async def async_setup_entry(
 class GoogleFindMyStatsSensor(CoordinatorEntity, SensorEntity):
     """Diagnostic counters for the integration.
 
-    Values are provided by coordinator.stats and persisted debounced by the coordinator.
+    Naming policy (HA Quality Scale – Platinum):
+    - Do **not** set a hard-coded `_attr_name`. We rely on `entity_description.translation_key`
+      and `_attr_has_entity_name = True` so HA composes the visible name as
+      "<device name> <translated entity name>". This ensures locale-correct UI strings.
     """
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_has_entity_name = False  # standalone (not per-device)
+    _attr_has_entity_name = True  # allow translated entity name to be used
 
     def __init__(
         self, coordinator: GoogleFindMyCoordinator, stat_key: str, description: SensorEntityDescription
     ) -> None:
-        """Initialize the stats sensor."""
+        """Initialize the stats sensor.
+
+        Args:
+            coordinator: The integration's data coordinator.
+            stat_key: Name of the counter in coordinator.stats.
+            description: Home Assistant entity description (icon, translation_key, etc.).
+        """
         super().__init__(coordinator)
         self._stat_key = stat_key
         self.entity_description = description
         self._attr_unique_id = f"{DOMAIN}_{stat_key}"
-        # Fallback name in case translations are missing
-        fallback_names = {
-            "skipped_duplicates": "Skipped Duplicates",
-            "background_updates": "Background Updates",
-            "crowd_sourced_updates": "Crowd-sourced Updates",
-        }
-        self._attr_name = (
-            f"Google Find My {fallback_names.get(stat_key, stat_key.replace('_', ' ').title())}"
-        )
+        # Intentionally no `_attr_name` here; translations drive the visible name.
         self._attr_native_unit_of_measurement = "updates"
 
     @property

--- a/custom_components/googlefindmy/services.yaml
+++ b/custom_components/googlefindmy/services.yaml
@@ -24,6 +24,19 @@ play_sound:
         device:
           integration: googlefindmy
 
+stop_sound:
+  name: Stop Sound
+  description: "Stop the sound on a Google Find My device"
+  # Note: no 'target' block — we use an explicit 'device_id' field for compatibility with our resolver.
+  fields:
+    device_id:
+      name: Device
+      description: "Select a Google Find My device (or pass a canonical ID via Developer Tools)"
+      required: true
+      selector:
+        device:
+          integration: googlefindmy
+
 locate_device_external:
   name: Locate Device (External)
   description: "Get current location using an external GoogleFindMyTools helper (workaround for FCM issues)"

--- a/custom_components/googlefindmy/tests/test_config_flow.py
+++ b/custom_components/googlefindmy/tests/test_config_flow.py
@@ -1,0 +1,602 @@
+# tests/test_config_flow.py
+"""Tests for the Google Find My Device config flow.
+
+This suite exercises the primary paths and edge cases for the custom
+integration's configuration and options flows, including:
+
+- Initial setup:
+  * Secrets-only path (valid JSON and token fallbacks)
+  * Manual-only path (field-level validation)
+  * Online validation during device selection
+  * Duplicate prevention via unique_id
+- Reauthentication and credentials update:
+  * Exactly-one-method checks (choose_one)
+  * JSON syntax vs. content/format errors
+  * Online validation via API call
+- Options flow:
+  * Credentials update success/fail paths
+  * Visibility management (restore ignored devices)
+- Error handling:
+  * cannot_connect on API errors
+  * no_devices when API returns none
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from homeassistant import config_entries
+from homeassistant.core import HomeAssistant
+
+# Prefer the core MockConfigEntry when running in HA-Core; fall back to the
+# pytest plugin for custom components when running outside.
+try:  # Home Assistant core test environment
+    from tests.common import MockConfigEntry  # type: ignore
+except Exception:  # pytest-homeassistant-custom-component environment
+    from pytest_homeassistant_custom_component.common import (  # type: ignore
+        MockConfigEntry,
+    )
+
+# Keep tests resilient: only use stable string keys where practical;
+# otherwise import integration constants directly.
+DOMAIN = "googlefindmy"
+
+# Option keys (mirroring integration consts but decoupled for test stability)
+OPT_TRACKED_DEVICES = "tracked_devices"
+OPT_LOCATION_POLL_INTERVAL = "location_poll_interval"
+OPT_DEVICE_POLL_DELAY = "device_poll_delay"
+OPT_MIN_ACCURACY_THRESHOLD = "min_accuracy_threshold"
+OPT_MOVEMENT_THRESHOLD = "movement_threshold"
+OPT_GOOGLE_HOME_FILTER_ENABLED = "google_home_filter_enabled"
+OPT_GOOGLE_HOME_FILTER_KEYWORDS = "google_home_filter_keywords"
+OPT_ENABLE_STATS_ENTITIES = "enable_stats_entities"
+OPT_MAP_VIEW_TOKEN_EXPIRATION = "map_view_token_expiration"
+
+CONF_OAUTH_TOKEN = "oauth_token"
+CONF_GOOGLE_EMAIL = "google_email"
+
+# Import ignored-devices option name from the integration to stay exact
+from custom_components.googlefindmy.const import OPT_IGNORED_DEVICES  # noqa: E402
+
+
+def _device_list() -> list[Dict[str, Any]]:
+    """Return a minimal device list payload like the API would."""
+    return [{"name": "Pixel 8", "id": "dev1"}]
+
+
+def _options_payload_defaults(dev_ids: list[str]) -> Dict[str, Any]:
+    """Build a valid options payload for the device_selection step."""
+    return {
+        OPT_TRACKED_DEVICES: dev_ids,
+        OPT_LOCATION_POLL_INTERVAL: 120,
+        OPT_DEVICE_POLL_DELAY: 2,
+        OPT_MIN_ACCURACY_THRESHOLD: 50,
+        OPT_MOVEMENT_THRESHOLD: 20,
+        OPT_GOOGLE_HOME_FILTER_ENABLED: False,
+        OPT_GOOGLE_HOME_FILTER_KEYWORDS: "",
+        OPT_ENABLE_STATS_ENTITIES: False,
+        OPT_MAP_VIEW_TOKEN_EXPIRATION: False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_user_flow_secrets_only_success(hass: HomeAssistant) -> None:
+    """Secrets-only: valid JSON and credentials flow through to create_entry."""
+    secrets = {
+        "username": "user@example.com",
+        "oauth_token": "x" * 32,
+    }
+
+    with patch(
+        "custom_components.googlefindmy.config_flow.GoogleFindMyAPI.async_get_basic_device_list",
+        new=AsyncMock(return_value=_device_list()),
+    ):
+        # Start the user flow
+        step = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        assert step["type"] == "form" and step["step_id"] == "user"
+
+        # Choose the secrets_json method
+        step = await hass.config_entries.flow.async_configure(
+            step["flow_id"], {"auth_method": "secrets_json"}
+        )
+        assert step["type"] == "form" and step["step_id"] == "secrets_json"
+
+        # Submit secrets.json to advance to device_selection
+        step = await hass.config_entries.flow.async_configure(
+            step["flow_id"], {"secrets_json": json.dumps(secrets)}
+        )
+        assert step["type"] == "form" and step["step_id"] == "device_selection"
+
+        # Submit the device selection/options → create_entry
+        step = await hass.config_entries.flow.async_configure(
+            step["flow_id"], _options_payload_defaults(["dev1"])
+        )
+        assert step["type"] == "create_entry"
+        assert step["title"] == "Google Find My Device"
+        assert step["data"][CONF_GOOGLE_EMAIL] == "user@example.com"
+        assert step["data"][CONF_OAUTH_TOKEN] == "x" * 32
+
+        # Unique ID must be set to avoid duplicates
+        entry = hass.config_entries.async_entries(DOMAIN)[0]
+        assert entry.unique_id == f"{DOMAIN}:user@example.com"
+
+
+@pytest.mark.asyncio
+async def test_user_flow_manual_only_success(hass: HomeAssistant) -> None:
+    """Manual-only: valid token+email advances to device_selection then creates entry."""
+    with patch(
+        "custom_components.googlefindmy.config_flow.GoogleFindMyAPI.async_get_basic_device_list",
+        new=AsyncMock(return_value=_device_list()),
+    ):
+        step = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        step = await hass.config_entries.flow.async_configure(
+            step["flow_id"], {"auth_method": "individual_tokens"}
+        )
+        assert step["type"] == "form" and step["step_id"] == "individual_tokens"
+
+        # Provide manual credentials (field-level validation applies in this step)
+        step = await hass.config_entries.flow.async_configure(
+            step["flow_id"],
+            {CONF_OAUTH_TOKEN: "t" * 32, CONF_GOOGLE_EMAIL: "user@example.com"},
+        )
+        assert step["type"] == "form" and step["step_id"] == "device_selection"
+
+        step = await hass.config_entries.flow.async_configure(
+            step["flow_id"], _options_payload_defaults(["dev1"])
+        )
+        assert step["type"] == "create_entry"
+        entry = hass.config_entries.async_entries(DOMAIN)[0]
+        assert entry.data[CONF_OAUTH_TOKEN] == "t" * 32
+        assert entry.data[CONF_GOOGLE_EMAIL] == "user@example.com"
+
+
+@pytest.mark.asyncio
+async def test_user_flow_secrets_only_missing_token_invalid_token(hass: HomeAssistant) -> None:
+    """Secrets-only: missing token in JSON yields base error invalid_token."""
+    secrets = {"username": "user@example.com"}  # no oauth/access/aas token
+    step = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    step = await hass.config_entries.flow.async_configure(
+        step["flow_id"], {"auth_method": "secrets_json"}
+    )
+    step = await hass.config_entries.flow.async_configure(
+        step["flow_id"], {"secrets_json": json.dumps(secrets)}
+    )
+    assert step["type"] == "form"
+    assert step["step_id"] == "secrets_json"
+    assert step["errors"]["base"] == "invalid_token"
+
+
+@pytest.mark.asyncio
+async def test_secrets_failover_access_token(hass: HomeAssistant) -> None:
+    """Secrets-only: if oauth_token is missing, fall back to access_token."""
+    secrets = {"username": "user@example.com", "access_token": "A" * 64}
+
+    with patch(
+        "custom_components.googlefindmy.config_flow.GoogleFindMyAPI.async_get_basic_device_list",
+        new=AsyncMock(return_value=_device_list()),
+    ):
+        step = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        step = await hass.config_entries.flow.async_configure(
+            step["flow_id"], {"auth_method": "secrets_json"}
+        )
+        step = await hass.config_entries.flow.async_configure(
+            step["flow_id"], {"secrets_json": json.dumps(secrets)}
+        )
+        assert step["type"] == "form" and step["step_id"] == "device_selection"
+
+        step = await hass.config_entries.flow.async_configure(
+            step["flow_id"], _options_payload_defaults(["dev1"])
+        )
+        assert step["type"] == "create_entry"
+        entry = hass.config_entries.async_entries(DOMAIN)[0]
+        assert entry.data[CONF_OAUTH_TOKEN] == "A" * 64
+
+
+@pytest.mark.asyncio
+async def test_secrets_failover_aas_token(hass: HomeAssistant) -> None:
+    """Secrets-only: if oauth/access token missing, accept aas_token."""
+    secrets = {"username": "user@example.com", "aas_token": "aas_et/" + "B" * 64}
+
+    with patch(
+        "custom_components.googlefindmy.config_flow.GoogleFindMyAPI.async_get_basic_device_list",
+        new=AsyncMock(return_value=_device_list()),
+    ):
+        step = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        step = await hass.config_entries.flow.async_configure(
+            step["flow_id"], {"auth_method": "secrets_json"}
+        )
+        step = await hass.config_entries.flow.async_configure(
+            step["flow_id"], {"secrets_json": json.dumps(secrets)}
+        )
+        assert step["type"] == "form" and step["step_id"] == "device_selection"
+
+        step = await hass.config_entries.flow.async_configure(
+            step["flow_id"], _options_payload_defaults(["dev1"])
+        )
+        assert step["type"] == "create_entry"
+        entry = hass.config_entries.async_entries(DOMAIN)[0]
+        assert entry.data[CONF_OAUTH_TOKEN].startswith("aas_et/")
+
+
+@pytest.mark.asyncio
+async def test_secrets_only_invalid_json(hass: HomeAssistant) -> None:
+    """Secrets-only: invalid JSON should flag the secrets field with invalid_json."""
+    step = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    step = await hass.config_entries.flow.async_configure(
+        step["flow_id"], {"auth_method": "secrets_json"}
+    )
+    step = await hass.config_entries.flow.async_configure(
+        step["flow_id"], {"secrets_json": "{not json"}
+    )
+    assert step["type"] == "form"
+    assert step["errors"]["secrets_json"] == "invalid_json"
+
+
+@pytest.mark.asyncio
+async def test_manual_field_level_errors(hass: HomeAssistant) -> None:
+    """Manual: empty/invalid fields result in field-level errors (required/invalid_token)."""
+    step = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    step = await hass.config_entries.flow.async_configure(
+        step["flow_id"], {"auth_method": "individual_tokens"}
+    )
+
+    # Case 1: both empty → both required
+    step1 = await hass.config_entries.flow.async_configure(
+        step["flow_id"], {CONF_OAUTH_TOKEN: "", CONF_GOOGLE_EMAIL: ""}
+    )
+    assert step1["type"] == "form"
+    assert step1["errors"][CONF_OAUTH_TOKEN] == "required"
+    assert step1["errors"][CONF_GOOGLE_EMAIL] == "required"
+
+    # Case 2: invalid token + invalid email
+    step2 = await hass.config_entries.flow.async_configure(
+        step["flow_id"], {CONF_OAUTH_TOKEN: "short", CONF_GOOGLE_EMAIL: "no-at"}
+    )
+    assert step2["type"] == "form"
+    assert step2["errors"][CONF_OAUTH_TOKEN] == "invalid_token"
+    assert step2["errors"][CONF_GOOGLE_EMAIL] == "invalid_token"
+
+
+@pytest.mark.asyncio
+async def test_device_selection_no_devices(hass: HomeAssistant) -> None:
+    """If API returns an empty list, device_selection shows base error no_devices."""
+    secrets = {"username": "user@example.com", "oauth_token": "x" * 32}
+
+    with patch(
+        "custom_components.googlefindmy.config_flow.GoogleFindMyAPI.async_get_basic_device_list",
+        new=AsyncMock(return_value=[]),
+    ):
+        step = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        step = await hass.config_entries.flow.async_configure(
+            step["flow_id"], {"auth_method": "secrets_json"}
+        )
+        step = await hass.config_entries.flow.async_configure(
+            step["flow_id"], {"secrets_json": json.dumps(secrets)}
+        )
+        assert step["type"] == "form"
+        assert step["step_id"] == "device_selection"
+        assert step["errors"]["base"] == "no_devices"
+
+
+@pytest.mark.asyncio
+async def test_device_selection_cannot_connect(hass: HomeAssistant) -> None:
+    """If API raises during device fetch, device_selection shows base error cannot_connect."""
+    secrets = {"username": "user@example.com", "oauth_token": "x" * 32}
+
+    with patch(
+        "custom_components.googlefindmy.config_flow.GoogleFindMyAPI.async_get_basic_device_list",
+        new=AsyncMock(side_effect=Exception("boom")),
+    ):
+        step = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        step = await hass.config_entries.flow.async_configure(
+            step["flow_id"], {"auth_method": "secrets_json"}
+        )
+        step = await hass.config_entries.flow.async_configure(
+            step["flow_id"], {"secrets_json": json.dumps(secrets)}
+        )
+        assert step["type"] == "form"
+        assert step["step_id"] == "device_selection"
+        assert step["errors"]["base"] == "cannot_connect"
+
+
+@pytest.mark.asyncio
+async def test_unique_id_prevents_duplicate_setup(hass: HomeAssistant) -> None:
+    """Second setup with the same email should abort as already_configured."""
+    existing = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_GOOGLE_EMAIL: "user@example.com", CONF_OAUTH_TOKEN: "O" * 32},
+        unique_id=f"{DOMAIN}:user@example.com",
+        title="Google Find My Device",
+    )
+    existing.add_to_hass(hass)
+
+    # Start another flow with the same user via secrets path
+    secrets = {"username": "user@example.com", "oauth_token": "N" * 32}
+    with patch(
+        "custom_components.googlefindmy.config_flow.GoogleFindMyAPI.async_get_basic_device_list",
+        new=AsyncMock(return_value=_device_list()),
+    ):
+        step = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        step = await hass.config_entries.flow.async_configure(
+            step["flow_id"], {"auth_method": "secrets_json"}
+        )
+        # Submitting secrets should trigger unique_id set and immediate abort
+        step = await hass.config_entries.flow.async_configure(
+            step["flow_id"], {"secrets_json": json.dumps(secrets)}
+        )
+        assert step["type"] == "abort"
+        assert step["reason"] == "already_configured"
+
+
+# -------------------------
+# Reauthentication (reauth)
+# -------------------------
+
+
+@pytest.mark.asyncio
+async def test_reauth_secrets_success(hass: HomeAssistant) -> None:
+    """Reauth: secrets-only validation succeeds and updates the entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_GOOGLE_EMAIL: "old@example.com", CONF_OAUTH_TOKEN: "O" * 32},
+        unique_id=f"{DOMAIN}:old@example.com",
+        title="Google Find My Device",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.googlefindmy.config_flow.GoogleFindMyAPI.async_get_basic_device_list",
+        new=AsyncMock(return_value=_device_list()),
+    ):
+        step = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_REAUTH, "entry_id": entry.entry_id},
+            data=entry.data,
+        )
+        assert step["type"] == "form" and step["step_id"] == "reauth_confirm"
+
+        new_secrets = {"username": "user@example.com", "oauth_token": "N" * 48}
+        step = await hass.config_entries.flow.async_configure(
+            step["flow_id"], {"secrets_json": json.dumps(new_secrets)}
+        )
+
+        # Reauth ends with abort(reason="reauth_successful")
+        assert step["type"] == "abort" and step["reason"] == "reauth_successful"
+
+        updated = hass.config_entries.async_get_entry(entry.entry_id)
+        assert updated is not None
+        assert updated.data[CONF_GOOGLE_EMAIL] == "user@example.com"
+        assert updated.data[CONF_OAUTH_TOKEN] == "N" * 48
+
+
+@pytest.mark.asyncio
+async def test_reauth_partial_manual_choose_one(hass: HomeAssistant) -> None:
+    """Reauth: providing only token or only email should yield base choose_one."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_GOOGLE_EMAIL: "old@example.com", CONF_OAUTH_TOKEN: "O" * 32},
+        unique_id=f"{DOMAIN}:old@example.com",
+        title="Google Find My Device",
+    )
+    entry.add_to_hass(hass)
+
+    step = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_REAUTH, "entry_id": entry.entry_id},
+        data=entry.data,
+    )
+    assert step["type"] == "form" and step["step_id"] == "reauth_confirm"
+
+    # Only token, no email → choose_one (incomplete/manual)
+    step = await hass.config_entries.flow.async_configure(
+        step["flow_id"], {CONF_OAUTH_TOKEN: "Z" * 40}
+    )
+    assert step["type"] == "form"
+    assert step["errors"]["base"] == "choose_one"
+
+
+@pytest.mark.asyncio
+async def test_reauth_mixed_input_choose_one(hass: HomeAssistant) -> None:
+    """Reauth: mixing secrets_json and manual fields should yield base choose_one."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_GOOGLE_EMAIL: "old@example.com", CONF_OAUTH_TOKEN: "O" * 32},
+        unique_id=f"{DOMAIN}:old@example.com",
+        title="Google Find My Device",
+    )
+    entry.add_to_hass(hass)
+
+    step = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_REAUTH, "entry_id": entry.entry_id},
+        data=entry.data,
+    )
+    assert step["type"] == "form" and step["step_id"] == "reauth_confirm"
+
+    step = await hass.config_entries.flow.async_configure(
+        step["flow_id"],
+        {
+            "secrets_json": json.dumps({"username": "x@y", "oauth_token": "X" * 32}),
+            CONF_OAUTH_TOKEN: "Y" * 32,
+            CONF_GOOGLE_EMAIL: "user@example.com",
+        },
+    )
+    assert step["type"] == "form"
+    assert step["errors"]["base"] == "choose_one"
+
+
+# -------------------------
+# Options flow (post-setup)
+# -------------------------
+
+
+@pytest.mark.asyncio
+async def test_options_credentials_update_manual_success(hass: HomeAssistant) -> None:
+    """Options flow: manual credentials update stores new values and reloads."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_GOOGLE_EMAIL: "old@example.com", CONF_OAUTH_TOKEN: "O" * 32},
+        unique_id=f"{DOMAIN}:old@example.com",
+        title="Google Find My Device",
+        options=_options_payload_defaults([]),
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.googlefindmy.config_flow.GoogleFindMyAPI.async_get_basic_device_list",
+        new=AsyncMock(return_value=_device_list()),
+    ):
+        # Enter options menu
+        step = await hass.config_entries.options.async_init(entry.entry_id)
+        assert step["type"] == "menu" and "credentials" in step["menu_options"]
+
+        # Navigate to credentials step
+        step = await hass.config_entries.options.async_configure(
+            step["flow_id"], "credentials"
+        )
+        assert step["type"] == "form" and step["step_id"] == "credentials"
+
+        # Submit new manual credentials
+        step = await hass.config_entries.options.async_configure(
+            step["flow_id"],
+            {"new_oauth_token": "Z" * 40, "new_google_email": "new@example.com"},
+        )
+        assert step["type"] == "abort" and step["reason"] == "reconfigure_successful"
+
+        updated = hass.config_entries.async_get_entry(entry.entry_id)
+        assert updated is not None
+        assert updated.data[CONF_GOOGLE_EMAIL] == "new@example.com"
+        assert updated.data[CONF_OAUTH_TOKEN] == "Z" * 40
+
+
+@pytest.mark.asyncio
+async def test_options_credentials_update_invalid_json(hass: HomeAssistant) -> None:
+    """Options flow: invalid secrets JSON should produce invalid_json error."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_GOOGLE_EMAIL: "old@example.com", CONF_OAUTH_TOKEN: "O" * 32},
+        unique_id=f"{DOMAIN}:old@example.com",
+        title="Google Find My Device",
+        options=_options_payload_defaults([]),
+    )
+    entry.add_to_hass(hass)
+
+    step = await hass.config_entries.options.async_init(entry.entry_id)
+    step = await hass.config_entries.options.async_configure(
+        step["flow_id"], "credentials"
+    )
+    step = await hass.config_entries.options.async_configure(
+        step["flow_id"], {"new_secrets_json": "{not json"}
+    )
+    assert step["type"] == "form"
+    # In config_flow, invalid_json is raised on the form base (or field).
+    # This test expects field-level error on secrets if implemented that way;
+    # otherwise, accept base-level assertion. Prefer the field if present.
+    assert step["errors"].get("new_secrets_json", step["errors"].get("base")) == "invalid_json"
+
+
+@pytest.mark.asyncio
+async def test_options_credentials_update_choose_one(hass: HomeAssistant) -> None:
+    """Options flow: mixing secrets and manual fields should yield choose_one."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_GOOGLE_EMAIL: "old@example.com", CONF_OAUTH_TOKEN: "O" * 32},
+        unique_id=f"{DOMAIN}:old@example.com",
+        title="Google Find My Device",
+        options=_options_payload_defaults([]),
+    )
+    entry.add_to_hass(hass)
+
+    step = await hass.config_entries.options.async_init(entry.entry_id)
+    step = await hass.config_entries.options.async_configure(
+        step["flow_id"], "credentials"
+    )
+    step = await hass.config_entries.options.async_configure(
+        step["flow_id"],
+        {
+            "new_secrets_json": json.dumps(
+                {"username": "x@y", "oauth_token": "X" * 32}
+            ),
+            "new_oauth_token": "Y" * 32,
+            "new_google_email": "user@example.com",
+        },
+    )
+    assert step["type"] == "form"
+    assert step["errors"]["base"] == "choose_one"
+
+
+@pytest.mark.asyncio
+async def test_options_visibility_restore_devices_success(hass: HomeAssistant) -> None:
+    """Options flow: visibility step should restore selected ignored devices."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_GOOGLE_EMAIL: "user@example.com", CONF_OAUTH_TOKEN: "O" * 32},
+        unique_id=f"{DOMAIN}:user@example.com",
+        title="Google Find My Device",
+        options={
+            **_options_payload_defaults([]),
+            OPT_IGNORED_DEVICES: ["devA", "devB", "devC"],
+        },
+    )
+    entry.add_to_hass(hass)
+
+    # Open options menu
+    step = await hass.config_entries.options.async_init(entry.entry_id)
+    assert step["type"] == "menu" and "visibility" in step["menu_options"]
+
+    # Go to visibility form
+    step = await hass.config_entries.options.async_configure(
+        step["flow_id"], "visibility"
+    )
+    assert step["type"] == "form" and step["step_id"] == "visibility"
+
+    # Restore two devices; expect new options with only the remaining ignored device
+    step = await hass.config_entries.options.async_configure(
+        step["flow_id"], {"unignore_devices": ["devA", "devB"]}
+    )
+    assert step["type"] == "create_entry"
+    data = step["data"]
+    assert data[OPT_IGNORED_DEVICES] == ["devC"]
+
+
+@pytest.mark.asyncio
+async def test_options_visibility_no_ignored_devices_abort(hass: HomeAssistant) -> None:
+    """Options flow: visibility aborts when there are no ignored devices to restore."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_GOOGLE_EMAIL: "user@example.com", CONF_OAUTH_TOKEN: "O" * 32},
+        unique_id=f"{DOMAIN}:user@example.com",
+        title="Google Find My Device",
+        options=_options_payload_defaults([]),
+    )
+    entry.add_to_hass(hass)
+
+    step = await hass.config_entries.options.async_init(entry.entry_id)
+    step = await hass.config_entries.options.async_configure(
+        step["flow_id"], "visibility"
+    )
+    assert step["type"] == "abort"
+    assert step["reason"] == "no_ignored_devices"

--- a/custom_components/googlefindmy/tests/test_diagnostics.py
+++ b/custom_components/googlefindmy/tests/test_diagnostics.py
@@ -1,0 +1,108 @@
+# tests/test_diagnostics.py
+"""Diagnostics tests for Google Find My Device.
+
+Validates:
+- No secrets/PII are exposed (tokens/emails/IDs redacted or omitted)
+- Options snapshot contains only counts and safe booleans/ints
+- Integration metadata present
+- Registry counts are computed
+- Coordinator snapshot shape is stable and safe
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+try:
+    from tests.common import MockConfigEntry  # type: ignore
+except Exception:
+    from pytest_homeassistant_custom_component.common import MockConfigEntry  # type: ignore
+
+DOMAIN = "googlefindmy"
+CONF_OAUTH_TOKEN = "oauth_token"
+CONF_GOOGLE_EMAIL = "google_email"
+
+# Import the function under test
+from custom_components.googlefindmy.diagnostics import (  # noqa: E402
+    async_get_config_entry_diagnostics,
+)
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_basic_shape_and_privacy(hass: HomeAssistant, device_registry, entity_registry) -> None:
+    """Diagnostics should include safe metadata, config snapshot, registry + coordinator counters."""
+    # Create a config entry with options set; data contains secrets (must not leak)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_GOOGLE_EMAIL: "user@example.com", CONF_OAUTH_TOKEN: "S" * 64},
+        options={
+            "tracked_devices": ["dev1", "dev2"],
+            "location_poll_interval": 120,
+            "device_poll_delay": 3,
+            "min_accuracy_threshold": 80,
+            "movement_threshold": 25,
+            "google_home_filter_enabled": True,
+            "google_home_filter_keywords": "nest, mini , speaker",
+            "enable_stats_entities": True,
+            "map_view_token_expiration": True,
+        },
+        title="Google Find My Device",
+        unique_id=f"{DOMAIN}:user@example.com",
+    )
+    entry.add_to_hass(hass)
+
+    # Simulate a minimal coordinator object stored in hass.data
+    class _Coordinator:
+        _is_polling = True
+        _last_poll_mono = 1.0  # some monotonic origin
+        stats = {"polled": 5, "timeouts": 0}
+        _device_names = {"dev1": "Phone", "dev2": "Watch"}
+        _device_location_data = {"dev1": object(), "dev2": object(), "dev3": object()}
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = _Coordinator()
+
+    # Add devices/entities linked to this entry to test registry counts
+    dev = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id, identifiers={(DOMAIN, "dev1")}
+    )
+    entity_registry.async_get_or_create(
+        domain="sensor",
+        platform=DOMAIN,
+        unique_id="sensor.dev1.last_seen",
+        config_entry=entry,
+        device_id=dev.id,
+    )
+
+    result: Dict[str, Any] = await async_get_config_entry_diagnostics(hass, entry)
+
+    # Top-level structure
+    assert "entry" in result and "config" in result and "integration" in result
+    assert "registry" in result and "coordinator" in result
+
+    # Entry section must not include unique_id/email/token
+    assert result["entry"]["domain"] == DOMAIN
+    assert "unique_id" not in result["entry"]
+    assert CONF_GOOGLE_EMAIL not in str(result)
+    assert CONF_OAUTH_TOKEN not in str(result)
+
+    # Config snapshot: counts and booleans only, keywords as count
+    cfg = result["config"]
+    assert cfg["tracked_devices_count"] == 2
+    assert cfg["google_home_filter_keywords_count"] == 3
+    assert isinstance(cfg["location_poll_interval"], int)
+    assert isinstance(cfg["enable_stats_entities"], bool)
+
+    # Registry section contains counts
+    reg = result["registry"]
+    assert reg["device_count"] >= 1
+    assert reg["entity_count"] >= 1
+
+    # Coordinator section has safe numeric stats and flags
+    coord = result["coordinator"]
+    assert coord["is_polling"] is True
+    assert "known_devices_count" in coord and "cache_items_count" in coord
+    assert isinstance(coord.get("last_poll_wall_ts"), (int, float, type(None)))
+    # stats are numeric-like or sanitized
+    assert isinstance(coord["stats"].get("polled"), int)

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -11,14 +11,14 @@
       },
       "secrets_json": {
         "title": "Methode 1: GoogleFindMyTools secrets.json",
-        "description": "Führe GoogleFindMyTools (Chrome) aus, um Authentifizierungs-Token zu erzeugen, und füge unten den vollständigen Inhalt der Datei Auth/secrets.json ein.",
+        "description": "Führe GoogleFindMyTools (Chrome) aus, um Authentifizierungs-Token zu erzeugen, und füge unten den vollständigen Inhalt der Datei Auth/secrets.json ein.\n\n{hint}",
         "data": {
           "secrets_json": "Inhalt der secrets.json"
         }
       },
       "individual_tokens": {
         "title": "Methode 2: Manueller OAuth-Token",
-        "description": "Gib deinen OAuth-Token und deine Google-E-Mail-Adresse aus dem manuellen Anmeldeprozess ein.",
+        "description": "Gib deinen OAuth-Token und deine Google-E-Mail-Adresse aus dem manuellen Anmeldeprozess ein.\n\n{hint}",
         "data": {
           "oauth_token": "OAuth-Token",
           "google_email": "Google-E-Mail-Adresse"
@@ -41,7 +41,7 @@
       },
       "reauth_confirm": {
         "title": "Erneute Authentifizierung",
-        "description": "Deine Anmeldedaten sind ungültig oder abgelaufen. Bitte gib unten neue Anmeldedaten ein.\n\nTipp: Du kannst entweder den vollständigen Inhalt einer neuen secrets.json einfügen **oder** einen neuen OAuth-Token und deine E-Mail-Adresse angeben."
+        "description": "{reason}\n\nTipp: Du kannst entweder den vollständigen Inhalt einer neuen secrets.json einfügen **oder** einen neuen OAuth-Token und deine E-Mail-Adresse angeben."
       }
     },
     "error": {
@@ -73,7 +73,7 @@
       },
       "credentials": {
         "title": "Anmeldedaten aktualisieren (optional)",
-        "description": "Aktualisiere deine Anmeldedaten, ohne bestehende Werte preiszugeben. Gib genau eine Methode an:\n\n• Vollständigen Inhalt einer neuen **secrets.json** einfügen\n**oder**\n• Neuen **OAuth-Token** und **Google-E-Mail** eingeben.\n\nFalls angegeben, werden die Anmeldedaten validiert und gespeichert. Die Integration wird neu geladen, ohne deine Entitätsnamen zu ändern.",
+        "description": "{hint}\n\nAktualisiere deine Anmeldedaten, ohne bestehende Werte preiszugeben. Gib genau eine Methode an:\n\n• Vollständigen Inhalt einer neuen **secrets.json** einfügen\n**oder**\n• Neuen **OAuth-Token** und **Google-E-Mail** eingeben.\n\nFalls angegeben, werden die Anmeldedaten validiert und gespeichert. Die Integration wird neu geladen, ohne deine Entitätsnamen zu ändern.",
         "data": {
           "secrets_json": "Neue secrets.json (vollständiger Inhalt)",
           "oauth_token": "Neuer OAuth-Token",

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -11,45 +11,45 @@
       },
       "secrets_json": {
         "title": "Methode 1: GoogleFindMyTools secrets.json",
-        "description": "Führe GoogleFindMyTools (Chrome) aus, um Authentifizierungs‑Token zu erzeugen, und füge unten den vollständigen Inhalt der Datei Auth/secrets.json ein.",
+        "description": "Führe GoogleFindMyTools (Chrome) aus, um Authentifizierungs-Token zu erzeugen, und füge unten den vollständigen Inhalt der Datei Auth/secrets.json ein.",
         "data": {
           "secrets_json": "Inhalt der secrets.json"
         }
       },
       "individual_tokens": {
-        "title": "Methode 2: Manueller OAuth‑Token",
-        "description": "Gib deinen OAuth‑Token und deine Google‑E‑Mail‑Adresse aus dem manuellen Anmeldeprozess ein.",
+        "title": "Methode 2: Manueller OAuth-Token",
+        "description": "Gib deinen OAuth-Token und deine Google-E-Mail-Adresse aus dem manuellen Anmeldeprozess ein.",
         "data": {
-          "oauth_token": "OAuth‑Token",
-          "google_email": "Google‑E‑Mail‑Adresse"
+          "oauth_token": "OAuth-Token",
+          "google_email": "Google-E-Mail-Adresse"
         }
       },
       "device_selection": {
         "title": "Geräte und Abfrageintervall",
-        "description": "Wähle die zu verfolgenden Geräte und konfiguriere die Abfrageparameter:\n• Positionsabfrage‑Intervall: Wie oft ein neuer Abfragezyklus startet (60–3600 Sekunden).\n• Verzögerung zwischen Geräteabfragen: Abstand zwischen den Abfragen einzelner Geräte innerhalb eines Zyklus (1–60 Sekunden).\n\nDie Integration fragt die Geräte nacheinander ab und fordert für jedes Gerät mit der angegebenen Verzögerung Positionsdaten an.",
+        "description": "Wähle die zu verfolgenden Geräte und konfiguriere die Abfrageparameter:\n• Positionsabfrage-Intervall: Wie oft ein neuer Abfragezyklus startet (60–3600 Sekunden).\n• Verzögerung zwischen Geräteabfragen: Abstand zwischen den Abfragen einzelner Geräte innerhalb eines Zyklus (1–60 Sekunden).\n\nDie Integration fragt die Geräte nacheinander ab und fordert für jedes Gerät mit der angegebenen Verzögerung Positionsdaten an.",
         "data": {
           "tracked_devices": "Verfolgte Geräte",
-          "location_poll_interval": "Positionsabfrage‑Intervall (s)",
+          "location_poll_interval": "Positionsabfrage-Intervall (s)",
           "device_poll_delay": "Verzögerung zwischen Geräteabfragen (s)",
           "min_accuracy_threshold": "Mindestgenauigkeit (m)",
           "movement_threshold": "Bewegungsschwelle (m)",
-          "google_home_filter_enabled": "Google‑Home‑Geräte filtern",
-          "google_home_filter_keywords": "Filter‑Schlüsselwörter (kommagetrennt)",
-          "enable_stats_entities": "Statistik‑Entitäten erstellen",
-          "map_view_token_expiration": "Ablauf von Kartenansicht‑Token aktivieren"
+          "google_home_filter_enabled": "Google-Home-Geräte filtern",
+          "google_home_filter_keywords": "Filter-Schlüsselwörter (kommagetrennt)",
+          "enable_stats_entities": "Statistik-Entitäten erstellen",
+          "map_view_token_expiration": "Ablauf von Kartenansicht-Token aktivieren"
         }
       },
       "reauth_confirm": {
         "title": "Erneute Authentifizierung",
-        "description": "Deine Anmeldedaten sind ungültig oder abgelaufen. Bitte gib unten neue Anmeldedaten ein.\n\nTipp: Du kannst entweder den vollständigen Inhalt einer neuen secrets.json einfügen **oder** einen neuen OAuth‑Token und deine E‑Mail‑Adresse angeben."
+        "description": "Deine Anmeldedaten sind ungültig oder abgelaufen. Bitte gib unten neue Anmeldedaten ein.\n\nTipp: Du kannst entweder den vollständigen Inhalt einer neuen secrets.json einfügen **oder** einen neuen OAuth-Token und deine E-Mail-Adresse angeben."
       }
     },
     "error": {
       "auth_failed": "Authentifizierung fehlgeschlagen. Bitte versuche es erneut.",
       "invalid_token": "Ungültiger Token oder erforderliche Felder fehlen.",
-      "invalid_json": "Ungültiges JSON‑Format im Inhalt der secrets.json.",
-      "no_devices": "Keine Geräte gefunden. Bitte stelle sicher, dass ‚Mein Gerät finden‘ in deinem Google‑Konto aktiviert ist.",
-      "cannot_connect": "Verbindung zur Google‑API fehlgeschlagen. Dies ist möglicherweise ein vorübergehendes Problem – bitte versuche es später erneut.",
+      "invalid_json": "Ungültiges JSON-Format im Inhalt der secrets.json.",
+      "no_devices": "Keine Geräte gefunden. Bitte stelle sicher, dass ‚Mein Gerät finden‘ in deinem Google-Konto aktiviert ist.",
+      "cannot_connect": "Verbindung zur Google-API fehlgeschlagen. Dies ist möglicherweise ein vorübergehendes Problem – bitte versuche es später erneut.",
       "choose_one": "Bitte gib genau eine Anmeldemethode an.",
       "required": "Dieses Feld ist erforderlich.",
       "unknown": "Unerwarteter Fehler."
@@ -67,55 +67,64 @@
         "description": "Was möchtest du konfigurieren?",
         "menu_options": {
           "credentials": "Anmeldedaten aktualisieren",
-          "settings": "Einstellungen ändern"
+          "settings": "Einstellungen ändern",
+          "visibility": "Gerätesichtbarkeit"
         }
       },
       "credentials": {
         "title": "Anmeldedaten aktualisieren (optional)",
-        "description": "Aktualisiere deine Anmeldedaten, ohne bestehende Werte preiszugeben. Gib genau eine Methode an:\n\n• Vollständigen Inhalt einer neuen **secrets.json** einfügen\n**oder**\n• Neuen **OAuth‑Token** und **Google‑E‑Mail** eingeben.\n\nFalls angegeben, werden die Anmeldedaten validiert und gespeichert. Die Integration wird neu geladen, ohne deine Entitätsnamen zu ändern.",
+        "description": "Aktualisiere deine Anmeldedaten, ohne bestehende Werte preiszugeben. Gib genau eine Methode an:\n\n• Vollständigen Inhalt einer neuen **secrets.json** einfügen\n**oder**\n• Neuen **OAuth-Token** und **Google-E-Mail** eingeben.\n\nFalls angegeben, werden die Anmeldedaten validiert und gespeichert. Die Integration wird neu geladen, ohne deine Entitätsnamen zu ändern.",
         "data": {
           "secrets_json": "Neue secrets.json (vollständiger Inhalt)",
-          "oauth_token": "Neuer OAuth‑Token",
-          "google_email": "Google‑E‑Mail",
+          "oauth_token": "Neuer OAuth-Token",
+          "google_email": "Google-E-Mail",
           "new_secrets_json": "Neue secrets.json (vollständiger Inhalt)",
-          "new_oauth_token": "Neuer OAuth‑Token",
-          "new_google_email": "Google‑E‑Mail"
+          "new_oauth_token": "Neuer OAuth-Token",
+          "new_google_email": "Google-E-Mail"
         }
       },
       "settings": {
         "title": "Optionen",
-        "description": "Einstellungen für die Ortung anpassen:\n• Positionsabfrage‑Intervall: Wie häufig Positionen abgefragt werden (60–3600 Sekunden).\n• Verzögerung zwischen Geräteabfragen: Abstand zwischen den Abfragen einzelner Geräte (1–60 Sekunden).\n• Mindestgenauigkeit: Positionen mit einer größeren Ungenauigkeit als dieser Wert werden ignoriert (25–500 Meter).\n• Bewegungsschwelle: Mindestbewegung, um eine Positionsaktualisierung auszulösen (10–200 Meter).\n\nGoogle‑Home‑Filter:\n• Aktivieren, um Ortungen durch Google‑Home‑Geräte der ‚Zuhause‘‑Zone zuzuordnen.\n• Schlüsselwörter unterstützen Teilübereinstimmungen (kommagetrennt).\n• Beispiel: ‚nest‘ passt zu ‚Küche Nest Mini‘.",
+        "description": "Einstellungen für die Ortung anpassen:\n• Positionsabfrage-Intervall: Wie häufig Positionen abgefragt werden (60–3600 Sekunden).\n• Verzögerung zwischen Geräteabfragen: Abstand zwischen den Abfragen einzelner Geräte (1–60 Sekunden).\n• Mindestgenauigkeit: Positionen mit einer größeren Ungenauigkeit als dieser Wert werden ignoriert (25–500 Meter).\n• Bewegungsschwelle: Mindestbewegung, um eine Positionsaktualisierung auszulösen (10–200 Meter).\n\nGoogle-Home-Filter:\n• Aktivieren, um Ortungen durch Google-Home-Geräte der ‚Zuhause‘-Zone zuzuordnen.\n• Schlüsselwörter unterstützen Teilübereinstimmungen (kommagetrennt).\n• Beispiel: ‚nest‘ passt zu ‚Küche Nest Mini‘.",
         "data": {
           "tracked_devices": "Verfolgte Geräte",
-          "location_poll_interval": "Positionsabfrage‑Intervall (s)",
+          "location_poll_interval": "Positionsabfrage-Intervall (s)",
           "device_poll_delay": "Verzögerung zwischen Geräteabfragen (s)",
           "min_accuracy_threshold": "Mindestgenauigkeit (m)",
           "movement_threshold": "Bewegungsschwelle (m)",
-          "google_home_filter_enabled": "Google‑Home‑Geräte filtern",
-          "google_home_filter_keywords": "Filter‑Schlüsselwörter (kommagetrennt)",
-          "enable_stats_entities": "Statistik‑Entitäten erstellen",
-          "map_view_token_expiration": "Ablauf von Kartenansicht‑Token aktivieren"
+          "google_home_filter_enabled": "Google-Home-Geräte filtern",
+          "google_home_filter_keywords": "Filter-Schlüsselwörter (kommagetrennt)",
+          "enable_stats_entities": "Statistik-Entitäten erstellen",
+          "map_view_token_expiration": "Ablauf von Kartenansicht-Token aktivieren"
         },
         "data_description": {
           "map_view_token_expiration": "Wenn aktiviert, laufen die Token für die Kartenansicht nach einer Woche ab. Wenn deaktiviert (Standard), laufen die Token nicht ab."
         }
+      },
+      "visibility": {
+        "title": "Gerätesichtbarkeit",
+        "description": "Stelle zuvor ignorierte Geräte wieder her, damit sie erneut sichtbar sind. Wähle ein oder mehrere Geräte aus und speichere.",
+        "data": {
+          "unignore_devices": "Geräte wiederherstellen"
+        }
       }
     },
     "error": {
-      "invalid_json": "Ungültiges JSON‑Format im Inhalt der secrets.json.",
+      "invalid_json": "Ungültiges JSON-Format im Inhalt der secrets.json.",
       "invalid": "Validierung fehlgeschlagen. Bitte überprüfe deine Eingabe.",
-      "cannot_connect": "Verbindung zur Google‑API fehlgeschlagen.",
+      "cannot_connect": "Verbindung zur Google-API fehlgeschlagen.",
       "choose_one": "Bitte gib genau eine Anmeldemethode an.",
       "required": "Dieses Feld ist erforderlich."
     },
     "abort": {
-      "reconfigure_successful": "Neukonfiguration erfolgreich."
+      "reconfigure_successful": "Neukonfiguration erfolgreich.",
+      "no_ignored_devices": "Es gibt keine ignorierten Geräte, die wiederhergestellt werden können."
     }
   },
   "services": {
     "locate_device": {
       "name": "Gerät orten",
-      "description": "Ermittelt die aktuelle Position eines Google‑Find‑My‑Geräts.",
+      "description": "Ermittelt die aktuelle Position eines Google-Find-My-Geräts.",
       "fields": {
         "device_id": {
           "name": "Gerät",
@@ -125,7 +134,7 @@
     },
     "play_sound": {
       "name": "Ton abspielen",
-      "description": "Spielt einen Ton auf einem Google‑Find‑My‑Gerät ab.",
+      "description": "Spielt einen Ton auf einem Google-Find-My-Gerät ab.",
       "fields": {
         "device_id": {
           "name": "Gerät",
@@ -134,8 +143,8 @@
       }
     },
     "refresh_device_urls": {
-      "name": "Geräte‑URLs aktualisieren",
-      "description": "Aktualisiert die Konfigurations‑URLs der Geräte, damit sie auf die integrierte Kartenansicht zeigen.",
+      "name": "Geräte-URLs aktualisieren",
+      "description": "Aktualisiert die Konfigurations-URLs der Geräte, damit sie auf die integrierte Kartenansicht zeigen.",
       "fields": {}
     },
     "locate_external": {
@@ -162,7 +171,7 @@
         },
         "device_ids": {
           "name": "Geräte (optional)",
-          "description": "Begrenzt den Vorgang auf bestimmte Geräte. Leer lassen, um alle Google‑Find‑My‑Geräte zu berücksichtigen."
+          "description": "Begrenzt den Vorgang auf bestimmte Geräte. Leer lassen, um alle Google-Find-My-Geräte zu berücksichtigen."
         }
       }
     }
@@ -189,13 +198,13 @@
         "name": "Übersprungene Duplikate"
       },
       "stat_background_updates": {
-        "name": "Hintergrund‑Aktualisierungen"
+        "name": "Hintergrund-Aktualisierungen"
       },
       "stat_polled_updates": {
         "name": "Abgefragte Aktualisierungen"
       },
       "stat_crowd_sourced_updates": {
-        "name": "Crowdsourcing‑Aktualisierungen"
+        "name": "Crowdsourcing-Aktualisierungen"
       },
       "stat_history_fallback_used": {
         "name": "Verwendete Verlaufsdaten"

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -26,9 +26,8 @@
       },
       "device_selection": {
         "title": "Geräte und Abfrageintervall",
-        "description": "Wähle die zu verfolgenden Geräte und konfiguriere die Abfrageparameter:\n• Positionsabfrage-Intervall: Wie oft ein neuer Abfragezyklus startet (60–3600 Sekunden)\n• Verzögerung zwischen Geräteabfragen: Abstand zwischen den Abfragen einzelner Geräte innerhalb eines Zyklus (1–60 Sekunden)\n\nDie Integration fragt die Geräte nacheinander ab und fordert für jedes Gerät mit der angegebenen Verzögerung Positionsdaten an.",
+        "description": "Neu erkannte Geräte erscheinen deaktiviert und können in den Geräteeinstellungen aktiviert werden. Konfiguriere hier die allgemeinen Abfrageparameter:\n• Positionsabfrage-Intervall: Wie oft ein neuer Abfragezyklus startet (60–3600 Sekunden)\n• Verzögerung zwischen Geräteabfragen: Abstand zwischen den Abfragen einzelner Geräte innerhalb eines Zyklus (1–60 Sekunden)",
         "data": {
-          "tracked_devices": "Verfolgte Geräte",
           "location_poll_interval": "Positionsabfrage-Intervall (s)",
           "device_poll_delay": "Verzögerung zwischen Geräteabfragen (s)",
           "min_accuracy_threshold": "Mindestgenauigkeit (m)",
@@ -87,7 +86,6 @@
         "title": "Optionen",
         "description": "Einstellungen für die Ortung anpassen:\n• Positionsabfrage-Intervall: Wie häufig Positionen abgefragt werden (60–3600 Sekunden)\n• Verzögerung zwischen Geräteabfragen: Abstand zwischen den Abfragen einzelner Geräte (1–60 Sekunden)\n• Mindestgenauigkeit: Positionen mit einer größeren Ungenauigkeit als dieser Wert werden ignoriert (25–500 Meter)\n• Bewegungsschwelle: Mindestbewegung, um eine Positionsaktualisierung auszulösen (10–200 Meter)\n\nGoogle-Home-Filter:\n• Aktivieren, um Ortungen durch Google-Home-Geräte der „Zuhause“-Zone zuzuordnen\n• Schlüsselwörter unterstützen Teilübereinstimmungen (kommagetrennt)\n• Beispiel: „nest“ passt zu „Küche Nest Mini“",
         "data": {
-          "tracked_devices": "Verfolgte Geräte",
           "location_poll_interval": "Positionsabfrage-Intervall (s)",
           "device_poll_delay": "Verzögerung zwischen Geräteabfragen (s)",
           "min_accuracy_threshold": "Mindestgenauigkeit (m)",

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -228,6 +228,9 @@
       },
       "stat_low_quality_dropped": {
         "name": "Verworfene Standorte (geringe Genauigkeit)"
+      },
+      "stat_non_significant_dropped": {
+        "name": "Unwesentliche Aktualisierungen verworfen"
       }
     }
   }

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -142,6 +142,16 @@
         }
       }
     },
+    "stop_sound": {
+      "name": "Ton stoppen",
+      "description": "Stoppt den Ton auf einem Google-Find-My-Gerät.",
+      "fields": {
+        "device_id": {
+          "name": "Gerät",
+          "description": "Wähle ein Gerät aus (oder übergib eine kanonische ID über die Entwicklerwerkzeuge)."
+        }
+      }
+    },
     "refresh_device_urls": {
       "name": "Geräte-URLs aktualisieren",
       "description": "Aktualisiert die Konfigurations-URLs der Geräte, damit sie auf die integrierte Kartenansicht zeigen.",

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -114,7 +114,8 @@
       "invalid": "Validierung fehlgeschlagen. Bitte überprüfe deine Eingabe.",
       "cannot_connect": "Verbindung zur Google-API fehlgeschlagen.",
       "choose_one": "Bitte gib genau eine Anmeldemethode an.",
-      "required": "Dieses Feld ist erforderlich."
+      "required": "Dieses Feld ist erforderlich.",
+      "invalid_token": "Ungültige Anmeldedaten (Token/E-Mail). Bitte prüfe Format und Inhalt."
     },
     "abort": {
       "reconfigure_successful": "Neukonfiguration erfolgreich.",

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -192,6 +192,9 @@
       "play_sound": {
         "name": "Ton abspielen"
       },
+      "stop_sound": {
+        "name": "Ton stoppen"
+      },
       "locate_device": {
         "name": "Jetzt orten"
       }

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -206,9 +206,6 @@
       "last_seen": {
         "name": "Zuletzt gesehen"
       },
-      "stat_skipped_duplicates": {
-        "name": "Übersprungene Duplikate"
-      },
       "stat_background_updates": {
         "name": "Hintergrund-Aktualisierungen"
       },

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -147,7 +147,7 @@
       "description": "Aktualisiert die Konfigurations-URLs der Geräte, damit sie auf die integrierte Kartenansicht zeigen.",
       "fields": {}
     },
-    "locate_external": {
+    "locate_device_external": {
       "name": "Gerät orten (extern)",
       "description": "Ortung über den externen Helfer; delegiert an die normale Ortung.",
       "fields": {

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -11,14 +11,14 @@
       },
       "secrets_json": {
         "title": "Methode 1: GoogleFindMyTools secrets.json",
-        "description": "Führe GoogleFindMyTools (Chrome) aus, um Authentifizierungs-Token zu erzeugen, und füge unten den vollständigen Inhalt der Datei Auth/secrets.json ein.\n\n{hint}",
+        "description": "Führe GoogleFindMyTools (Chrome) aus, um Authentifizierungs-Tokens zu erzeugen, und füge unten den vollständigen Inhalt der Datei Auth/secrets.json ein.",
         "data": {
           "secrets_json": "Inhalt der secrets.json"
         }
       },
       "individual_tokens": {
         "title": "Methode 2: Manueller OAuth-Token",
-        "description": "Gib deinen OAuth-Token und deine Google-E-Mail-Adresse aus dem manuellen Anmeldeprozess ein.\n\n{hint}",
+        "description": "Gib deinen OAuth-Token und deine Google-E-Mail-Adresse aus dem manuellen Anmeldeprozess ein.",
         "data": {
           "oauth_token": "OAuth-Token",
           "google_email": "Google-E-Mail-Adresse"
@@ -26,7 +26,7 @@
       },
       "device_selection": {
         "title": "Geräte und Abfrageintervall",
-        "description": "Wähle die zu verfolgenden Geräte und konfiguriere die Abfrageparameter:\n• Positionsabfrage-Intervall: Wie oft ein neuer Abfragezyklus startet (60–3600 Sekunden).\n• Verzögerung zwischen Geräteabfragen: Abstand zwischen den Abfragen einzelner Geräte innerhalb eines Zyklus (1–60 Sekunden).\n\nDie Integration fragt die Geräte nacheinander ab und fordert für jedes Gerät mit der angegebenen Verzögerung Positionsdaten an.",
+        "description": "Wähle die zu verfolgenden Geräte und konfiguriere die Abfrageparameter:\n• Positionsabfrage-Intervall: Wie oft ein neuer Abfragezyklus startet (60–3600 Sekunden)\n• Verzögerung zwischen Geräteabfragen: Abstand zwischen den Abfragen einzelner Geräte innerhalb eines Zyklus (1–60 Sekunden)\n\nDie Integration fragt die Geräte nacheinander ab und fordert für jedes Gerät mit der angegebenen Verzögerung Positionsdaten an.",
         "data": {
           "tracked_devices": "Verfolgte Geräte",
           "location_poll_interval": "Positionsabfrage-Intervall (s)",
@@ -36,19 +36,19 @@
           "google_home_filter_enabled": "Google-Home-Geräte filtern",
           "google_home_filter_keywords": "Filter-Schlüsselwörter (kommagetrennt)",
           "enable_stats_entities": "Statistik-Entitäten erstellen",
-          "map_view_token_expiration": "Ablauf von Kartenansicht-Token aktivieren"
+          "map_view_token_expiration": "Ablauf von Kartenansicht-Tokens aktivieren"
         }
       },
       "reauth_confirm": {
         "title": "Erneute Authentifizierung",
-        "description": "{reason}\n\nTipp: Du kannst entweder den vollständigen Inhalt einer neuen secrets.json einfügen **oder** einen neuen OAuth-Token und deine E-Mail-Adresse angeben."
+        "description": "Deine Anmeldedaten sind ungültig oder abgelaufen. Bitte gib unten neue Anmeldedaten ein.\n\nTipp: Du kannst entweder den vollständigen Inhalt einer neuen secrets.json einfügen **oder** einen neuen OAuth-Token und deine E-Mail-Adresse angeben."
       }
     },
     "error": {
       "auth_failed": "Authentifizierung fehlgeschlagen. Bitte versuche es erneut.",
-      "invalid_token": "Ungültiger Token oder erforderliche Felder fehlen.",
+      "invalid_token": "Ungültige E-Mail/Token oder erforderliche Felder fehlen.",
       "invalid_json": "Ungültiges JSON-Format im Inhalt der secrets.json.",
-      "no_devices": "Keine Geräte gefunden. Bitte stelle sicher, dass ‚Mein Gerät finden‘ in deinem Google-Konto aktiviert ist.",
+      "no_devices": "Keine Geräte gefunden. Bitte stelle sicher, dass „Mein Gerät finden“ in deinem Google-Konto aktiviert ist.",
       "cannot_connect": "Verbindung zur Google-API fehlgeschlagen. Dies ist möglicherweise ein vorübergehendes Problem – bitte versuche es später erneut.",
       "choose_one": "Bitte gib genau eine Anmeldemethode an.",
       "required": "Dieses Feld ist erforderlich.",
@@ -73,7 +73,7 @@
       },
       "credentials": {
         "title": "Anmeldedaten aktualisieren (optional)",
-        "description": "{hint}\n\nAktualisiere deine Anmeldedaten, ohne bestehende Werte preiszugeben. Gib genau eine Methode an:\n\n• Vollständigen Inhalt einer neuen **secrets.json** einfügen\n**oder**\n• Neuen **OAuth-Token** und **Google-E-Mail** eingeben.\n\nFalls angegeben, werden die Anmeldedaten validiert und gespeichert. Die Integration wird neu geladen, ohne deine Entitätsnamen zu ändern.",
+        "description": "Aktualisiere deine Anmeldedaten, ohne bestehende Werte preiszugeben. Gib genau eine Methode an:\n\n• Vollständigen Inhalt einer neuen **secrets.json** einfügen\n**oder**\n• Neuen **OAuth-Token** und **Google-E-Mail** eingeben.\n\nFalls angegeben, werden die Anmeldedaten validiert und gespeichert. Die Integration wird neu geladen, ohne deine Entitätsnamen zu ändern.",
         "data": {
           "secrets_json": "Neue secrets.json (vollständiger Inhalt)",
           "oauth_token": "Neuer OAuth-Token",
@@ -85,7 +85,7 @@
       },
       "settings": {
         "title": "Optionen",
-        "description": "Einstellungen für die Ortung anpassen:\n• Positionsabfrage-Intervall: Wie häufig Positionen abgefragt werden (60–3600 Sekunden).\n• Verzögerung zwischen Geräteabfragen: Abstand zwischen den Abfragen einzelner Geräte (1–60 Sekunden).\n• Mindestgenauigkeit: Positionen mit einer größeren Ungenauigkeit als dieser Wert werden ignoriert (25–500 Meter).\n• Bewegungsschwelle: Mindestbewegung, um eine Positionsaktualisierung auszulösen (10–200 Meter).\n\nGoogle-Home-Filter:\n• Aktivieren, um Ortungen durch Google-Home-Geräte der ‚Zuhause‘-Zone zuzuordnen.\n• Schlüsselwörter unterstützen Teilübereinstimmungen (kommagetrennt).\n• Beispiel: ‚nest‘ passt zu ‚Küche Nest Mini‘.",
+        "description": "Einstellungen für die Ortung anpassen:\n• Positionsabfrage-Intervall: Wie häufig Positionen abgefragt werden (60–3600 Sekunden)\n• Verzögerung zwischen Geräteabfragen: Abstand zwischen den Abfragen einzelner Geräte (1–60 Sekunden)\n• Mindestgenauigkeit: Positionen mit einer größeren Ungenauigkeit als dieser Wert werden ignoriert (25–500 Meter)\n• Bewegungsschwelle: Mindestbewegung, um eine Positionsaktualisierung auszulösen (10–200 Meter)\n\nGoogle-Home-Filter:\n• Aktivieren, um Ortungen durch Google-Home-Geräte der „Zuhause“-Zone zuzuordnen\n• Schlüsselwörter unterstützen Teilübereinstimmungen (kommagetrennt)\n• Beispiel: „nest“ passt zu „Küche Nest Mini“",
         "data": {
           "tracked_devices": "Verfolgte Geräte",
           "location_poll_interval": "Positionsabfrage-Intervall (s)",
@@ -95,10 +95,10 @@
           "google_home_filter_enabled": "Google-Home-Geräte filtern",
           "google_home_filter_keywords": "Filter-Schlüsselwörter (kommagetrennt)",
           "enable_stats_entities": "Statistik-Entitäten erstellen",
-          "map_view_token_expiration": "Ablauf von Kartenansicht-Token aktivieren"
+          "map_view_token_expiration": "Ablauf von Kartenansicht-Tokens aktivieren"
         },
         "data_description": {
-          "map_view_token_expiration": "Wenn aktiviert, laufen die Token für die Kartenansicht nach einer Woche ab. Wenn deaktiviert (Standard), laufen die Token nicht ab."
+          "map_view_token_expiration": "Wenn aktiviert, laufen die Token für die Kartenansicht nach 1 Woche ab. Wenn deaktiviert (Standard), laufen die Token nicht ab."
         }
       },
       "visibility": {
@@ -177,7 +177,7 @@
       "fields": {
         "mode": {
           "name": "Modus",
-          "description": "‚Rebuild‘ entfernt Entitäten/Geräte und lädt neu; ‚Migrate‘ wendet nur die Übertragung der Einstellungen an."
+          "description": "„Rebuild“ entfernt Entitäten/Geräte und lädt neu; „Migrate“ wendet nur die Übertragung der Einstellungen an."
         },
         "device_ids": {
           "name": "Geräte (optional)",

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -41,12 +41,12 @@
       },
       "reauth_confirm": {
         "title": "Reauthenticate",
-        "description": "Your credentials are invalid or expired. Please provide new credentials below.\n\nTip: You can either paste the full contents of a fresh secrets.json **or** supply a new OAuth token and email."
+        "description": "Your credentials appear to be invalid or expired. Please provide new credentials below.\n\nTip: You can either paste the full contents of a fresh secrets.json **or** supply a new OAuth token and email."
       }
     },
     "error": {
       "auth_failed": "Authentication failed. Please try again.",
-      "invalid_token": "Invalid email/token or required fields are missing.",
+      "invalid_token": "Invalid token/email provided or required fields are missing.",
       "invalid_json": "Invalid JSON format in secrets.json content.",
       "no_devices": "No devices found. Please ensure that Find My Device is enabled on your Google account.",
       "cannot_connect": "Failed to connect to the Google API. This may be temporary — please try again later.",
@@ -114,7 +114,8 @@
       "invalid": "Validation failed. Please check your input.",
       "cannot_connect": "Failed to connect to the Google API.",
       "choose_one": "Please provide exactly one credential method.",
-      "required": "This field is required."
+      "required": "This field is required.",
+      "invalid_token": "Invalid credentials (token/email). Please check format and content."
     },
     "abort": {
       "reconfigure_successful": "Reconfiguration successful.",

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -67,7 +67,8 @@
         "description": "What would you like to configure?",
         "menu_options": {
           "credentials": "Update credentials",
-          "settings": "Modify settings"
+          "settings": "Modify settings",
+          "visibility": "Device visibility"
         }
       },
       "credentials": {
@@ -99,6 +100,13 @@
         "data_description": {
           "map_view_token_expiration": "When enabled, map view tokens expire after 1 week. When disabled (default), tokens do not expire."
         }
+      },
+      "visibility": {
+        "title": "Device visibility",
+        "description": "Restore previously ignored devices to make them visible again. Select one or more devices to restore and save.",
+        "data": {
+          "unignore_devices": "Restore devices"
+        }
       }
     },
     "error": {
@@ -109,7 +117,8 @@
       "required": "This field is required."
     },
     "abort": {
-      "reconfigure_successful": "Reconfiguration successful."
+      "reconfigure_successful": "Reconfiguration successful.",
+      "no_ignored_devices": "There are no ignored devices to restore."
     }
   },
   "services": {

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -102,10 +102,10 @@
         }
       },
       "visibility": {
-        "title": "Device visibility",
+        "title": "Device Visibility",
         "description": "Restore previously ignored devices to make them visible again. Select one or more devices to restore and save.",
         "data": {
-          "unignore_devices": "Restore devices"
+          "unignore_devices": "Devices to restore"
         }
       }
     },
@@ -163,7 +163,7 @@
     },
     "rebuild_registry": {
       "name": "Rebuild / Migrate Registry",
-      "description": "Maintenance: run a soft data→options migration or rebuild entities/devices for this integration.",
+      "description": "Maintenance: Run a soft data→options migration or rebuild entities/devices for this integration.",
       "fields": {
         "mode": {
           "name": "Mode",

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -147,7 +147,7 @@
       "description": "Refresh the configuration URLs for Google Find My devices to point to the integrated map view.",
       "fields": {}
     },
-    "locate_external": {
+    "locate_device_external": {
       "name": "Locate Device (External)",
       "description": "Locate a device using the external helper; delegates to the normal locate operation.",
       "fields": {

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -11,14 +11,14 @@
       },
       "secrets_json": {
         "title": "Method 1: GoogleFindMyTools secrets.json",
-        "description": "Run GoogleFindMyTools (Chrome) to generate authentication tokens, then paste the full contents of the Auth/secrets.json file below.",
+        "description": "Run GoogleFindMyTools (Chrome) to generate authentication tokens, then paste the full contents of the Auth/secrets.json file below.\n\n{hint}",
         "data": {
           "secrets_json": "Contents of secrets.json file"
         }
       },
       "individual_tokens": {
         "title": "Method 2: Individual OAuth Token",
-        "description": "Enter your OAuth token and Google email address obtained from a manual authentication process.",
+        "description": "Enter your OAuth token and Google email address obtained from a manual authentication process.\n\n{hint}",
         "data": {
           "oauth_token": "OAuth Token",
           "google_email": "Google Email Address"
@@ -41,7 +41,7 @@
       },
       "reauth_confirm": {
         "title": "Reauthenticate",
-        "description": "Your credentials appear to be invalid or expired. Please provide new credentials below.\n\nTip: You can either paste the full contents of a fresh secrets.json **or** supply a new OAuth token and email."
+        "description": "{reason}\n\nTip: You can either paste the full contents of a fresh secrets.json **or** supply a new OAuth token and email."
       }
     },
     "error": {
@@ -73,7 +73,7 @@
       },
       "credentials": {
         "title": "Update Credentials (optional)",
-        "description": "Update credentials without exposing existing values. Provide exactly one method:\n\n• Paste full contents of a new **secrets.json**\n**or**\n• Enter a new **OAuth token** and **Google email**.\n\nIf provided, credentials will be validated and stored; the integration will reload without changing your entity names.",
+        "description": "{hint}\n\nUpdate credentials without exposing existing values. Provide exactly one method:\n\n• Paste full contents of a new **secrets.json**\n**or**\n• Enter a new **OAuth token** and **Google email**.\n\nIf provided, credentials will be validated and stored; the integration will reload without changing your entity names.",
         "data": {
           "secrets_json": "New secrets.json (full contents)",
           "oauth_token": "New OAuth token",

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -228,6 +228,9 @@
       },
       "stat_low_quality_dropped": {
         "name": "Low-accuracy dropped"
+      },
+      "stat_non_significant_dropped": {
+        "name": "Non-significant updates dropped"
       }
     }
   }

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -26,9 +26,8 @@
       },
       "device_selection": {
         "title": "Select Devices and Polling",
-        "description": "Select the devices to track and configure the polling parameters:\n• Location poll interval: How often to start a new polling cycle (60–3600 seconds)\n• Device poll delay: Delay between individual device polls within a cycle (1–60 seconds)\n\nThe integration cycles through devices sequentially, requesting location data for each device with the specified delay.",
+        "description": "Newly discovered devices appear disabled and can be enabled in device settings. Configure the general polling parameters:\n• Location poll interval: How often to start a new polling cycle (60–3600 seconds)\n• Device poll delay: Delay between individual device polls within a cycle (1–60 seconds)",
         "data": {
-          "tracked_devices": "Tracked devices",
           "location_poll_interval": "Location poll interval (s)",
           "device_poll_delay": "Device poll delay (s)",
           "min_accuracy_threshold": "Minimum accuracy (m)",
@@ -85,9 +84,8 @@
       },
       "settings": {
         "title": "Options",
-        "description": "Modify tracking settings:\n• Location poll interval: How often to poll for locations (60–3600 seconds)\n• Device poll delay: Delay between device polls (1–60 seconds)\n• Min accuracy threshold: Ignore locations worse than this (25–500 meters)\n• Movement threshold: Minimum movement to trigger a location update (10–200 meters)\n\nGoogle Home Filter:\n• Enable to group Google Home detections into the Home zone\n• Keywords support partial matching (comma-separated)\n• Example: 'nest' matches 'Kitchen Nest Mini'",
+        "description": "Adjust location settings:\n• Location poll interval: How often to poll for locations (60–3600 seconds)\n• Device poll delay: Delay between device polls (1–60 seconds)\n• Minimum accuracy: Ignore locations with an accuracy worse than this value (25–500 meters)\n• Movement threshold: Minimum movement required to trigger a location update (10–200 meters)\n\nGoogle Home Filter:\n• Enable to associate detections from Google Home devices with the Home zone\n• Keywords support partial matching (comma-separated)\n• Example: “nest” matches “Kitchen Nest Mini”",
         "data": {
-          "tracked_devices": "Tracked devices",
           "location_poll_interval": "Location poll interval (s)",
           "device_poll_delay": "Device poll delay (s)",
           "min_accuracy_threshold": "Minimum accuracy (m)",

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -192,6 +192,9 @@
       "play_sound": {
         "name": "Play sound"
       },
+      "stop_sound": {
+        "name": "Stop sound"
+      },
       "locate_device": {
         "name": "Locate now"
       }

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -11,14 +11,14 @@
       },
       "secrets_json": {
         "title": "Method 1: GoogleFindMyTools secrets.json",
-        "description": "Run GoogleFindMyTools (Chrome) to generate authentication tokens, then paste the full contents of the Auth/secrets.json file below.\n\n{hint}",
+        "description": "Run GoogleFindMyTools (Chrome) to generate authentication tokens, then paste the full contents of the Auth/secrets.json file below.",
         "data": {
           "secrets_json": "Contents of secrets.json file"
         }
       },
       "individual_tokens": {
         "title": "Method 2: Individual OAuth Token",
-        "description": "Enter your OAuth token and Google email address obtained from a manual authentication process.\n\n{hint}",
+        "description": "Enter your OAuth token and Google email address obtained from a manual authentication process.",
         "data": {
           "oauth_token": "OAuth Token",
           "google_email": "Google Email Address"
@@ -41,12 +41,12 @@
       },
       "reauth_confirm": {
         "title": "Reauthenticate",
-        "description": "{reason}\n\nTip: You can either paste the full contents of a fresh secrets.json **or** supply a new OAuth token and email."
+        "description": "Your credentials are invalid or expired. Please provide new credentials below.\n\nTip: You can either paste the full contents of a fresh secrets.json **or** supply a new OAuth token and email."
       }
     },
     "error": {
       "auth_failed": "Authentication failed. Please try again.",
-      "invalid_token": "Invalid token provided or required fields are missing.",
+      "invalid_token": "Invalid email/token or required fields are missing.",
       "invalid_json": "Invalid JSON format in secrets.json content.",
       "no_devices": "No devices found. Please ensure that Find My Device is enabled on your Google account.",
       "cannot_connect": "Failed to connect to the Google API. This may be temporary — please try again later.",
@@ -73,7 +73,7 @@
       },
       "credentials": {
         "title": "Update Credentials (optional)",
-        "description": "{hint}\n\nUpdate credentials without exposing existing values. Provide exactly one method:\n\n• Paste full contents of a new **secrets.json**\n**or**\n• Enter a new **OAuth token** and **Google email**.\n\nIf provided, credentials will be validated and stored; the integration will reload without changing your entity names.",
+        "description": "Update credentials without exposing existing values. Provide exactly one method:\n\n• Paste full contents of a new **secrets.json**\n**or**\n• Enter a new **OAuth token** and **Google email**.\n\nIf provided, credentials will be validated and stored; the integration will reload without changing your entity names.",
         "data": {
           "secrets_json": "New secrets.json (full contents)",
           "oauth_token": "New OAuth token",

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -142,6 +142,16 @@
         }
       }
     },
+    "stop_sound": {
+      "name": "Stop Sound",
+      "description": "Stop the sound on a Google Find My device.",
+      "fields": {
+        "device_id": {
+          "name": "Device",
+          "description": "Select a Google Find My device (or pass a canonical ID via Developer Tools)."
+        }
+      }
+    },
     "refresh_device_urls": {
       "name": "Refresh Device URLs",
       "description": "Refresh the configuration URLs for Google Find My devices to point to the integrated map view.",

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -206,9 +206,6 @@
       "last_seen": {
         "name": "Last Seen"
       },
-      "stat_skipped_duplicates": {
-        "name": "Skipped duplicates"
-      },
       "stat_background_updates": {
         "name": "Background updates"
       },

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -11,14 +11,14 @@
       },
       "secrets_json": {
         "title": "Método 1: GoogleFindMyTools secrets.json",
-        "description": "Ejecuta GoogleFindMyTools (Chrome) para generar los tokens de autenticación y pega a continuación el contenido completo del archivo Auth/secrets.json.",
+        "description": "Ejecuta GoogleFindMyTools (Chrome) para generar los tokens de autenticación y pega a continuación el contenido completo del archivo Auth/secrets.json.\n\n{hint}",
         "data": {
           "secrets_json": "Contenido del archivo secrets.json"
         }
       },
       "individual_tokens": {
         "title": "Método 2: Token OAuth individual",
-        "description": "Introduce tu token OAuth y tu dirección de correo de Google obtenidos mediante un proceso de autenticación manual.",
+        "description": "Introduce tu token OAuth y tu dirección de correo de Google obtenidos mediante un proceso de autenticación manual.\n\n{hint}",
         "data": {
           "oauth_token": "Token OAuth",
           "google_email": "Dirección de correo de Google"
@@ -41,7 +41,7 @@
       },
       "reauth_confirm": {
         "title": "Volver a autenticar",
-        "description": "Tus credenciales parecen no ser válidas o han caducado. Proporciona nuevas credenciales a continuación.\n\nConsejo: puedes pegar el contenido completo de un secrets.json reciente **o** facilitar un nuevo token OAuth y correo electrónico."
+        "description": "{reason}\n\nConsejo: puedes pegar el contenido completo de un secrets.json reciente **o** facilitar un nuevo token OAuth y correo electrónico."
       }
     },
     "error": {
@@ -73,7 +73,7 @@
       },
       "credentials": {
         "title": "Actualizar credenciales (opcional)",
-        "description": "Actualiza credenciales sin exponer los valores existentes. Proporciona exactamente un método:\n\n• Pega el contenido completo de un **secrets.json** nuevo\n**o**\n• Introduce un **token OAuth** nuevo y **correo de Google**.\n\nSi se proporcionan, las credenciales se validarán y guardarán; la integración se recargará sin cambiar los nombres de tus entidades.",
+        "description": "{hint}\n\nActualiza credenciales sin exponer los valores existentes. Proporciona exactamente un método:\n\n• Pega el contenido completo de un **secrets.json** nuevo\n**o**\n• Introduce un **token OAuth** nuevo y **correo de Google**.\n\nSi se proporcionan, las credenciales se validarán y guardarán; la integración se recargará sin cambiar los nombres de tus entidades.",
         "data": {
           "secrets_json": "Nuevo secrets.json (contenido completo)",
           "oauth_token": "Nuevo token OAuth",

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -192,6 +192,9 @@
       "play_sound": {
         "name": "Reproducir sonido"
       },
+      "stop_sound": {
+        "name": "Detener sonido"
+      },
       "locate_device": {
         "name": "Localizar ahora"
       }

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -206,9 +206,6 @@
       "last_seen": {
         "name": "Visto por última vez"
       },
-      "stat_skipped_duplicates": {
-        "name": "Duplicados omitidos"
-      },
       "stat_background_updates": {
         "name": "Actualizaciones en segundo plano"
       },

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -26,9 +26,8 @@
       },
       "device_selection": {
         "title": "Selección de dispositivos y sondeo",
-        "description": "Selecciona los dispositivos a seguir y configura los parámetros de sondeo:\n• Intervalo de sondeo de ubicación: con qué frecuencia iniciar un nuevo ciclo (60–3600 segundos)\n• Retardo entre sondeos de dispositivos: intervalo entre las consultas de cada dispositivo dentro de un ciclo (1–60 segundos)\n\nLa integración recorre los dispositivos de forma secuencial y solicita datos de ubicación para cada uno con el retardo indicado.",
+        "description": "Los dispositivos descubiertos recientemente aparecen desactivados y se pueden activar en la configuración del dispositivo. Configura aquí los parámetros generales de sondeo:\n• Intervalo de sondeo de ubicación: con qué frecuencia iniciar un nuevo ciclo de sondeo (60–3600 segundos)\n• Retardo entre sondeos de dispositivos: intervalo entre las consultas de cada dispositivo dentro de un ciclo (1–60 segundos)",
         "data": {
-          "tracked_devices": "Dispositivos seguidos",
           "location_poll_interval": "Intervalo de sondeo de ubicación (s)",
           "device_poll_delay": "Retardo entre sondeos de dispositivos (s)",
           "min_accuracy_threshold": "Precisión mínima (m)",
@@ -85,9 +84,8 @@
       },
       "settings": {
         "title": "Opciones",
-        "description": "Modificar la configuración de seguimiento:\n• Intervalo de sondeo de ubicación: frecuencia de consulta de ubicaciones (60–3600 segundos)\n• Retardo entre sondeos de dispositivos: intervalo entre consultas por dispositivo (1–60 segundos)\n• Precisión mínima: ignorar ubicaciones peores que este valor (25–500 metros)\n• Umbral de movimiento: movimiento mínimo que desencadena una actualización de ubicación (10–200 metros)\n\nFiltro de Google Home:\n• Activar para agrupar las detecciones de Google Home en la zona ‘Hogar’\n• Las palabras clave aceptan coincidencias parciales (separadas por comas)\n• Ejemplo: ‘nest’ coincide con ‘Kitchen Nest Mini’",
+        "description": "Ajustar la configuración de localización:\n• Intervalo de sondeo de ubicación: frecuencia con la que se consultan ubicaciones (60–3600 segundos)\n• Retardo entre sondeos de dispositivos: intervalo entre consultas por dispositivo (1–60 segundos)\n• Precisión mínima: ignorar ubicaciones peores que este valor (25–500 metros)\n• Umbral de movimiento: movimiento mínimo necesario para activar una actualización de ubicación (10–200 metros)\n\nFiltro de Google Home:\n• Activar para asociar las detecciones de Google Home con la zona «Hogar»\n• Las palabras clave admiten coincidencias parciales (separadas por comas)\n• Ejemplo: «nest» coincide con «Kitchen Nest Mini»",
         "data": {
-          "tracked_devices": "Dispositivos seguidos",
           "location_poll_interval": "Intervalo de sondeo de ubicación (s)",
           "device_poll_delay": "Retardo entre sondeos de dispositivos (s)",
           "min_accuracy_threshold": "Precisión mínima (m)",

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -142,6 +142,16 @@
         }
       }
     },
+    "stop_sound": {
+      "name": "Detener sonido",
+      "description": "Detiene el sonido en un dispositivo de Google Find My.",
+      "fields": {
+        "device_id": {
+          "name": "Dispositivo",
+          "description": "Selecciona un dispositivo de Google Find My (o pasa un ID canónico desde Herramientas para desarrolladores)."
+        }
+      }
+    },
     "refresh_device_urls": {
       "name": "Actualizar URL de los dispositivos",
       "description": "Actualiza las URL de configuración de los dispositivos de Google Find My para que apunten a la vista de mapa integrada.",

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -67,7 +67,8 @@
         "description": "¿Qué te gustaría configurar?",
         "menu_options": {
           "credentials": "Actualizar credenciales",
-          "settings": "Modificar ajustes"
+          "settings": "Modificar ajustes",
+          "visibility": "Visibilidad de dispositivos"
         }
       },
       "credentials": {
@@ -99,6 +100,13 @@
         "data_description": {
           "map_view_token_expiration": "Si está activado, los tokens de la vista de mapa caducan tras 1 semana. Si está desactivado (por defecto), no caducan."
         }
+      },
+      "visibility": {
+        "title": "Visibilidad de dispositivos",
+        "description": "Restaura dispositivos previamente ignorados para que vuelvan a ser visibles. Selecciona uno o varios dispositivos y guarda.",
+        "data": {
+          "unignore_devices": "Restaurar dispositivos"
+        }
       }
     },
     "error": {
@@ -109,7 +117,8 @@
       "required": "Este campo es obligatorio."
     },
     "abort": {
-      "reconfigure_successful": "Reconfiguración correcta."
+      "reconfigure_successful": "Reconfiguración correcta.",
+      "no_ignored_devices": "No hay dispositivos ignorados para restaurar."
     }
   },
   "services": {
@@ -138,9 +147,9 @@
       "description": "Actualiza las URL de configuración de los dispositivos de Google Find My para que apunten a la vista de mapa integrada.",
       "fields": {}
     },
-    "locate_external": {
+    "locate_device_external": {
       "name": "Localizar dispositivo (externo)",
-      "description": "Localiza un dispositivo usando el servicio externo (delegado a la localización normal).",
+      "description": "Localiza un dispositivo usando el asistente externo; delega en la localización normal.",
       "fields": {
         "device_id": {
           "name": "Dispositivo",

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -228,6 +228,9 @@
       },
       "stat_low_quality_dropped": {
         "name": "Lecturas de baja precisión descartadas"
+      },
+      "stat_non_significant_dropped": {
+        "name": "Actualizaciones no significativas descartadas"
       }
     }
   }

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -46,7 +46,7 @@
     },
     "error": {
       "auth_failed": "Error de autenticación. Vuelve a intentarlo.",
-      "invalid_token": "Correo electrónico/token no válido o faltan campos obligatorios.",
+      "invalid_token": "Credenciales no válidas (token/correo) o faltan campos obligatorios.",
       "invalid_json": "Formato JSON no válido en el contenido de secrets.json.",
       "no_devices": "No se han encontrado dispositivos. Asegúrate de que ‘Encontrar mi dispositivo’ esté activado en tu cuenta de Google.",
       "cannot_connect": "No se pudo conectar con la API de Google. Puede ser un problema temporal: inténtalo de nuevo más tarde.",
@@ -114,7 +114,8 @@
       "invalid": "Falló la validación. Revisa tus datos.",
       "cannot_connect": "No se pudo conectar con la API de Google.",
       "choose_one": "Proporciona exactamente un método de credenciales.",
-      "required": "Este campo es obligatorio."
+      "required": "Este campo es obligatorio.",
+      "invalid_token": "Credenciales no válidas (token/correo). Comprueba el formato y el contenido."
     },
     "abort": {
       "reconfigure_successful": "Reconfiguración correcta.",

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -11,14 +11,14 @@
       },
       "secrets_json": {
         "title": "Método 1: GoogleFindMyTools secrets.json",
-        "description": "Ejecuta GoogleFindMyTools (Chrome) para generar los tokens de autenticación y pega a continuación el contenido completo del archivo Auth/secrets.json.\n\n{hint}",
+        "description": "Ejecuta GoogleFindMyTools (Chrome) para generar los tokens de autenticación y pega a continuación el contenido completo del archivo Auth/secrets.json.",
         "data": {
           "secrets_json": "Contenido del archivo secrets.json"
         }
       },
       "individual_tokens": {
         "title": "Método 2: Token OAuth individual",
-        "description": "Introduce tu token OAuth y tu dirección de correo de Google obtenidos mediante un proceso de autenticación manual.\n\n{hint}",
+        "description": "Introduce tu token OAuth y tu dirección de correo de Google obtenidos mediante un proceso de autenticación manual.",
         "data": {
           "oauth_token": "Token OAuth",
           "google_email": "Dirección de correo de Google"
@@ -41,12 +41,12 @@
       },
       "reauth_confirm": {
         "title": "Volver a autenticar",
-        "description": "{reason}\n\nConsejo: puedes pegar el contenido completo de un secrets.json reciente **o** facilitar un nuevo token OAuth y correo electrónico."
+        "description": "Tus credenciales parecen no ser válidas o han caducado. Proporciona nuevas credenciales a continuación.\n\nConsejo: puedes pegar el contenido completo de un secrets.json reciente **o** facilitar un nuevo token OAuth y correo electrónico."
       }
     },
     "error": {
       "auth_failed": "Error de autenticación. Vuelve a intentarlo.",
-      "invalid_token": "Token no válido o faltan campos obligatorios.",
+      "invalid_token": "Correo electrónico/token no válido o faltan campos obligatorios.",
       "invalid_json": "Formato JSON no válido en el contenido de secrets.json.",
       "no_devices": "No se han encontrado dispositivos. Asegúrate de que ‘Encontrar mi dispositivo’ esté activado en tu cuenta de Google.",
       "cannot_connect": "No se pudo conectar con la API de Google. Puede ser un problema temporal: inténtalo de nuevo más tarde.",
@@ -73,7 +73,7 @@
       },
       "credentials": {
         "title": "Actualizar credenciales (opcional)",
-        "description": "{hint}\n\nActualiza credenciales sin exponer los valores existentes. Proporciona exactamente un método:\n\n• Pega el contenido completo de un **secrets.json** nuevo\n**o**\n• Introduce un **token OAuth** nuevo y **correo de Google**.\n\nSi se proporcionan, las credenciales se validarán y guardarán; la integración se recargará sin cambiar los nombres de tus entidades.",
+        "description": "Actualiza credenciales sin exponer los valores existentes. Proporciona exactamente un método:\n\n• Pega el contenido completo de un **secrets.json** nuevo\n**o**\n• Introduce un **token OAuth** nuevo y **correo de Google**.\n\nSi se proporcionan, las credenciales se validarán y guardarán; la integración se recargará sin cambiar los nombres de tus entidades.",
         "data": {
           "secrets_json": "Nuevo secrets.json (contenido completo)",
           "oauth_token": "Nuevo token OAuth",

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -206,9 +206,6 @@
       "last_seen": {
         "name": "Vu pour la dernière fois"
       },
-      "stat_skipped_duplicates": {
-        "name": "Doublons ignorés"
-      },
       "stat_background_updates": {
         "name": "Mises à jour en arrière-plan"
       },

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -192,6 +192,9 @@
       "play_sound": {
         "name": "Émettre un son"
       },
+      "stop_sound": {
+        "name": "Arrêter le son"
+      },
       "locate_device": {
         "name": "Localiser maintenant"
       }

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -67,7 +67,8 @@
         "description": "Que souhaitez-vous configurer ?",
         "menu_options": {
           "credentials": "Mettre à jour les identifiants",
-          "settings": "Modifier les paramètres"
+          "settings": "Modifier les paramètres",
+          "visibility": "Visibilité des appareils"
         }
       },
       "credentials": {
@@ -99,6 +100,13 @@
         "data_description": {
           "map_view_token_expiration": "Lorsqu’elle est activée, les jetons de la vue carte expirent après 1 semaine. Lorsqu’elle est désactivée (par défaut), ils n’expirent pas."
         }
+      },
+      "visibility": {
+        "title": "Visibilité des appareils",
+        "description": "Restaurez des appareils précédemment ignorés pour les rendre à nouveau visibles. Sélectionnez un ou plusieurs appareils puis enregistrez.",
+        "data": {
+          "unignore_devices": "Restaurer des appareils"
+        }
       }
     },
     "error": {
@@ -109,7 +117,8 @@
       "required": "Ce champ est obligatoire."
     },
     "abort": {
-      "reconfigure_successful": "Reconfiguration réussie."
+      "reconfigure_successful": "Reconfiguration réussie.",
+      "no_ignored_devices": "Aucun appareil ignoré à restaurer."
     }
   },
   "services": {
@@ -138,9 +147,9 @@
       "description": "Actualise les URL de configuration des appareils Google Find My pour qu’elles pointent vers la vue carte intégrée.",
       "fields": {}
     },
-    "locate_external": {
+    "locate_device_external": {
       "name": "Localiser l’appareil (externe)",
-      "description": "Localiser un appareil en utilisant le service externe (délègue à la localisation normale).",
+      "description": "Localiser un appareil à l’aide de l’assistant externe ; délègue à la localisation normale.",
       "fields": {
         "device_id": {
           "name": "Appareil",

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -41,12 +41,12 @@
       },
       "reauth_confirm": {
         "title": "Se réauthentifier",
-        "description": "Vos identifiants sont invalides ou ont expiré. Veuillez fournir de nouveaux identifiants ci-dessous.\n\nAstuce : vous pouvez coller le contenu complet d’un secrets.json récent **ou** fournir un nouveau jeton OAuth et une adresse e-mail."
+        "description": "Vos identifiants semblent invalides ou ont expiré. Veuillez fournir de nouveaux identifiants ci-dessous.\n\nAstuce : vous pouvez soit coller le contenu complet d’un secrets.json récent **ou** fournir un nouveau jeton OAuth et une adresse e-mail."
       }
     },
     "error": {
       "auth_failed": "Échec de l’authentification. Veuillez réessayer.",
-      "invalid_token": "E-mail/jeton invalide ou champs requis manquants.",
+      "invalid_token": "Identifiants invalides (jeton/e-mail) ou champs requis manquants.",
       "invalid_json": "Format JSON invalide dans le contenu de secrets.json.",
       "no_devices": "Aucun appareil trouvé. Assurez-vous que « Localiser mon appareil » est activé sur votre compte Google.",
       "cannot_connect": "Échec de la connexion à l’API Google. Il peut s’agir d’un problème temporaire — réessayez plus tard.",
@@ -114,7 +114,8 @@
       "invalid": "Échec de la validation. Veuillez vérifier vos saisies.",
       "cannot_connect": "Échec de la connexion à l’API Google.",
       "choose_one": "Veuillez fournir exactement une méthode d’authentification.",
-      "required": "Ce champ est obligatoire."
+      "required": "Ce champ est obligatoire.",
+      "invalid_token": "Identifiants invalides (jeton/e-mail). Veuillez vérifier le format et le contenu."
     },
     "abort": {
       "reconfigure_successful": "Reconfiguration réussie.",

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -142,6 +142,16 @@
         }
       }
     },
+    "stop_sound": {
+      "name": "Arrêter le son",
+      "description": "Arrêter le son sur un appareil Google Find My.",
+      "fields": {
+        "device_id": {
+          "name": "Appareil",
+          "description": "Sélectionnez un appareil Google Find My (ou transmettez un ID canonique via les Outils de développement)."
+        }
+      }
+    },
     "refresh_device_urls": {
       "name": "Actualiser les URL des appareils",
       "description": "Actualise les URL de configuration des appareils Google Find My pour qu’elles pointent vers la vue carte intégrée.",

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -228,6 +228,9 @@
       },
       "stat_low_quality_dropped": {
         "name": "Positions à faible précision écartées"
+      },
+      "stat_non_significant_dropped": {
+        "name": "Mises à jour non significatives écartées"
       }
     }
   }

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -11,14 +11,14 @@
       },
       "secrets_json": {
         "title": "Méthode 1 : GoogleFindMyTools secrets.json",
-        "description": "Exécutez GoogleFindMyTools (Chrome) pour générer des jetons d’authentification, puis collez ci-dessous le contenu complet du fichier Auth/secrets.json.",
+        "description": "Exécutez GoogleFindMyTools (Chrome) pour générer des jetons d’authentification, puis collez ci-dessous le contenu complet du fichier Auth/secrets.json.\n\n{hint}",
         "data": {
           "secrets_json": "Contenu du fichier secrets.json"
         }
       },
       "individual_tokens": {
         "title": "Méthode 2 : Jeton OAuth individuel",
-        "description": "Saisissez votre jeton OAuth et votre adresse e-mail Google obtenus lors d’un processus d’authentification manuel.",
+        "description": "Saisissez votre jeton OAuth et votre adresse e-mail Google obtenus lors d’un processus d’authentification manuel.\n\n{hint}",
         "data": {
           "oauth_token": "Jeton OAuth",
           "google_email": "Adresse e-mail Google"
@@ -26,7 +26,7 @@
       },
       "device_selection": {
         "title": "Sélection des appareils et interrogation",
-        "description": "Sélectionnez les appareils à suivre et configurez les paramètres d’interrogation :\n• Intervalle d’interrogation de position : fréquence de démarrage d’un nouveau cycle (60–3600 secondes)\n• Délai entre les interrogations d’appareil : intervalle entre les requêtes pour chaque appareil au sein d’un cycle (1–60 secondes)\n\nL’intégration interroge les appareils de manière séquentielle et demande les données de position pour chaque appareil avec le délai spécifié.",
+        "description": "Sélectionnez les appareils à suivre et configurez les paramètres d’interrogation :\n• Intervalle d’interrogation de position : fréquence de démarrage d’un nouveau cycle (60–3600 secondes)\n• Délai entre les interrogations d’appareil : intervalle entre les requêtes par appareil dans un cycle (1–60 secondes)\n\nL’intégration interroge les appareils de manière séquentielle, en demandant la position de chaque appareil avec le délai spécifié.",
         "data": {
           "tracked_devices": "Appareils suivis",
           "location_poll_interval": "Intervalle d’interrogation de position (s)",
@@ -41,7 +41,7 @@
       },
       "reauth_confirm": {
         "title": "Se réauthentifier",
-        "description": "Vos identifiants semblent invalides ou ont expiré. Veuillez fournir de nouveaux identifiants ci-dessous.\n\nAstuce : vous pouvez soit coller le contenu complet d’un secrets.json récent **ou** fournir un nouveau jeton OAuth et une adresse e-mail."
+        "description": "{reason}\n\nAstuce : vous pouvez soit coller le contenu complet d’un secrets.json récent **ou** fournir un nouveau jeton OAuth et une adresse e-mail."
       }
     },
     "error": {
@@ -73,7 +73,7 @@
       },
       "credentials": {
         "title": "Mettre à jour les identifiants (optionnel)",
-        "description": "Mettez à jour les identifiants sans exposer les valeurs existantes. Fournissez exactement une méthode :\n\n• Coller le contenu complet d’un **secrets.json** neuf\n**ou**\n• Saisir un **jeton OAuth** neuf et une **adresse e-mail Google**.\n\nLe cas échéant, les identifiants seront validés et enregistrés ; l’intégration sera rechargée sans modifier les noms de vos entités.",
+        "description": "{hint}\n\nMettez à jour les identifiants sans exposer les valeurs existantes. Fournissez exactement une méthode :\n\n• Coller le contenu complet d’un **secrets.json** neuf\n**ou**\n• Saisir un **jeton OAuth** neuf et une **adresse e-mail Google**.\n\nLe cas échéant, les identifiants seront validés et enregistrés ; l’intégration sera rechargée sans modifier les noms de vos entités.",
         "data": {
           "secrets_json": "Nouveau secrets.json (contenu complet)",
           "oauth_token": "Nouveau jeton OAuth",

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -11,14 +11,14 @@
       },
       "secrets_json": {
         "title": "Méthode 1 : GoogleFindMyTools secrets.json",
-        "description": "Exécutez GoogleFindMyTools (Chrome) pour générer des jetons d’authentification, puis collez ci-dessous le contenu complet du fichier Auth/secrets.json.\n\n{hint}",
+        "description": "Exécutez GoogleFindMyTools (Chrome) pour générer des jetons d’authentification, puis collez ci-dessous le contenu complet du fichier Auth/secrets.json.",
         "data": {
           "secrets_json": "Contenu du fichier secrets.json"
         }
       },
       "individual_tokens": {
         "title": "Méthode 2 : Jeton OAuth individuel",
-        "description": "Saisissez votre jeton OAuth et votre adresse e-mail Google obtenus lors d’un processus d’authentification manuel.\n\n{hint}",
+        "description": "Saisissez votre jeton OAuth et votre adresse e-mail Google obtenus lors d’un processus d’authentification manuel.",
         "data": {
           "oauth_token": "Jeton OAuth",
           "google_email": "Adresse e-mail Google"
@@ -26,7 +26,7 @@
       },
       "device_selection": {
         "title": "Sélection des appareils et interrogation",
-        "description": "Sélectionnez les appareils à suivre et configurez les paramètres d’interrogation :\n• Intervalle d’interrogation de position : fréquence de démarrage d’un nouveau cycle (60–3600 secondes)\n• Délai entre les interrogations d’appareil : intervalle entre les requêtes par appareil dans un cycle (1–60 secondes)\n\nL’intégration interroge les appareils de manière séquentielle, en demandant la position de chaque appareil avec le délai spécifié.",
+        "description": "Sélectionnez les appareils à suivre et configurez les paramètres d’interrogation :\n• Intervalle d’interrogation de position : fréquence de démarrage d’un nouveau cycle (60–3600 secondes)\n• Délai entre les interrogations d’appareil : intervalle entre les requêtes pour chaque appareil au sein d’un cycle (1–60 secondes)\n\nL’intégration interroge les appareils de manière séquentielle et demande les données de position pour chaque appareil avec le délai spécifié.",
         "data": {
           "tracked_devices": "Appareils suivis",
           "location_poll_interval": "Intervalle d’interrogation de position (s)",
@@ -41,12 +41,12 @@
       },
       "reauth_confirm": {
         "title": "Se réauthentifier",
-        "description": "{reason}\n\nAstuce : vous pouvez soit coller le contenu complet d’un secrets.json récent **ou** fournir un nouveau jeton OAuth et une adresse e-mail."
+        "description": "Vos identifiants sont invalides ou ont expiré. Veuillez fournir de nouveaux identifiants ci-dessous.\n\nAstuce : vous pouvez coller le contenu complet d’un secrets.json récent **ou** fournir un nouveau jeton OAuth et une adresse e-mail."
       }
     },
     "error": {
       "auth_failed": "Échec de l’authentification. Veuillez réessayer.",
-      "invalid_token": "Jeton invalide ou champs requis manquants.",
+      "invalid_token": "E-mail/jeton invalide ou champs requis manquants.",
       "invalid_json": "Format JSON invalide dans le contenu de secrets.json.",
       "no_devices": "Aucun appareil trouvé. Assurez-vous que « Localiser mon appareil » est activé sur votre compte Google.",
       "cannot_connect": "Échec de la connexion à l’API Google. Il peut s’agir d’un problème temporaire — réessayez plus tard.",
@@ -73,7 +73,7 @@
       },
       "credentials": {
         "title": "Mettre à jour les identifiants (optionnel)",
-        "description": "{hint}\n\nMettez à jour les identifiants sans exposer les valeurs existantes. Fournissez exactement une méthode :\n\n• Coller le contenu complet d’un **secrets.json** neuf\n**ou**\n• Saisir un **jeton OAuth** neuf et une **adresse e-mail Google**.\n\nLe cas échéant, les identifiants seront validés et enregistrés ; l’intégration sera rechargée sans modifier les noms de vos entités.",
+        "description": "Mettez à jour les identifiants sans exposer les valeurs existantes. Fournissez exactement une méthode :\n\n• Coller le contenu complet d’un **secrets.json** neuf\n**ou**\n• Saisir un **jeton OAuth** neuf et une **adresse e-mail Google**.\n\nLe cas échéant, les identifiants seront validés et enregistrés ; l’intégration sera rechargée sans modifier les noms de vos entités.",
         "data": {
           "secrets_json": "Nouveau secrets.json (contenu complet)",
           "oauth_token": "Nouveau jeton OAuth",

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -26,9 +26,8 @@
       },
       "device_selection": {
         "title": "Sélection des appareils et interrogation",
-        "description": "Sélectionnez les appareils à suivre et configurez les paramètres d’interrogation :\n• Intervalle d’interrogation de position : fréquence de démarrage d’un nouveau cycle (60–3600 secondes)\n• Délai entre les interrogations d’appareil : intervalle entre les requêtes pour chaque appareil au sein d’un cycle (1–60 secondes)\n\nL’intégration interroge les appareils de manière séquentielle et demande les données de position pour chaque appareil avec le délai spécifié.",
+        "description": "Les nouveaux appareils détectés apparaissent désactivés et peuvent être activés dans les paramètres de l’appareil. Configurez ici les paramètres généraux d’interrogation :\n• Intervalle d’interrogation de position : fréquence de démarrage d’un nouveau cycle (60–3600 secondes)\n• Délai entre les interrogations d’appareil : intervalle entre les requêtes pour chaque appareil au sein d’un cycle (1–60 secondes)",
         "data": {
-          "tracked_devices": "Appareils suivis",
           "location_poll_interval": "Intervalle d’interrogation de position (s)",
           "device_poll_delay": "Délai entre les interrogations d’appareil (s)",
           "min_accuracy_threshold": "Précision minimale (m)",
@@ -85,9 +84,8 @@
       },
       "settings": {
         "title": "Options",
-        "description": "Modifier les paramètres de suivi :\n• Intervalle d’interrogation de position : fréquence des requêtes de position (60–3600 secondes)\n• Délai entre les interrogations d’appareil : intervalle entre les requêtes par appareil (1–60 secondes)\n• Précision minimale : ignorer les positions moins précises que cette valeur (25–500 mètres)\n• Seuil de mouvement : mouvement minimal déclenchant une mise à jour de la position (10–200 mètres)\n\nFiltre Google Home :\n• Activer pour regrouper les détections Google Home dans la zone « Domicile »\n• Les mots-clés acceptent les correspondances partielles (séparés par des virgules)\n• Exemple : « nest » correspond à « Kitchen Nest Mini »",
+        "description": "Ajuster les paramètres de localisation :\n• Intervalle d’interrogation de position : fréquence des requêtes de position (60–3600 secondes)\n• Délai entre les interrogations d’appareil : intervalle entre les requêtes par appareil (1–60 secondes)\n• Précision minimale : ignorer les positions moins précises que cette valeur (25–500 mètres)\n• Seuil de mouvement : mouvement minimal déclenchant une mise à jour de la position (10–200 mètres)\n\nFiltre Google Home :\n• Activer pour associer les détections Google Home à la zone « Domicile »\n• Les mots-clés acceptent les correspondances partielles (séparés par des virgules)\n• Exemple : « nest » correspond à « Kitchen Nest Mini »",
         "data": {
-          "tracked_devices": "Appareils suivis",
           "location_poll_interval": "Intervalle d’interrogation de position (s)",
           "device_poll_delay": "Délai entre les interrogations d’appareil (s)",
           "min_accuracy_threshold": "Précision minimale (m)",

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -142,6 +142,16 @@
         }
       }
     },
+    "stop_sound": {
+      "name": "Interrompi suono",
+      "description": "Interrompe il suono su un dispositivo Google Find My.",
+      "fields": {
+        "device_id": {
+          "name": "Dispositivo",
+          "description": "Seleziona un dispositivo Google Find My (oppure passa un ID canonico tramite Strumenti per sviluppatori)."
+        }
+      }
+    },
     "refresh_device_urls": {
       "name": "Aggiorna URL dei dispositivi",
       "description": "Aggiorna gli URL di configurazione dei dispositivi Google Find My per puntare alla vista mappa integrata.",

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -26,9 +26,8 @@
       },
       "device_selection": {
         "title": "Selezione dispositivi e polling",
-        "description": "Seleziona i dispositivi da monitorare e configura i parametri di polling:\n• Intervallo di polling posizione: frequenza di avvio di un nuovo ciclo (60–3600 secondi)\n• Ritardo tra interrogazioni dei dispositivi: intervallo tra le richieste per ciascun dispositivo all’interno di un ciclo (1–60 secondi)\n\nL’integrazione scorre i dispositivi in sequenza e richiede i dati di posizione per ciascuno con il ritardo specificato.",
+        "description": "I nuovi dispositivi rilevati appaiono disattivati e possono essere attivati nelle impostazioni del dispositivo. Configura qui i parametri generali di polling:\n• Intervallo di polling posizione: frequenza di avvio di un nuovo ciclo (60–3600 secondi)\n• Ritardo tra interrogazioni dei dispositivi: intervallo tra le richieste per ciascun dispositivo all’interno di un ciclo (1–60 secondi)",
         "data": {
-          "tracked_devices": "Dispositivi monitorati",
           "location_poll_interval": "Intervallo di polling posizione (s)",
           "device_poll_delay": "Ritardo tra interrogazioni dei dispositivi (s)",
           "min_accuracy_threshold": "Accuratezza minima (m)",
@@ -85,9 +84,8 @@
       },
       "settings": {
         "title": "Opzioni",
-        "description": "Modifica le impostazioni di monitoraggio:\n• Intervallo di polling posizione: frequenza di interrogazione delle posizioni (60–3600 secondi)\n• Ritardo tra interrogazioni dei dispositivi: intervallo tra le richieste per dispositivo (1–60 secondi)\n• Accuratezza minima: ignora posizioni peggiori di questo valore (25–500 metri)\n• Soglia di movimento: movimento minimo per generare un aggiornamento di posizione (10–200 metri)\n\nFiltro Google Home:\n• Abilita per raggruppare i rilevamenti Google Home nella zona ‘Casa’\n• Le parole chiave supportano corrispondenze parziali (separate da virgole)\n• Esempio: ‘nest’ corrisponde a ‘Kitchen Nest Mini’",
+        "description": "Modifica le impostazioni di localizzazione:\n• Intervallo di polling posizione: frequenza di interrogazione delle posizioni (60–3600 secondi)\n• Ritardo tra interrogazioni dei dispositivi: intervallo tra le richieste per dispositivo (1–60 secondi)\n• Accuratezza minima: ignora posizioni peggiori di questo valore (25–500 metri)\n• Soglia di movimento: movimento minimo per generare un aggiornamento di posizione (10–200 metri)\n\nFiltro Google Home:\n• Abilita per associare i rilevamenti Google Home alla zona ‘Casa’\n• Le parole chiave supportano corrispondenze parziali (separate da virgole)\n• Esempio: ‘nest’ corrisponde a ‘Kitchen Nest Mini’",
         "data": {
-          "tracked_devices": "Dispositivi monitorati",
           "location_poll_interval": "Intervallo di polling posizione (s)",
           "device_poll_delay": "Ritardo tra interrogazioni dei dispositivi (s)",
           "min_accuracy_threshold": "Accuratezza minima (m)",

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -46,7 +46,7 @@
     },
     "error": {
       "auth_failed": "Autenticazione non riuscita. Riprova.",
-      "invalid_token": "Email/token non valido o campi obbligatori mancanti.",
+      "invalid_token": "Credenziali non valide (token/e-mail) o campi obbligatori mancanti.",
       "invalid_json": "Formato JSON non valido nel contenuto di secrets.json.",
       "no_devices": "Nessun dispositivo trovato. Assicurati che ‘Trova il mio dispositivo’ sia attivato nel tuo account Google.",
       "cannot_connect": "Impossibile connettersi all’API di Google. Potrebbe trattarsi di un problema temporaneo — riprova più tardi.",
@@ -114,7 +114,8 @@
       "invalid": "Convalida non riuscita. Controlla i tuoi dati.",
       "cannot_connect": "Impossibile connettersi all’API di Google.",
       "choose_one": "Fornisci esattamente un metodo di credenziali.",
-      "required": "Questo campo è obbligatorio."
+      "required": "Questo campo è obbligatorio.",
+      "invalid_token": "Credenziali non valide (token/e-mail). Verifica formato e contenuto."
     },
     "abort": {
       "reconfigure_successful": "Riconfigurazione riuscita.",

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -11,14 +11,14 @@
       },
       "secrets_json": {
         "title": "Metodo 1: GoogleFindMyTools secrets.json",
-        "description": "Esegui GoogleFindMyTools (Chrome) per generare i token di autenticazione, quindi incolla qui sotto il contenuto completo del file Auth/secrets.json.\n\n{hint}",
+        "description": "Esegui GoogleFindMyTools (Chrome) per generare i token di autenticazione, quindi incolla qui sotto il contenuto completo del file Auth/secrets.json.",
         "data": {
           "secrets_json": "Contenuto del file secrets.json"
         }
       },
       "individual_tokens": {
         "title": "Metodo 2: Token OAuth individuale",
-        "description": "Inserisci il token OAuth e l’indirizzo email Google ottenuti tramite il processo di autenticazione manuale.\n\n{hint}",
+        "description": "Inserisci il token OAuth e l’indirizzo email Google ottenuti tramite il processo di autenticazione manuale.",
         "data": {
           "oauth_token": "Token OAuth",
           "google_email": "Indirizzo email Google"
@@ -41,12 +41,12 @@
       },
       "reauth_confirm": {
         "title": "Riautenticazione",
-        "description": "{reason}\n\nSuggerimento: puoi incollare il contenuto completo di un nuovo secrets.json **oppure** fornire un nuovo token OAuth e l’email."
+        "description": "Le tue credenziali sembrano non valide o sono scadute. Fornisci nuove credenziali qui sotto.\n\nSuggerimento: puoi incollare il contenuto completo di un nuovo secrets.json **oppure** fornire un nuovo token OAuth e l’email."
       }
     },
     "error": {
       "auth_failed": "Autenticazione non riuscita. Riprova.",
-      "invalid_token": "Token non valido o campi obbligatori mancanti.",
+      "invalid_token": "Email/token non valido o campi obbligatori mancanti.",
       "invalid_json": "Formato JSON non valido nel contenuto di secrets.json.",
       "no_devices": "Nessun dispositivo trovato. Assicurati che ‘Trova il mio dispositivo’ sia attivato nel tuo account Google.",
       "cannot_connect": "Impossibile connettersi all’API di Google. Potrebbe trattarsi di un problema temporaneo — riprova più tardi.",
@@ -73,7 +73,7 @@
       },
       "credentials": {
         "title": "Aggiorna credenziali (opzionale)",
-        "description": "{hint}\n\nAggiorna le credenziali senza esporre i valori esistenti. Fornisci esattamente un metodo:\n\n• Incolla il contenuto completo di un **secrets.json** nuovo\n**oppure**\n• Inserisci un **token OAuth** nuovo e **email Google**.\n\nSe fornite, le credenziali saranno convalidate e salvate; l’integrazione verrà ricaricata senza cambiare i nomi delle tue entità.",
+        "description": "Aggiorna le credenziali senza esporre i valori esistenti. Fornisci esattamente un metodo:\n\n• Incolla il contenuto completo di un **secrets.json** nuovo\n**oppure**\n• Inserisci un **token OAuth** nuovo e **email Google**.\n\nSe fornite, le credenziali saranno convalidate e salvate; l’integrazione verrà ricaricata senza cambiare i nomi delle tue entità.",
         "data": {
           "secrets_json": "Nuovo secrets.json (contenuto completo)",
           "oauth_token": "Nuovo token OAuth",

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -206,9 +206,6 @@
       "last_seen": {
         "name": "Ultima volta visto"
       },
-      "stat_skipped_duplicates": {
-        "name": "Duplicati ignorati"
-      },
       "stat_background_updates": {
         "name": "Aggiornamenti in background"
       },

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -11,14 +11,14 @@
       },
       "secrets_json": {
         "title": "Metodo 1: GoogleFindMyTools secrets.json",
-        "description": "Esegui GoogleFindMyTools (Chrome) per generare i token di autenticazione, quindi incolla qui sotto il contenuto completo del file Auth/secrets.json.",
+        "description": "Esegui GoogleFindMyTools (Chrome) per generare i token di autenticazione, quindi incolla qui sotto il contenuto completo del file Auth/secrets.json.\n\n{hint}",
         "data": {
           "secrets_json": "Contenuto del file secrets.json"
         }
       },
       "individual_tokens": {
         "title": "Metodo 2: Token OAuth individuale",
-        "description": "Inserisci il token OAuth e l’indirizzo email Google ottenuti tramite il processo di autenticazione manuale.",
+        "description": "Inserisci il token OAuth e l’indirizzo email Google ottenuti tramite il processo di autenticazione manuale.\n\n{hint}",
         "data": {
           "oauth_token": "Token OAuth",
           "google_email": "Indirizzo email Google"
@@ -41,7 +41,7 @@
       },
       "reauth_confirm": {
         "title": "Riautenticazione",
-        "description": "Le tue credenziali sembrano non valide o sono scadute. Fornisci nuove credenziali qui sotto.\n\nSuggerimento: puoi incollare il contenuto completo di un nuovo secrets.json **oppure** fornire un nuovo token OAuth e l’email."
+        "description": "{reason}\n\nSuggerimento: puoi incollare il contenuto completo di un nuovo secrets.json **oppure** fornire un nuovo token OAuth e l’email."
       }
     },
     "error": {
@@ -73,7 +73,7 @@
       },
       "credentials": {
         "title": "Aggiorna credenziali (opzionale)",
-        "description": "Aggiorna le credenziali senza esporre i valori esistenti. Fornisci esattamente un metodo:\n\n• Incolla il contenuto completo di un **secrets.json** nuovo\n**oppure**\n• Inserisci un **token OAuth** nuovo e **email Google**.\n\nSe fornite, le credenziali saranno convalidate e salvate; l’integrazione verrà ricaricata senza cambiare i nomi delle tue entità.",
+        "description": "{hint}\n\nAggiorna le credenziali senza esporre i valori esistenti. Fornisci esattamente un metodo:\n\n• Incolla il contenuto completo di un **secrets.json** nuovo\n**oppure**\n• Inserisci un **token OAuth** nuovo e **email Google**.\n\nSe fornite, le credenziali saranno convalidate e salvate; l’integrazione verrà ricaricata senza cambiare i nomi delle tue entità.",
         "data": {
           "secrets_json": "Nuovo secrets.json (contenuto completo)",
           "oauth_token": "Nuovo token OAuth",

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -228,6 +228,9 @@
       },
       "stat_low_quality_dropped": {
         "name": "Posizioni a bassa accuratezza scartate"
+      },
+      "stat_non_significant_dropped": {
+        "name": "Aggiornamenti non significativi scartati"
       }
     }
   }

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -67,7 +67,8 @@
         "description": "Cosa desideri configurare?",
         "menu_options": {
           "credentials": "Aggiorna credenziali",
-          "settings": "Modifica impostazioni"
+          "settings": "Modifica impostazioni",
+          "visibility": "Visibilità dei dispositivi"
         }
       },
       "credentials": {
@@ -99,6 +100,13 @@
         "data_description": {
           "map_view_token_expiration": "Se abilitato, i token della vista mappa scadono dopo 1 settimana. Se disabilitato (predefinito), non scadono."
         }
+      },
+      "visibility": {
+        "title": "Visibilità dei dispositivi",
+        "description": "Ripristina i dispositivi precedentemente ignorati per renderli di nuovo visibili. Seleziona uno o più dispositivi e salva.",
+        "data": {
+          "unignore_devices": "Ripristina dispositivi"
+        }
       }
     },
     "error": {
@@ -109,7 +117,8 @@
       "required": "Questo campo è obbligatorio."
     },
     "abort": {
-      "reconfigure_successful": "Riconfigurazione riuscita."
+      "reconfigure_successful": "Riconfigurazione riuscita.",
+      "no_ignored_devices": "Non ci sono dispositivi ignorati da ripristinare."
     }
   },
   "services": {
@@ -138,9 +147,9 @@
       "description": "Aggiorna gli URL di configurazione dei dispositivi Google Find My per puntare alla vista mappa integrata.",
       "fields": {}
     },
-    "locate_external": {
+    "locate_device_external": {
       "name": "Localizza dispositivo (esterno)",
-      "description": "Localizza un dispositivo utilizzando il servizio esterno (delegato alla localizzazione normale).",
+      "description": "Localizza un dispositivo utilizzando l’assistente esterno; delega alla localizzazione normale.",
       "fields": {
         "device_id": {
           "name": "Dispositivo",

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -192,6 +192,9 @@
       "play_sound": {
         "name": "Riproduci suono"
       },
+      "stop_sound": {
+        "name": "Interrompi suono"
+      },
       "locate_device": {
         "name": "Localizza ora"
       }

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -228,6 +228,9 @@
       },
       "stat_low_quality_dropped": {
         "name": "Odrzucono zbyt niską dokładność"
+      },
+      "stat_non_significant_dropped": {
+        "name": "Odrzucone nieistotne aktualizacje"
       }
     }
   }

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -192,6 +192,9 @@
       "play_sound": {
         "name": "Odtwórz dźwięk"
       },
+      "stop_sound": {
+        "name": "Zatrzymaj dźwięk"
+      },
       "locate_device": {
         "name": "Zlokalizuj teraz"
       }

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -11,14 +11,14 @@
       },
       "secrets_json": {
         "title": "Metoda 1: GoogleFindMyTools secrets.json",
-        "description": "Uruchom GoogleFindMyTools (Chrome), aby wygenerować tokeny uwierzytelniające, a następnie wklej poniżej pełną zawartość pliku Auth/secrets.json.\n\n{hint}",
+        "description": "Uruchom GoogleFindMyTools (Chrome), aby wygenerować tokeny uwierzytelniające, a następnie wklej poniżej pełną zawartość pliku Auth/secrets.json.",
         "data": {
           "secrets_json": "Zawartość pliku secrets.json"
         }
       },
       "individual_tokens": {
         "title": "Metoda 2: Indywidualny token OAuth",
-        "description": "Wprowadź token OAuth i adres e-mail Google uzyskane podczas ręcznej autoryzacji.\n\n{hint}",
+        "description": "Wprowadź token OAuth i adres e-mail Google uzyskane podczas ręcznej autoryzacji.",
         "data": {
           "oauth_token": "Token OAuth",
           "google_email": "Adres e-mail Google"
@@ -41,12 +41,12 @@
       },
       "reauth_confirm": {
         "title": "Ponowne uwierzytelnienie",
-        "description": "{reason}\n\nWskazówka: możesz wkleić pełną zawartość nowego pliku secrets.json **albo** podać nowy token OAuth i adres e-mail."
+        "description": "Twoje poświadczenia są nieprawidłowe lub wygasły. Podaj poniżej nowe.\n\nWskazówka: możesz wkleić pełną zawartość nowego pliku secrets.json **albo** podać nowy token OAuth i adres e-mail."
       }
     },
     "error": {
       "auth_failed": "Uwierzytelnianie nie powiodło się. Spróbuj ponownie.",
-      "invalid_token": "Podano nieprawidłowy token lub brakuje wymaganych pól.",
+      "invalid_token": "Nieprawidłowy e-mail/token lub brakuje wymaganych pól.",
       "invalid_json": "Nieprawidłowy format JSON w zawartości pliku secrets.json.",
       "no_devices": "Nie znaleziono urządzeń. Upewnij się, że „Znajdź moje urządzenie” jest włączone na Twoim koncie Google.",
       "cannot_connect": "Nie udało się połączyć z interfejsem Google API. Może to być problem tymczasowy — spróbuj ponownie później.",
@@ -73,7 +73,7 @@
       },
       "credentials": {
         "title": "Aktualizuj poświadczenia (opcjonalnie)",
-        "description": "{hint}\n\nZaktualizuj poświadczenia bez ujawniania istniejących wartości. Podaj dokładnie jedną metodę:\n\n• Wklej pełną zawartość nowego **secrets.json**\n**albo**\n• Podaj nowy **token OAuth** i **adres e-mail Google**.\n\nJeśli podasz nowe dane, zostaną one zweryfikowane i zapisane; integracja przeładuje się bez zmiany nazw Twoich encji.",
+        "description": "Zaktualizuj poświadczenia bez ujawniania istniejących wartości. Podaj dokładnie jedną metodę:\n\n• Wklej pełną zawartość nowego **secrets.json**\n**albo**\n• Podaj nowy **token OAuth** i **adres e-mail Google**.\n\nJeśli podasz nowe dane, zostaną one zweryfikowane i zapisane; integracja przeładuje się bez zmiany nazw Twoich encji.",
         "data": {
           "secrets_json": "Nowy secrets.json (pełna zawartość)",
           "oauth_token": "Nowy token OAuth",

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -67,7 +67,8 @@
         "description": "Co chcesz skonfigurować?",
         "menu_options": {
           "credentials": "Zaktualizuj poświadczenia",
-          "settings": "Zmień ustawienia"
+          "settings": "Zmień ustawienia",
+          "visibility": "Widoczność urządzeń"
         }
       },
       "credentials": {
@@ -99,6 +100,13 @@
         "data_description": {
           "map_view_token_expiration": "Po włączeniu tokeny widoku mapy wygasają po 1 tygodniu. Po wyłączeniu (domyślnie) nie wygasają."
         }
+      },
+      "visibility": {
+        "title": "Widoczność urządzeń",
+        "description": "Przywróć wcześniej ignorowane urządzenia, aby znów były widoczne. Wybierz jedno lub więcej urządzeń i zapisz.",
+        "data": {
+          "unignore_devices": "Przywróć urządzenia"
+        }
       }
     },
     "error": {
@@ -109,7 +117,8 @@
       "required": "To pole jest wymagane."
     },
     "abort": {
-      "reconfigure_successful": "Ponowna konfiguracja zakończona pomyślnie."
+      "reconfigure_successful": "Ponowna konfiguracja zakończona pomyślnie.",
+      "no_ignored_devices": "Brak ignorowanych urządzeń do przywrócenia."
     }
   },
   "services": {
@@ -138,9 +147,9 @@
       "description": "Odświeża adresy URL konfiguracji urządzeń Google Find My tak, aby wskazywały na zintegrowany widok mapy.",
       "fields": {}
     },
-    "locate_external": {
+    "locate_device_external": {
       "name": "Zlokalizuj urządzenie (zewnętrznie)",
-      "description": "Zlokalizuj urządzenie przy użyciu zewnętrznej usługi (deleguje do zwykłej lokalizacji).",
+      "description": "Zlokalizuj urządzenie przy użyciu zewnętrznego pomocnika; deleguje do zwykłej lokalizacji.",
       "fields": {
         "device_id": {
           "name": "Urządzenie",

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -11,14 +11,14 @@
       },
       "secrets_json": {
         "title": "Metoda 1: GoogleFindMyTools secrets.json",
-        "description": "Uruchom GoogleFindMyTools (Chrome), aby wygenerować tokeny uwierzytelniające, a następnie wklej poniżej pełną zawartość pliku Auth/secrets.json.",
+        "description": "Uruchom GoogleFindMyTools (Chrome), aby wygenerować tokeny uwierzytelniające, a następnie wklej poniżej pełną zawartość pliku Auth/secrets.json.\n\n{hint}",
         "data": {
           "secrets_json": "Zawartość pliku secrets.json"
         }
       },
       "individual_tokens": {
         "title": "Metoda 2: Indywidualny token OAuth",
-        "description": "Wprowadź token OAuth i adres e-mail Google uzyskane podczas ręcznej autoryzacji.",
+        "description": "Wprowadź token OAuth i adres e-mail Google uzyskane podczas ręcznej autoryzacji.\n\n{hint}",
         "data": {
           "oauth_token": "Token OAuth",
           "google_email": "Adres e-mail Google"
@@ -41,7 +41,7 @@
       },
       "reauth_confirm": {
         "title": "Ponowne uwierzytelnienie",
-        "description": "Twoje poświadczenia są nieprawidłowe lub wygasły. Podaj poniżej nowe.\n\nWskazówka: możesz wkleić pełną zawartość nowego pliku secrets.json **albo** podać nowy token OAuth i adres e-mail."
+        "description": "{reason}\n\nWskazówka: możesz wkleić pełną zawartość nowego pliku secrets.json **albo** podać nowy token OAuth i adres e-mail."
       }
     },
     "error": {
@@ -73,7 +73,7 @@
       },
       "credentials": {
         "title": "Aktualizuj poświadczenia (opcjonalnie)",
-        "description": "Zaktualizuj poświadczenia bez ujawniania istniejących wartości. Podaj dokładnie jedną metodę:\n\n• Wklej pełną zawartość nowego **secrets.json**\n**albo**\n• Podaj nowy **token OAuth** i **adres e-mail Google**.\n\nJeśli podasz nowe dane, zostaną one zweryfikowane i zapisane; integracja przeładuje się bez zmiany nazw Twoich encji.",
+        "description": "{hint}\n\nZaktualizuj poświadczenia bez ujawniania istniejących wartości. Podaj dokładnie jedną metodę:\n\n• Wklej pełną zawartość nowego **secrets.json**\n**albo**\n• Podaj nowy **token OAuth** i **adres e-mail Google**.\n\nJeśli podasz nowe dane, zostaną one zweryfikowane i zapisane; integracja przeładuje się bez zmiany nazw Twoich encji.",
         "data": {
           "secrets_json": "Nowy secrets.json (pełna zawartość)",
           "oauth_token": "Nowy token OAuth",

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -142,6 +142,16 @@
         }
       }
     },
+    "stop_sound": {
+      "name": "Zatrzymaj dźwięk",
+      "description": "Zatrzymuje dźwięk na urządzeniu Google Find My.",
+      "fields": {
+        "device_id": {
+          "name": "Urządzenie",
+          "description": "Wybierz urządzenie Google Find My (lub przekaż kanoniczny identyfikator przez Narzędzia deweloperskie)."
+        }
+      }
+    },
     "refresh_device_urls": {
       "name": "Odśwież adresy URL urządzeń",
       "description": "Odświeża adresy URL konfiguracji urządzeń Google Find My tak, aby wskazywały na zintegrowany widok mapy.",

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -46,7 +46,7 @@
     },
     "error": {
       "auth_failed": "Uwierzytelnianie nie powiodło się. Spróbuj ponownie.",
-      "invalid_token": "Nieprawidłowy e-mail/token lub brakuje wymaganych pól.",
+      "invalid_token": "Nieprawidłowy token/e-mail lub brakuje wymaganych pól.",
       "invalid_json": "Nieprawidłowy format JSON w zawartości pliku secrets.json.",
       "no_devices": "Nie znaleziono urządzeń. Upewnij się, że „Znajdź moje urządzenie” jest włączone na Twoim koncie Google.",
       "cannot_connect": "Nie udało się połączyć z interfejsem Google API. Może to być problem tymczasowy — spróbuj ponownie później.",
@@ -114,7 +114,8 @@
       "invalid": "Walidacja nie powiodła się. Sprawdź swoje dane.",
       "cannot_connect": "Nie udało się połączyć z interfejsem Google API.",
       "choose_one": "Podaj dokładnie jedną metodę poświadczeń.",
-      "required": "To pole jest wymagane."
+      "required": "To pole jest wymagane.",
+      "invalid_token": "Nieprawidłowe dane logowania (token/e-mail). Sprawdź format i zawartość."
     },
     "abort": {
       "reconfigure_successful": "Ponowna konfiguracja zakończona pomyślnie.",

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -26,9 +26,8 @@
       },
       "device_selection": {
         "title": "Wybór urządzeń i odpytywania",
-        "description": "Wybierz urządzenia do śledzenia i skonfiguruj parametry odpytywania:\n• Interwał odpytywania lokalizacji: jak często rozpoczynać nowy cykl (60–3600 sekund)\n• Opóźnienie między odpytywaniem urządzeń: odstęp między zapytaniami dla poszczególnych urządzeń w cyklu (1–60 sekund)\n\nIntegracja odpyta urządzenia sekwencyjnie, żądając danych lokalizacji dla każdego urządzenia z podanym opóźnieniem.",
+        "description": "Nowo wykryte urządzenia pojawiają się jako wyłączone i można je włączyć w ustawieniach urządzenia. Skonfiguruj tutaj ogólne parametry odpytywania:\n• Interwał odpytywania lokalizacji: jak często rozpoczyna się nowy cykl (60–3600 sekund)\n• Opóźnienie między odpytywaniem urządzeń: odstęp między zapytaniami dla poszczególnych urządzeń w cyklu (1–60 sekund)",
         "data": {
-          "tracked_devices": "Śledzone urządzenia",
           "location_poll_interval": "Interwał odpytywania lokalizacji (s)",
           "device_poll_delay": "Opóźnienie między odpytywaniem urządzeń (s)",
           "min_accuracy_threshold": "Minimalna dokładność (m)",
@@ -85,9 +84,8 @@
       },
       "settings": {
         "title": "Opcje",
-        "description": "Dostosuj ustawienia śledzenia:\n• Interwał odpytywania lokalizacji: jak często pobierać pozycje (60–3600 sekund)\n• Opóźnienie między odpytywaniem urządzeń: odstęp między zapytaniami (1–60 sekund)\n• Minimalna dokładność: ignoruj pozycje gorsze niż ta wartość (25–500 metrów)\n• Próg ruchu: minimalny ruch wyzwalający aktualizację pozycji (10–200 metrów)\n\nFiltr Google Home:\n• Włącz, aby grupować wykrycia Google Home w strefie „Dom”\n• Słowa kluczowe wspierają dopasowania częściowe (oddzielone przecinkami)\n• Przykład: „nest” pasuje do „Kitchen Nest Mini”",
+        "description": "Dostosuj ustawienia lokalizacji:\n• Interwał odpytywania lokalizacji: jak często pobierać pozycje (60–3600 sekund)\n• Opóźnienie między odpytywaniem urządzeń: odstęp między zapytaniami (1–60 sekund)\n• Minimalna dokładność: ignoruj pozycje gorsze niż ta wartość (25–500 metrów)\n• Próg ruchu: minimalny ruch wyzwalający aktualizację pozycji (10–200 metrów)\n\nFiltr Google Home:\n• Włącz, aby grupować wykrycia Google Home w strefie „Dom”\n• Słowa kluczowe wspierają dopasowania częściowe (oddzielone przecinkami)\n• Przykład: „nest” pasuje do „Kitchen Nest Mini”",
         "data": {
-          "tracked_devices": "Śledzone urządzenia",
           "location_poll_interval": "Interwał odpytywania lokalizacji (s)",
           "device_poll_delay": "Opóźnienie między odpytywaniem urządzeń (s)",
           "min_accuracy_threshold": "Minimalna dokładność (m)",

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -206,9 +206,6 @@
       "last_seen": {
         "name": "Ostatnio widziany"
       },
-      "stat_skipped_duplicates": {
-        "name": "Pominięte duplikaty"
-      },
       "stat_background_updates": {
         "name": "Aktualizacje w tle"
       },


### PR DESCRIPTION
Fixes a lot of bugs, adds a stop_sound service, adds ability to ignore devices (disable/delete devices).
This could become a stable pre-release.

---

# Improve reliability, runtime hygiene & device visibility; add `stop_sound` service

## Summary

This PR addresses multiple reliability issues around manual locate results, FCM shutdown, and push handling; introduces a durable **ignored devices** workflow (no skeletons, early exits in push/poll paths); refines the Google Home filter; and adds a new **`stop_sound`** service that mirrors `play_sound`.

---

## Motivation

* Manual `Locate now` results were not always reflected in the UI immediately.
* On reload/unload, the FCM client could linger long enough to risk a shutdown timeout.
* Devices removed by the user could reappear or create skeleton entities.
* Filter logic around “Home” was label-based and brittle.
* Users need a way to **stop** a ringing device from HA, symmetric to `play_sound`.

---

## Bug fixes (behavioral correctness)

1. **Coordinator cache & UI refresh**

   * Persist results from **manual** `async_locate_device(device_id)` into the coordinator cache and **push a fresh snapshot** via `push_updated([device_id])`.
     *Outcome:* The entity state updates immediately after a manual locate.

2. **FCM: treat `tracked_devices` as poll-only; still process push for all devices**

   * Push updates are processed regardless of `tracked_devices`, ensuring **new devices** receive live status, while `tracked_devices` remain the **poll** source of truth.

3. **FCM client shutdown timeouts**

   * Harden `fcmpushclient` shutdown to avoid lingering tasks causing **unload/reload timeouts**.

4. **Coordinator logging & validation**

   * Tighter guards and diagnostics to surface misconfigurations early (low-noise logs).

5. **Entity import fixes**

   * `binary_sensor.py`: explicit `device_registry` import (avoids runtime errors in some setups).

---

## Features & improvements

1. **Ignored devices (end-to-end)**

   * When a user deletes a device from HA, we **persist that intent** in `entry.options.ignored_devices` (idempotent).
   * Coordinator, FCM push path, and platforms honor `ignored_devices`:

     * **No skeletons** are created for ignored devices (`device_tracker.py`, `sensor.py`).
     * FCM path has an **early exit** for ignored device IDs.
     * `const.py`, `config_flow.py` and **translations** updated (EN/DE/ES/FR/IT/PL).

2. **Google Home filter robustness**

   * **Replace semantic label** checks with **cached `zone.home` coordinates** (passive use).
     *Outcome:* More predictable “at home” handling without relying on provider-side labels.
   * Enforce **options-first** configuration with safe fallback to `entry.data` and constants.

3. **Map view polish**

   * Internal correctness/formatting updates in `map_view.py` (kept API stable; token policy unchanged).
     *Outcome:* Cleaner rendering and param handling; no breaking changes.

4. **New `stop_sound` service**

   * Add `googlefindmy.stop_sound` with a **device_id selector** (mirrors `play_sound` schema/UX).
   * Coordinator exposes `async_stop_sound(device_id)` and **reuses push cooldown/error logic**.
   * Registered in `__init__.py`; localized strings added in EN/DE/ES/FR/IT/PL; keys included in `const.py`.

---

## Technical notes & rationale

* Entities are **event-driven** off the coordinator (no polling from entities). Use of `DataUpdateCoordinator` and `CoordinatorEntity` is aligned with HA guidance for single-source polling + push updates. ([[developers.home-assistant.io](https://developers.home-assistant.io/docs/integration_fetching_data/?utm_source=chatgpt.com)][1])
* Instance URLs are always derived via `homeassistant.helpers.network.get_url(hass, ...)` (not deprecated `base_url`). ([[developers.home-assistant.io](https://developers.home-assistant.io/blog/2020/05/08/instance-url-helper/?utm_source=chatgpt.com)][2])
* The **service device** is marked with `entry_type=DeviceEntryType.SERVICE`, following the device registry recommendations. ([[developers.home-assistant.io](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/devices/?utm_source=chatgpt.com)][3])
* Translation keys are kept **identical across locales**; custom integration i18n follows the backend format and folder structure. ([[developers.home-assistant.io](https://developers.home-assistant.io/docs/internationalization/custom_integration/?utm_source=chatgpt.com)][4])
* Adding `stop_sound` as an integration service follows HA’s preference to expose non-standard actions as **service actions**. ([[developers.home-assistant.io](https://developers.home-assistant.io/docs/architecture/devices-and-services/?utm_source=chatgpt.com)][5])

---

## Detailed change list (high-level, grouped)

### Fixes

* **coordinator:** persist manual locate results into cache; call `push_updated([device_id])`.
* **fcm_receiver_ha:** treat `tracked_devices` as poll-only; process all push updates to ensure new devices get live status.
* **fcmpushclient:** prevent shutdown timeout on unload/reload.
* **binary_sensor:** add missing `device_registry` import.
* **coordinator:** logging & validation improvements.

### Features / Enhancements

* **ignored devices (options):**

  * `__init__.py`: persist deletions into `ignored_devices`; remove from `tracked_devices` (idempotent).
  * `coordinator.py`: ignore filter integrated.
  * `fcm_receiver_ha.py`: early exit for ignored device IDs.
  * `device_tracker.py` / `sensor.py`: avoid creating skeletons for ignored devices.
  * `config_flow.py`: surface configuration for visibility.
  * `const.py`: new keys; version bump.
  * **i18n:** EN/DE/ES/FR/IT/PL updated.
* **google_home_filter:** substitute **Home coordinates** (cache `zone.home`), clear semantic labels; align to HA best practices; imports fixed.
* **map_view.py:** internal polish (time/format handling and parameter wiring).
* **services:** add `stop_sound`; register in `__init__.py`; coordinator method + cooldown reuse; i18n + `const.py` updates.

---

## Breaking changes

None.

* Existing services untouched.
* Map endpoints unchanged.
* `ignored_devices` is additive and only acts on user-initiated deletions / configuration.

---

## How to test (manual)

1. **Setup & discovery**

   * Start integration with multiple devices; verify **newly added** Google devices appear (push processed even if not in `tracked_devices`).
2. **Manual locate path**

   * Click **Locate now** on a device → confirm **immediate state refresh** (no page reload).
3. **Ignored devices**

   * Delete a device in the HA UI → confirm the device ID is stored under `entry.options.ignored_devices`.
   * Restart/reload → confirm no skeleton entities are created and push updates are **ignored** for that device.
4. **FCM unload/reload**

   * Reload the integration multiple times and on full HA shutdown → no FCM shutdown warnings/timeouts.
5. **Google Home filter**

   * With `zone.home` configured, verify home detection is **coordinate-based** (labels do not affect behavior).
6. **`stop_sound` service**

   * Call `googlefindmy.stop_sound` using the **device selector**; verify action completes and cooldown/error handling mirrors `play_sound`.
7. **Translations**

   * Switch HA language (EN/DE/ES/FR/IT/PL) → verify strings for **ignored devices** and **stop_sound** appear and keys are consistent.

---

## Screenshots / UI (optional)

N/A – services & runtime behavior.

---

## Checklist

* [x] Async-first; no blocking I/O in HA paths.
* [x] Uses global `aiohttp` session via HA helpers.
* [x] Coordinator remains the single source of truth; entities inherit `CoordinatorEntity`. ([[developers.home-assistant.io](https://developers.home-assistant.io/docs/integration_fetching_data/?utm_source=chatgpt.com)][1])
* [x] Device registry service device uses `DeviceEntryType.SERVICE`. ([[developers.home-assistant.io](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/devices/?utm_source=chatgpt.com)][3])
* [x] Translations updated across locales; keys identical. ([[developers.home-assistant.io](https://developers.home-assistant.io/docs/internationalization/custom_integration/?utm_source=chatgpt.com)][4])
* [x] No secrets logged; tokens redacted.
* [x] Backwards compatible; no schema breaks.

---

## Notes for reviewers

* The **ignored devices** path is idempotent and options-first by design; it does not migrate secrets or sensitive data.
* `stop_sound` mirrors `play_sound` exactly in schema and guard rails; implementation shares cooldown/error handling to keep semantics uniform.
* Filter changes intentionally switch to **coordinate** checks to avoid brittleness when external labels drift.

---

## Linked commits

(As referenced in branch history: coordinator cache fix for manual locate, FCM push handling & shutdown fix, ignored devices pipeline across init/coordinator/push/platforms/config/i18n, GoogleHomeFilter robustness, `stop_sound` service and coordinator method, map view polish, and final coordinator logging/validation.)

---

### References

* Home Assistant Developers (2025) *Fetching data / DataUpdateCoordinator & CoordinatorEntity*. Available at: [developers.home-assistant.io](https://developers.home-assistant.io/docs/integration_fetching_data/) (accessed 11 Oct 2025). ([developers.home-assistant.io][1])
* Home Assistant Developers (2020) *Instance URL helper / get_url (base_url deprecation)*. Available at: [developers.home-assistant.io](https://developers.home-assistant.io/blog/2020/05/08/instance-url-helper/) (accessed 11 Oct 2025). ([developers.home-assistant.io][2])
* Home Assistant Developers (2025) *Integration quality scale – Devices* (SERVICE entry type). Available at: [developers.home-assistant.io](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/devices/) (accessed 11 Oct 2025). ([developers.home-assistant.io][3])
* Home Assistant Developers (2024) *Custom integration localization*. Available at: [developers.home-assistant.io](https://developers.home-assistant.io/docs/internationalization/custom_integration/) (accessed 11 Oct 2025). ([developers.home-assistant.io][4])
* Home Assistant Developers (2025) *Dev 101 – Services (service actions)*. Available at: [developers.home-assistant.io](https://developers.home-assistant.io/docs/dev_101_services/) (accessed 11 Oct 2025). ([developers.home-assistant.io][6])

---

[1]: https://developers.home-assistant.io/docs/integration_fetching_data/ "Fetching data | Home Assistant Developer Docs"
[2]: https://developers.home-assistant.io/blog/2020/05/08/instance-url-helper/ "Instance URL helper"
[3]: https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/devices/ "The integration creates devices"
[4]: https://developers.home-assistant.io/docs/internationalization/custom_integration/ "Custom integration localization"
[5]: https://developers.home-assistant.io/docs/architecture/devices-and-services/ "Entities: integrating devices & services"
[6]: https://developers.home-assistant.io/docs/dev_101_services/ "Integration service actions"