### PR TITLE
Fix/database write optimization

### DIFF
--- a/custom_components/googlefindmy/config_flow.py
+++ b/custom_components/googlefindmy/config_flow.py
@@ -95,6 +95,7 @@ from .const import (
     DEFAULT_MAP_VIEW_TOKEN_EXPIRATION,
     DEFAULT_OPTIONS,
     DEFAULT_SEMANTIC_DETECTION_RADIUS,
+    DEFAULT_SHOW_LOCATION_AGE,
     DEFAULT_STALE_THRESHOLD,
     # Core domain & credential keys
     DOMAIN,
@@ -108,6 +109,7 @@ from .const import (
     OPT_MAP_VIEW_TOKEN_EXPIRATION,
     OPT_OPTIONS_SCHEMA_VERSION,
     OPT_SEMANTIC_LOCATIONS,
+    OPT_SHOW_LOCATION_AGE,
     OPT_STALE_THRESHOLD,
     OPTION_KEYS,
     SERVICE_FEATURE_PLATFORMS,
@@ -5316,6 +5318,7 @@ class OptionsFlowHandler(OptionsFlowBase, _OptionsFlowMixin):  # type: ignore[mi
             ),
             OPT_CONTRIBUTOR_MODE: _get(OPT_CONTRIBUTOR_MODE, DEFAULT_CONTRIBUTOR_MODE),
             OPT_STALE_THRESHOLD: _get(OPT_STALE_THRESHOLD, DEFAULT_STALE_THRESHOLD),
+            OPT_SHOW_LOCATION_AGE: _get(OPT_SHOW_LOCATION_AGE, DEFAULT_SHOW_LOCATION_AGE),
         }
         if (
             OPT_GOOGLE_HOME_FILTER_ENABLED is not None
@@ -5433,6 +5436,7 @@ class OptionsFlowHandler(OptionsFlowBase, _OptionsFlowMixin):  # type: ignore[mi
             vol.Optional(OPT_STALE_THRESHOLD),
             vol.All(vol.Coerce(int), vol.Range(min=300, max=86400)),
         )
+        _register(vol.Optional(OPT_SHOW_LOCATION_AGE), bool)
 
         base_schema = vol.Schema(fields)
         schema_with_defaults = self.add_suggested_values_to_schema(base_schema, current)

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -110,6 +110,7 @@ OPT_CONTRIBUTOR_MODE: str = "contributor_mode"
 OPT_IGNORED_DEVICES: str = "ignored_devices"
 OPT_DELETE_CACHES_ON_REMOVE: str = "delete_caches_on_remove"
 OPT_STALE_THRESHOLD: str = "stale_threshold"
+OPT_SHOW_LOCATION_AGE: str = "show_location_age"
 # Legacy option key - kept for reading old configurations, no longer used
 OPT_STALE_THRESHOLD_ENABLED: str = "stale_threshold_enabled"
 
@@ -128,6 +129,7 @@ OPTION_KEYS: tuple[str, ...] = (
     OPT_DELETE_CACHES_ON_REMOVE,
     OPT_CONTRIBUTOR_MODE,
     OPT_STALE_THRESHOLD,
+    OPT_SHOW_LOCATION_AGE,
 )
 
 # Keys which may exist historically in entry.data and should be soft-copied to entry.options
@@ -210,6 +212,7 @@ DEFAULT_DELETE_CACHES_ON_REMOVE: bool = True
 # Default: 1800 seconds (30 minutes) - conservative value for "really gone"
 # Minimum: 300 seconds (5 minutes) - allows ~2-3 typical update cycles
 DEFAULT_STALE_THRESHOLD: int = 1800
+DEFAULT_SHOW_LOCATION_AGE: bool = True
 
 CONTRIBUTOR_MODE_HIGH_TRAFFIC: str = "high_traffic"
 CONTRIBUTOR_MODE_IN_ALL_AREAS: str = "in_all_areas"
@@ -235,6 +238,7 @@ DEFAULT_OPTIONS: dict[str, object] = {
     OPT_DELETE_CACHES_ON_REMOVE: DEFAULT_DELETE_CACHES_ON_REMOVE,
     OPT_CONTRIBUTOR_MODE: DEFAULT_CONTRIBUTOR_MODE,
     OPT_STALE_THRESHOLD: DEFAULT_STALE_THRESHOLD,
+    OPT_SHOW_LOCATION_AGE: DEFAULT_SHOW_LOCATION_AGE,
 }
 
 # -------------------- Options schema versioning (lightweight) --------------------
@@ -566,6 +570,7 @@ __all__ = [
     "OPTION_KEYS",
     "OPT_DELETE_CACHES_ON_REMOVE",
     "OPT_STALE_THRESHOLD",
+    "OPT_SHOW_LOCATION_AGE",
     "OPT_STALE_THRESHOLD_ENABLED",
     "MIGRATE_DATA_KEYS_TO_OPTIONS",
     "UPDATE_INTERVAL",
@@ -581,6 +586,7 @@ __all__ = [
     "DEFAULT_MAP_VIEW_TOKEN_EXPIRATION",
     "DEFAULT_DELETE_CACHES_ON_REMOVE",
     "DEFAULT_STALE_THRESHOLD",
+    "DEFAULT_SHOW_LOCATION_AGE",
     "DEFAULT_OPTIONS",
     "CONFIG_FIELDS",
     "TOKEN_REFRESH_COOLDOWN_S",

--- a/custom_components/googlefindmy/coordinator/main.py
+++ b/custom_components/googlefindmy/coordinator/main.py
@@ -1871,9 +1871,24 @@ class GoogleFindMyCoordinator(
             devices_stub.append({"id": dev_id, "name": name})
 
         snapshot = self._build_snapshot_from_cache(devices_stub, wall_now=wall_now)
-        self._refresh_subentry_index(devices_stub)
-        self._store_subentry_snapshots(snapshot)
-        self.async_set_updated_data(snapshot)
+
+        # Merge this push snapshot with the existing self.data (all devices)
+        merged_snapshot = list(snapshot)
+        if self.data:
+            merged_dict = {
+                entry["device_id"]: entry
+                for entry in self.data
+                if isinstance(entry, dict) and "device_id" in entry
+            }
+            for entry in snapshot:
+                if isinstance(entry, dict) and "device_id" in entry:
+                    merged_dict[entry["device_id"]] = entry
+            merged_snapshot = list(merged_dict.values())
+
+        # Refresh index and store snapshots using the complete merged list of all devices
+        self._refresh_subentry_index(None)
+        self._store_subentry_snapshots(merged_snapshot)
+        self.async_set_updated_data(merged_snapshot)
         _LOGGER.debug(
             "Pushed snapshot for %d device(s) via push_updated()", len(snapshot)
         )

--- a/custom_components/googlefindmy/coordinator/main.py
+++ b/custom_components/googlefindmy/coordinator/main.py
@@ -1873,17 +1873,9 @@ class GoogleFindMyCoordinator(
         snapshot = self._build_snapshot_from_cache(devices_stub, wall_now=wall_now)
 
         # Merge this push snapshot with the existing self.data (all devices)
-        merged_snapshot = list(snapshot)
-        if self.data:
-            merged_dict = {
-                entry["device_id"]: entry
-                for entry in self.data
-                if isinstance(entry, dict) and "device_id" in entry
-            }
-            for entry in snapshot:
-                if isinstance(entry, dict) and "device_id" in entry:
-                    merged_dict[entry["device_id"]] = entry
-            merged_snapshot = list(merged_dict.values())
+        old_devices = {d["device_id"]: d for d in (self.data or []) if isinstance(d, dict) and "device_id" in d}
+        new_devices = {d["device_id"]: d for d in snapshot if isinstance(d, dict) and "device_id" in d}
+        merged_snapshot = list((old_devices | new_devices).values())
 
         # Refresh index and store snapshots using the complete merged list of all devices
         self._refresh_subentry_index(None)

--- a/custom_components/googlefindmy/device_tracker.py
+++ b/custom_components/googlefindmy/device_tracker.py
@@ -44,8 +44,10 @@ from . import EntityRecoveryManager, _extract_email_from_entry
 from .const import (
     CONF_OAUTH_TOKEN,
     DATA_SECRET_BUNDLE,
+    DEFAULT_SHOW_LOCATION_AGE,
     DEFAULT_STALE_THRESHOLD,
     DOMAIN,
+    OPT_SHOW_LOCATION_AGE,
     OPT_STALE_THRESHOLD,
     TRACKER_SUBENTRY_KEY,
 )
@@ -1142,10 +1144,18 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
         attributes["google_device_id"] = self.device_id
 
         location_age = self._get_location_age()
-        if location_age is not None:
-            # Round location_age to the nearest 5 minutes (300s) to suppress database writes
-            # from redundant sub-second/minute updates when the device is stationary.
-            attributes["location_age"] = int(round(location_age / 300.0) * 300)
+        show_location_age: bool = bool(
+            self.coordinator.config_entry.options.get(
+                OPT_SHOW_LOCATION_AGE, DEFAULT_SHOW_LOCATION_AGE
+            )
+        )
+        if show_location_age and location_age is not None:
+            # Round to the nearest 1 minute (60 s) to reduce unnecessary database
+            # writes for stationary devices while staying close to the real value.
+            attributes["location_age"] = int(round(location_age / 60.0) * 60)
+        # When show_location_age is False the attribute is omitted entirely.
+        # Absolute timestamps remain available via the "last_seen" attribute
+        # and the sensor.*_last_seen entity.
         attributes["location_status"] = self._get_location_status()
 
         if stale:

--- a/custom_components/googlefindmy/device_tracker.py
+++ b/custom_components/googlefindmy/device_tracker.py
@@ -1143,7 +1143,9 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
 
         location_age = self._get_location_age()
         if location_age is not None:
-            attributes["location_age"] = round(location_age)
+            # Round location_age to the nearest 5 minutes (300s) to suppress database writes
+            # from redundant sub-second/minute updates when the device is stationary.
+            attributes["location_age"] = int(round(location_age / 300.0) * 300)
         attributes["location_status"] = self._get_location_status()
 
         if stale:

--- a/custom_components/googlefindmy/strings.json
+++ b/custom_components/googlefindmy/strings.json
@@ -260,6 +260,7 @@
           "location_poll_interval": "Location poll interval (s)",
           "device_poll_delay": "Device poll delay (s)",
           "stale_threshold": "Stale threshold (s)",
+          "show_location_age": "Show location age attribute",
           "google_home_filter_enabled": "Filter Google Home devices",
           "google_home_filter_keywords": "Filter keywords (comma-separated)",
           "enable_stats_entities": "Create statistics entities",
@@ -270,6 +271,7 @@
         },
         "data_description": {
           "stale_threshold": "After this many seconds without a location update, the tracker state becomes unknown. Use the 'Last Location' entity to always see the last known position. Default: 1800 (30 minutes).",
+          "show_location_age": "When enabled (default), a 'location_age' attribute (rounded to 1 minute) is added to each tracker entity. Disable to eliminate all database writes for stationary devices. The absolute 'last_seen' attribute and sensor.*_last_seen entities are always available.",
           "delete_caches_on_remove": "Remove cached tokens and device metadata when this entry is deleted.",
           "map_view_token_expiration": "When enabled, map view tokens expire after 1 week. When disabled (default), tokens do not expire.",
           "contributor_mode": "Choose how your device contributes to Google's network (High-traffic areas by default, or All areas for crowdsourced reporting).",

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -266,14 +266,16 @@
           "delete_caches_on_remove": "Caches beim Entfernen löschen",
           "map_view_token_expiration": "Ablauf von Kartenansicht-Tokens aktivieren",
           "contributor_mode": "Modus für Standortmeldungen",
-          "subentry": "Funktionsgruppe"
+          "subentry": "Funktionsgruppe",
+          "show_location_age": "Attribut für Standortalter anzeigen"
         },
         "data_description": {
           "stale_threshold": "Nach dieser Zeit (in Sekunden) ohne Standortaktualisierung wird der Tracker-Status unbekannt. Verwende die Entität 'Letzter Standort', um immer die letzte bekannte Position zu sehen. Standard: 1800 (30 Minuten).",
           "delete_caches_on_remove": "Löscht zwischengespeicherte Tokens und Gerätemetadaten, wenn dieser Eintrag entfernt wird.",
           "map_view_token_expiration": "Wenn aktiviert, laufen die Token für die Kartenansicht nach 1 Woche ab. Wenn deaktiviert (Standard), laufen die Token nicht ab.",
           "contributor_mode": "Lege fest, wie dein Gerät zum Google-Netzwerk beiträgt (standardmäßig Alle Bereiche für Crowdsourcing oder nur stark frequentierte Bereiche).",
-          "subentry": "Speichern Sie diese Optionen in der ausgewählten Funktionsgruppe. Beispiele finden Sie unter [Subeinträge und Funktionsgruppen]({subentries_docs_url})."
+          "subentry": "Speichern Sie diese Optionen in der ausgewählten Funktionsgruppe. Beispiele finden Sie unter [Subeinträge und Funktionsgruppen]({subentries_docs_url}).",
+          "show_location_age": "Wenn aktiviert (Standard), wird jeder Tracker-Entität ein 'location_age'-Attribut (auf 1 Minute gerundet) hinzugefügt. Deaktivieren, um alle Datenbank-Schreibvorgänge für stationäre Geräte zu eliminieren. Das absolute 'last_seen'-Attribut und sensor.*_last_seen-Entitäten sind immer verfügbar."
         }
       },
       "visibility": {

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -260,6 +260,7 @@
           "location_poll_interval": "Location poll interval (s)",
           "device_poll_delay": "Device poll delay (s)",
           "stale_threshold": "Stale threshold (s)",
+          "show_location_age": "Show location age attribute",
           "google_home_filter_enabled": "Filter Google Home devices",
           "google_home_filter_keywords": "Filter keywords (comma-separated)",
           "enable_stats_entities": "Create statistics entities",
@@ -270,6 +271,7 @@
         },
         "data_description": {
           "stale_threshold": "After this many seconds without a location update, the tracker state becomes unknown. Use the 'Last Location' entity to always see the last known position. Default: 1800 (30 minutes).",
+          "show_location_age": "When enabled (default), a 'location_age' attribute (rounded to 1 minute) is added to each tracker entity. Disable to eliminate all database writes for stationary devices. The absolute 'last_seen' attribute and sensor.*_last_seen entities are always available.",
           "delete_caches_on_remove": "Remove cached tokens and device metadata when this entry is deleted.",
           "map_view_token_expiration": "When enabled, map view tokens expire after 1 week. When disabled (default), tokens do not expire.",
           "contributor_mode": "Choose how your device contributes to Google's network (All areas by default for crowdsourced reporting, or High-traffic areas only).",

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -266,14 +266,16 @@
           "delete_caches_on_remove": "Borrar cachés al eliminar la entrada",
           "map_view_token_expiration": "Activar caducidad del token de la vista de mapa",
           "contributor_mode": "Modo de contribución de ubicaciones",
-          "subentry": "Grupo de funciones"
+          "subentry": "Grupo de funciones",
+          "show_location_age": "Mostrar atributo de antigüedad de la ubicación"
         },
         "data_description": {
           "stale_threshold": "Tras este número de segundos sin una actualización de ubicación, el estado del rastreador pasa a desconocido. Usa la entidad 'Última ubicación' para ver siempre la última posición conocida. Por defecto: 1800 (30 minutos).",
           "delete_caches_on_remove": "Borra los tokens almacenados en caché y los metadatos de los dispositivos cuando se elimina esta entrada.",
           "map_view_token_expiration": "Si está activado, los tokens de la vista de mapa caducan tras 1 semana. Si está desactivado (por defecto), no caducan.",
           "contributor_mode": "Elige cómo contribuye tu dispositivo a la red de Google (Todas las zonas por defecto para aportes colaborativos o solo Zonas de alto tránsito).",
-          "subentry": "Guarda estas opciones en el grupo de funciones seleccionado. Consulta [Subentradas y grupos de funciones]({subentries_docs_url}) para ver ejemplos."
+          "subentry": "Guarda estas opciones en el grupo de funciones seleccionado. Consulta [Subentradas y grupos de funciones]({subentries_docs_url}) para ver ejemplos.",
+          "show_location_age": "Cuando está habilitado (por defecto), se agrega un atributo 'location_age' (redondeado a 1 minuto) a cada entidad de rastreo. Deshabilítelo para eliminar todas las escrituras en la base de datos de los dispositivos estacionarios. El atributo absoluto 'last_seen' y las entidades sensor.*_last_seen siempre están disponibles."
         }
       },
       "visibility": {

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -266,14 +266,16 @@
           "delete_caches_on_remove": "Supprimer les caches lors de la suppression de l’entrée",
           "map_view_token_expiration": "Activer l’expiration du jeton de la vue carte",
           "contributor_mode": "Mode de contribution de localisation",
-          "subentry": "Groupe de fonctionnalités"
+          "subentry": "Groupe de fonctionnalités",
+          "show_location_age": "Afficher l'attribut d'ancienneté de l'emplacement"
         },
         "data_description": {
           "stale_threshold": "Après ce délai en secondes sans mise à jour de position, l'état du traceur passe à inconnu. Utilisez l'entité 'Dernière position' pour toujours voir la dernière position connue. Par défaut : 1800 (30 minutes).",
           "delete_caches_on_remove": "Supprime les jetons mis en cache et les métadonnées des appareils lors de la suppression de cette entrée.",
           "map_view_token_expiration": "Lorsqu'elle est activée, les jetons de la vue carte expirent après 1 semaine. Lorsqu'elle est désactivée (par défaut), ils n'expirent pas.",
           "contributor_mode": "Choisissez comment votre appareil contribue au réseau Google (par défaut Toutes les zones pour une contribution participative ou uniquement les zones à forte affluence).",
-          "subentry": "Enregistrez ces options pour le groupe de fonctionnalités sélectionné. Consultez [Sous-entrées et groupes de fonctionnalités]({subentries_docs_url}) pour des exemples."
+          "subentry": "Enregistrez ces options pour le groupe de fonctionnalités sélectionné. Consultez [Sous-entrées et groupes de fonctionnalités]({subentries_docs_url}) pour des exemples.",
+          "show_location_age": "Lorsqu'il est activé (par défaut), un attribut « location_age » (arrondi à 1 minute) est ajouté à chaque entité de suivi. Désactivez-le pour éliminer toutes les écritures dans la base de données pour les appareils fixes. L'attribut absolu « last_seen » et les entités sensor.*_last_seen sont toujours disponibles."
         }
       },
       "visibility": {

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -266,14 +266,16 @@
           "delete_caches_on_remove": "Elimina cache alla rimozione dell’elemento",
           "map_view_token_expiration": "Abilita scadenza dei token della vista mappa",
           "contributor_mode": "Modalità di contributo posizione",
-          "subentry": "Gruppo di funzionalità"
+          "subentry": "Gruppo di funzionalità",
+          "show_location_age": "Mostra attributo età della posizione"
         },
         "data_description": {
           "stale_threshold": "Dopo questo numero di secondi senza aggiornamento di posizione, lo stato del tracker diventa sconosciuto. Usa l'entità 'Ultima posizione' per vedere sempre l'ultima posizione nota. Predefinito: 1800 (30 minuti).",
           "delete_caches_on_remove": "Elimina i token memorizzati in cache e i metadati dei dispositivi quando questa voce viene rimossa.",
           "map_view_token_expiration": "Se abilitato, i token della vista mappa scadono dopo 1 settimana. Se disabilitato (predefinito), non scadono.",
           "contributor_mode": "Scegli come il dispositivo contribuisce alla rete di Google (per impostazione predefinita Tutte le aree per un contributo collaborativo oppure solo Aree ad alto traffico).",
-          "subentry": "Salva queste opzioni nel gruppo di funzionalità selezionato. Consulta [Sotto-voci e gruppi di funzionalità]({subentries_docs_url}) per esempi pratici."
+          "subentry": "Salva queste opzioni nel gruppo di funzionalità selezionato. Consulta [Sotto-voci e gruppi di funzionalità]({subentries_docs_url}) per esempi pratici.",
+          "show_location_age": "Se abilitato (impostazione predefinita), un attributo 'location_age' (arrotondato a 1 minuto) viene aggiunto a ogni entità tracciatore. Disabilitalo per eliminare tutte le scritture nel database per i dispositivi fissi. L'attributo assoluto 'last_seen' e le entità sensor.*_last_seen sono sempre disponibili."
         }
       },
       "visibility": {

--- a/custom_components/googlefindmy/translations/nl.json
+++ b/custom_components/googlefindmy/translations/nl.json
@@ -266,14 +266,16 @@
           "delete_caches_on_remove": "Caches verwijderen bij verwijderen item",
           "map_view_token_expiration": "Kaartweergave-tokenverloopdatum inschakelen",
           "contributor_mode": "Locatiebijdragermodus",
-          "subentry": "Functiegroep"
+          "subentry": "Functiegroep",
+          "show_location_age": "Locatie-leeftijd attribuut weergeven"
         },
         "data_description": {
           "stale_threshold": "Wanneer een locatie ouder is dan deze drempel (in seconden), wordt de trackerstatus 'onbekend'. Gebruik de entiteit 'Laatste locatie' om altijd de laatst bekende positie te zien. Standaard: 1800 (30 minuten).",
           "delete_caches_on_remove": "Verwijder gecachete tokens en apparaatmetadata wanneer dit item wordt verwijderd.",
           "map_view_token_expiration": "Indien ingeschakeld, verlopen kaartweergavetokens na 1 week. Indien uitgeschakeld (standaard), verlopen tokens niet.",
           "contributor_mode": "Kies hoe je apparaat bijdraagt aan het Google-netwerk (standaard Alle gebieden voor crowdsourced rapportage, of alleen drukbezochte gebieden).",
-          "subentry": "Sla deze opties op in de geselecteerde functiegroep. Zie [Subentries en functiegroepen]({subentries_docs_url}) voor voorbeelden."
+          "subentry": "Sla deze opties op in de geselecteerde functiegroep. Zie [Subentries en functiegroepen]({subentries_docs_url}) voor voorbeelden.",
+          "show_location_age": "Wanneer ingeschakeld (standaard), wordt een 'location_age'-attribuut (afgerond op 1 minuut) toegevoegd aan elke tracker-entiteit. Schakel uit om alle database-schrijfacties voor stationaire apparaten te elimineren. Het absolute 'last_seen'-attribuut en sensor.*_last_seen-entiteiten zijn altijd beschikbaar."
         }
       },
       "visibility": {

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -266,14 +266,16 @@
           "delete_caches_on_remove": "Usuń pamięć podręczną podczas usuwania wpisu",
           "map_view_token_expiration": "Włącz wygasanie tokenu widoku mapy",
           "contributor_mode": "Tryb raportowania lokalizacji",
-          "subentry": "Grupa funkcji"
+          "subentry": "Grupa funkcji",
+          "show_location_age": "Pokaż atrybut wieku lokalizacji"
         },
         "data_description": {
           "stale_threshold": "Po upływie tej liczby sekund bez aktualizacji lokalizacji, status trackera zmienia się na nieznany. Użyj encji 'Ostatnia lokalizacja', aby zawsze widzieć ostatnią znaną pozycję. Domyślnie: 1800 (30 minut).",
           "delete_caches_on_remove": "Usuwa buforowane tokeny i metadane urządzeń podczas usuwania tego wpisu.",
           "map_view_token_expiration": "Po włączeniu tokeny widoku mapy wygasają po 1 tygodniu. Po wyłączeniu (domyślnie) nie wygasają.",
           "contributor_mode": "Wybierz, jak urządzenie współpracuje z siecią Google (domyślnie Wszystkie obszary w trybie crowdsourcingu lub tylko obszary o dużym ruchu).",
-          "subentry": "Zapisz te opcje w wybranej grupie funkcji. Zobacz [Podpozycje i grupy funkcji]({subentries_docs_url}), aby poznać przykłady."
+          "subentry": "Zapisz te opcje w wybranej grupie funkcji. Zobacz [Podpozycje i grupy funkcji]({subentries_docs_url}), aby poznać przykłady.",
+          "show_location_age": "Gdy jest włączony (domyślnie), atrybut 'location_age' (zaokrąglony do 1 minuty) jest dodawany do każdej encji lokalizatora. Wyłącz, aby wyeliminować wszystkie zapisy do bazy danych dla urządzeń stacjonarnych. Atrybut bezwzględny 'last_seen' i encje sensor.*_last_seen są zawsze dostępne."
         }
       },
       "visibility": {

--- a/custom_components/googlefindmy/translations/pt-BR.json
+++ b/custom_components/googlefindmy/translations/pt-BR.json
@@ -266,14 +266,16 @@
           "delete_caches_on_remove": "Exclua caches ao remover entrada",
           "map_view_token_expiration": "Ativar a expiração do token de visualização do mapa",
           "contributor_mode": "Modo de contribuidor de localização",
-          "subentry": "Grupo de recursos"
+          "subentry": "Grupo de recursos",
+          "show_location_age": "Mostrar atributo de idade da localização"
         },
         "data_description": {
           "stale_threshold": "Após este número de segundos sem atualização de localização, o status do rastreador muda para desconhecido. Use a entidade 'Última localização' para ver sempre a última posição conhecida. Padrão: 1800 (30 minutos).",
           "delete_caches_on_remove": "Remova os tokens armazenados em cache e os metadados do dispositivo quando esta entrada for excluída.",
           "map_view_token_expiration": "Quando ativado, os tokens de visualização do mapa expiram após 1 semana. ",
           "contributor_mode": "Escolha como seu dispositivo contribui para a rede do Google (todas as áreas por padrão para relatórios de crowdsourcing ou apenas áreas de alto tráfego).",
-          "subentry": "Armazene essas opções no grupo de recursos selecionado. Consulte [Subentradas e grupos de recursos]({subentries_docs_url}) para exemplos."
+          "subentry": "Armazene essas opções no grupo de recursos selecionado. Consulte [Subentradas e grupos de recursos]({subentries_docs_url}) para exemplos.",
+          "show_location_age": "Quando ativado (padrão), um atributo 'location_age' (arredondado para 1 minuto) é adicionado a cada entidade rastreadora. Desative para eliminar todas as gravações de banco de dados para dispositivos estacionários. O atributo absoluto 'last_seen' e as entidades sensor.*_last_seen estão sempre disponíveis."
         }
       },
       "visibility": {

--- a/custom_components/googlefindmy/translations/pt.json
+++ b/custom_components/googlefindmy/translations/pt.json
@@ -266,14 +266,16 @@
           "delete_caches_on_remove": "Exclua caches ao remover entrada",
           "map_view_token_expiration": "Ativar a expiração do token de visualização do mapa",
           "contributor_mode": "Modo de contribuidor de localização",
-          "subentry": "Grupo de recursos"
+          "subentry": "Grupo de recursos",
+          "show_location_age": "Mostrar atributo de idade da localização"
         },
         "data_description": {
           "stale_threshold": "Após este número de segundos sem atualização de localização, o estado do rastreador muda para desconhecido. Use a entidade 'Última localização' para ver sempre a última posição conhecida. Predefinição: 1800 (30 minutos).",
           "delete_caches_on_remove": "Remova os tokens armazenados em cache e os metadados do dispositivo quando esta entrada for excluída.",
           "map_view_token_expiration": "Quando ativado, os tokens de visualização do mapa expiram após 1 semana. ",
           "contributor_mode": "Escolha como seu dispositivo contribui para a rede do Google (todas as áreas por padrão para relatórios de crowdsourcing ou apenas áreas de alto tráfego).",
-          "subentry": "Armazene essas opções no grupo de recursos selecionado. Consulte [Subentradas e grupos de recursos]({subentries_docs_url}) para exemplos."
+          "subentry": "Armazene essas opções no grupo de recursos selecionado. Consulte [Subentradas e grupos de recursos]({subentries_docs_url}) para exemplos.",
+          "show_location_age": "Quando ativado (predefinição), um atributo 'location_age' (arredondado para 1 minuto) é adicionado a cada entidade rastreadora. Desative para eliminar todas as escrituras na base de dados para dispositivos estacionários. O atributo absoluto 'last_seen' e as entidades sensor.*_last_seen estão sempre disponíveis."
         }
       },
       "visibility": {


### PR DESCRIPTION
Hi! Thanks for this custom component!

I was poking around my own install and found that two things were causing substantial database writes and bloat:

### 1. Thrashing state due to `self.data` replacement instead of upsert

When an FCM push payload is received, `push_updated()` is invoked. The payload only contains data for the specific device with the update. In the original implementation, the coordinator completely replaced `self.data` with this single device update.

Any device absent from the current push window would return  `False ` under  `coordinator_has_device()` , setting its tracker entity into  "unknown"  state. This causes devices to thrash between "unknown" and their actual state, until the next poll correctly computes state for all devices, which leads to state table bloat, and automations which trigger on state change to spuriously fire.

#### Fix

`push_updated()` upserts the device updates into the existing data object instead of completely replacing data.

### 2. Relative `location_age` causes state/attribute updates each second

Including a second-precision`location_age` in each state's attribute causes `old_state.attributes == new_state.attributes` to almost always return `False`, causing the component to generate a flood of attribute (and thus state) updates where the only change was the relative age. This is pretty inefficient, especially since the attribute payload for these states is fairly bulky.

#### Fix

I personally don't think we need a `location_age` attribute property at all, since the equivalent can be trivially calculated using absolute timestamps already provided:

```jinja
{{ (as_timestamp(now()) - as_timestamp(state_attr('device_tracker.{device}', 'last_seen') or now())) | int }}
```

But to avoid a hard breaking change, I implemented two fixes:

1: Round `location_age` to the nearest minute -- this effectively reduces attribute updates to 1.6% of the original load.
2. Made `location_age` optional and bound to a settings toggle (but default it to true)

I'm happy to simplify by just removing it entirely or defaulting the setting to false, however.

