### PR TITLE
Update version to 1.7.0-5 in manifest.json

### DIFF
--- a/custom_components/googlefindmy/manifest.json
+++ b/custom_components/googlefindmy/manifest.json
@@ -35,5 +35,5 @@
     "selenium>=4.25.0",
     "undetected_chromedriver>=3.5.5"
   ],
-  "version": "1.7.0-3"
+  "version": "1.7.0-5"
 }


### PR DESCRIPTION
The bump to 1.7.0-4 was missed, creating a bit of confusion. Propose bumping to 1.7.0-5 for the next release, or a forced release in a few days if no release is needed.