### PR TITLE
Add referrerPolicy to tileLayer in map_view.py

### DIFF
--- a/custom_components/googlefindmy/map_view.py
+++ b/custom_components/googlefindmy/map_view.py
@@ -498,7 +498,8 @@ class GoogleFindMyMapView(HomeAssistantView):
                 var map = L.map('map').setView([{center_lat}, {center_lon}], 13);
 
                 L.tileLayer('https://{{s}}.tile.openstreetmap.org/{{z}}/{{x}}/{{y}}.png', {{
-                    attribution: '© OpenStreetMap contributors'
+                    attribution: '© OpenStreetMap contributors',
+                    referrerPolicy: 'origin'
                 }}).addTo(map);
 
                 var allMarkers = [];


### PR DESCRIPTION
this is required because otherwise tiles get blocked by OSM because of non-compliance with their policy
<img width="1185" height="615" alt="image" src="https://github.com/user-attachments/assets/aa109607-c0bd-45d6-8b33-1987a6f59fe1" />
also added it to the maps cards too https://github.com/BSkando/GoogleFindMy-Card/issues/15