### PR TITLE
Update README.md to mention port 5228 for FCM

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The integration provides a couple of Home Assistant Actions for use with automat
 - Extended timeout allows up to 60 seconds for device response
 - Check firewall settings for Firebase Cloud Messaging
 - Review FCM debug logs for connection details
+- Ensure port 5228 is forwarded if you run this behind reverse-proxy, inside KVM or any other virtual environment not directly exposed.
 
 ### Rate Limiting
 The integration respects Google's rate limits by:


### PR DESCRIPTION
Port 5228 must be directly exposed or forwarded for FCM to correctly connect.

When running inside KVM on my Debian machine this was causing many logs in HA logs, like "push transport not ready" and resulted in complete inability to locate any device.