### PR TITLE
Bring PR #162 and PR #159 into 1.7 (closes #162 closes #159)

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ The integration provides a couple of Home Assistant Actions for use with automat
 - Extended timeout allows up to 60 seconds for device response
 - Check firewall settings for Firebase Cloud Messaging
 - Review FCM debug logs for connection details
+- Ensure port 5228 is forwarded if you run this behind reverse-proxy, inside KVM or any other virtual environment not directly exposed.
 
 ### Authentication Expires Repeatedly
 - Google may revoke tokens when API requests originate from a different IP address or geographic region than where the token was originally created.

--- a/custom_components/googlefindmy/map_view.py
+++ b/custom_components/googlefindmy/map_view.py
@@ -415,7 +415,8 @@ class GoogleFindMyMapView(HomeAssistantView):
     <script>
         var map = L.map('map').setView([{center_lat}, {center_lon}], 13);
         L.tileLayer('https://{{s}}.tile.openstreetmap.org/{{z}}/{{x}}/{{y}}.png', {{
-            attribution: '© OpenStreetMap contributors'
+            attribution: '© OpenStreetMap contributors',
+            referrerPolicy: 'origin'
         }}).addTo(map);
 
         var locations = {locations_json};


### PR DESCRIPTION
Bundles two open community PRs that target `main` but apply cleanly on top of `1.7`. Cherry-picked into the fork's `1.7.0-5` branch so fork users get them in the next release cycle; opening this against `1.7` so they also land in the upstream release line. **Original authorship is preserved on both commits** (`git log` shows the original authors; I'm only the committer for conflict resolution / cherry-pick provenance).

## Bundled PRs

- **#162** by @hemperek — Update README.md: mention port 5228 for FCM (docs, no code change)
- **#159** by @simon-smith — Add `referrerPolicy='origin'` to tileLayer in `map_view.py` (privacy hardening, drops Referer header to OSM tile server)

## Provenance

Both commits carry the `(cherry picked from commit …)` trailer (`git cherry-pick -x`) pointing to the original PR commits. Author = original contributor, Committer = me.

```
70cae080 Simon Smith   | Add referrerPolicy to tileLayer in map_view.py
365dfe43 Tomasz Hemperek | Update README.md
```

## Conflict resolution

PR #162 applied cleanly.
PR #159 had a trivial whitespace conflict against the `1.7` `map_view.py` refactor (the surrounding block changed indent 16→4 spaces in the new layout). Resolved manually with identical semantics — `referrerPolicy: 'origin'` added to the `L.tileLayer(...)` options object. The commit body documents the resolution.

## Credit

Both PRs should get the credit. If this bundle PR is merged, GitHub will auto-close #162 and #159 via the `closes` keywords in the title, and the contributor list will show **Tomasz Hemperek** and **Simon Smith** as authors of the two commits (which is the correct attribution — they wrote the patches). I did not author either change.

## CI

Green on the `jleinenbach:1.7.0-5` head with these exact two SHAs on top of #169's merge base. No new test failures introduced (no code paths changed for #162; #159 is a one-line option addition to an existing `L.tileLayer` call).

## Why bundle into `1.7` instead of waiting for `main`

The two original PRs target `main`. The `1.7` release branch is where active fork users pull from, so without this bundle the next `1.7` release wouldn't include either fix. Once `main` catches up to `1.7` and the original PRs merge there, the same SHAs will appear naturally in the `main` history.