### PR TITLE
Canonical ConfigEntry stub fixture + test migration (tests-only)

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -37,6 +37,47 @@ See the modern registry TypeError propagation reminder in
 when updating registry expectations so new coverage stays aligned with
 Home Assistant's current registry keyword surface.
 
+### Canonical config-entry stub: `make_config_entry`
+
+New tests **must** use
+`tests.helpers.config_entries_stub.make_config_entry(...)` instead of
+ad-hoc `SimpleNamespace(entry_id=..., data=..., options=...)` constructions.
+The factory guarantees that `data` and `options` are always plain dicts
+(never `None`), which is exactly the contract production helpers like
+`_opt()` and `entry.data.get(...)` rely on. Ad-hoc stubs that omit
+either field — or set them to `None` — are the structural cause of the
+`AttributeError` failures fixed defensively in PR #172.
+
+Use the full import path; do not re-export through
+`tests/helpers/__init__.py` (mirrors the convention for
+`install_config_entries_stubs`):
+
+```python
+from tests.helpers.config_entries_stub import make_config_entry
+
+entry = make_config_entry(
+    entry_id="test_entry",
+    data={"oauth_token": "abc"},
+    options={"poll_interval": 60},
+)
+```
+
+Field rules:
+
+- `entry_id`: explicit when the test asserts on the value; otherwise
+  auto-generated (`entry-test-<n>`, not deterministic across runs).
+- `data`/`options`: pass a dict literal; the factory copies it (in-place
+  mutation by the test does not leak into the caller).
+- Fields not in the factory signature (test-specific markers, exotic HA
+  attributes): pass via `**extra`, ideally with an inline comment
+  explaining why the field stays out of the canonical signature.
+- Methods (`async_on_unload`, `add_update_listener`, …) are intentionally
+  not part of the factory. Tests that need them attach them per-instance.
+
+Wave-based migration of existing call sites is tracked in
+`/app/memory/plans/active/PLAN_CANONICAL_CONFIG_ENTRY_STUB.md` (Commit 12
+in PR #172's follow-up).
+
 ## Package layout
 
 The test suite is a Python package (`tests/__init__.py`). Use

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -74,9 +74,9 @@ Field rules:
 - Methods (`async_on_unload`, `add_update_listener`, …) are intentionally
   not part of the factory. Tests that need them attach them per-instance.
 
-Wave-based migration of existing call sites is tracked in
-`/app/memory/plans/active/PLAN_CANONICAL_CONFIG_ENTRY_STUB.md` (Commit 12
-in PR #172's follow-up).
+Wave-based migration of the existing call sites lands in this branch as
+follow-up commits (waves 1–3); see the corresponding PR description for
+the rollout order.
 
 ## Package layout
 

--- a/tests/helpers/config_entries_stub.py
+++ b/tests/helpers/config_entries_stub.py
@@ -14,10 +14,12 @@ import asyncio
 import inspect
 from collections.abc import Mapping
 from itertools import count
-from types import MappingProxyType, ModuleType
+from types import MappingProxyType, ModuleType, SimpleNamespace
 from typing import Any
 
-__all__ = ["install_config_entries_stubs"]
+__all__ = ["install_config_entries_stubs", "make_config_entry"]
+
+_ENTRY_COUNTER = count(1)
 
 
 def install_config_entries_stubs(target: ModuleType) -> None:
@@ -306,3 +308,57 @@ def install_config_entries_stubs(target: ModuleType) -> None:
     target.OptionsFlowWithReload = OptionsFlowWithReload
     target.UNDEFINED = _UndefinedType()
     target.HANDLERS = handlers
+
+
+def make_config_entry(
+    *,
+    entry_id: str | None = None,
+    domain: str = "googlefindmy",
+    data: Mapping[str, Any] | None = None,
+    options: Mapping[str, Any] | None = None,
+    runtime_data: Any = None,
+    title: str = "Test Account",
+    unique_id: str | None = None,
+    state: str = "loaded",
+    version: int = 1,
+    minor_version: int = 0,
+    source: str = "user",
+    pref_disable_new_entities: bool = False,
+    pref_disable_polling: bool = False,
+    disabled_by: str | None = None,
+    **extra: Any,
+) -> SimpleNamespace:
+    """Canonical config-entry stub for tests.
+
+    Always sets ``data`` and ``options`` as plain dicts so production helpers
+    like ``_opt()`` and ``entry.data.get(...)`` work without additional
+    defensive code in callers. Extra keyword arguments are attached verbatim,
+    matching ad-hoc ``SimpleNamespace`` patterns previously scattered across
+    the test tree.
+
+    Mirrors the surface tests actually use; not the full HA ``ConfigEntry``
+    contract. Mock methods (``async_on_unload``, ``add_update_listener``)
+    are intentionally NOT included; add them per-test if needed.
+
+    ``_ENTRY_COUNTER`` is module-level state. pytest-xdist workers each import
+    the module fresh, so IDs are worker-isolated but not deterministic across
+    test runs. Tests that assert on ``entry_id`` MUST pass ``entry_id=...``
+    explicitly.
+    """
+    return SimpleNamespace(
+        entry_id=entry_id or f"entry-test-{next(_ENTRY_COUNTER)}",
+        domain=domain,
+        data=dict(data or {}),
+        options=dict(options or {}),
+        runtime_data=runtime_data,
+        title=title,
+        unique_id=unique_id,
+        state=state,
+        version=version,
+        minor_version=minor_version,
+        source=source,
+        pref_disable_new_entities=pref_disable_new_entities,
+        pref_disable_polling=pref_disable_polling,
+        disabled_by=disabled_by,
+        **extra,
+    )

--- a/tests/helpers/test_config_entries_stub.py
+++ b/tests/helpers/test_config_entries_stub.py
@@ -1,0 +1,89 @@
+"""Smoke tests for the canonical ``make_config_entry`` factory.
+
+These guard the documented defaults (``data``/``options`` always dict,
+auto-generated ``entry_id``, ``**extra`` pass-through) so future migrations
+to the factory can rely on them. See ``tests/AGENTS.md`` for the convention.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from tests.helpers.config_entries_stub import make_config_entry
+
+
+def test_make_config_entry_returns_simplenamespace() -> None:
+    entry = make_config_entry()
+    assert isinstance(entry, SimpleNamespace)
+
+
+def test_data_and_options_default_to_dict_not_none() -> None:
+    entry = make_config_entry()
+    assert entry.data == {}
+    assert entry.options == {}
+    assert isinstance(entry.data, dict)
+    assert isinstance(entry.options, dict)
+
+
+def test_data_and_options_are_copied_into_dict() -> None:
+    src_data = {"oauth_token": "abc"}
+    src_options = {"poll_interval": 60}
+    entry = make_config_entry(data=src_data, options=src_options)
+
+    assert entry.data == {"oauth_token": "abc"}
+    assert entry.options == {"poll_interval": 60}
+    entry.data["mutated"] = True
+    assert "mutated" not in src_data
+
+
+def test_entry_id_auto_generated_when_omitted() -> None:
+    entry_a = make_config_entry()
+    entry_b = make_config_entry()
+    assert entry_a.entry_id.startswith("entry-test-")
+    assert entry_b.entry_id.startswith("entry-test-")
+    assert entry_a.entry_id != entry_b.entry_id
+
+
+def test_entry_id_explicit_overrides_auto() -> None:
+    entry = make_config_entry(entry_id="custom-id")
+    assert entry.entry_id == "custom-id"
+
+
+def test_default_domain_is_googlefindmy() -> None:
+    entry = make_config_entry()
+    assert entry.domain == "googlefindmy"
+
+
+def test_explicit_kwargs_override_defaults() -> None:
+    entry = make_config_entry(
+        domain="other",
+        title="My Account",
+        unique_id="user@example.com",
+        state="setup_in_progress",
+        version=2,
+        minor_version=3,
+        source="reauth",
+    )
+    assert entry.domain == "other"
+    assert entry.title == "My Account"
+    assert entry.unique_id == "user@example.com"
+    assert entry.state == "setup_in_progress"
+    assert entry.version == 2
+    assert entry.minor_version == 3
+    assert entry.source == "reauth"
+
+
+def test_extra_kwargs_are_passed_through() -> None:
+    entry = make_config_entry(my_test_marker="present")
+    assert entry.my_test_marker == "present"
+
+
+def test_runtime_data_defaults_to_none() -> None:
+    entry = make_config_entry()
+    assert entry.runtime_data is None
+
+
+def test_runtime_data_can_be_set() -> None:
+    sentinel = object()
+    entry = make_config_entry(runtime_data=sentinel)
+    assert entry.runtime_data is sentinel

--- a/tests/test_binary_sensor_icons.py
+++ b/tests/test_binary_sensor_icons.py
@@ -8,6 +8,8 @@ from types import ModuleType, SimpleNamespace
 
 import pytest
 
+from tests.helpers.config_entries_stub import make_config_entry
+
 if "homeassistant.components.binary_sensor" not in sys.modules:
     binary_sensor_module = ModuleType("homeassistant.components.binary_sensor")
 
@@ -126,7 +128,7 @@ def test_auth_status_sensor_icon(event_state: bool, expected_icon: str) -> None:
     """Auth status sensor exposes state-specific icons for clarity."""
 
     coordinator = SimpleNamespace(api_status=None)
-    entry = SimpleNamespace(entry_id="entry-id")
+    entry = make_config_entry(entry_id="entry-id")
     sensor = GoogleFindMyAuthStatusSensor(
         coordinator,
         entry,
@@ -156,7 +158,7 @@ def test_auth_status_sensor_attributes_include_nova_snapshots() -> None:
             changed_at=1700000100.5,
         ),
     )
-    entry = SimpleNamespace(entry_id="entry-id")
+    entry = make_config_entry(entry_id="entry-id")
     sensor = GoogleFindMyAuthStatusSensor(
         coordinator,
         entry,
@@ -179,7 +181,7 @@ def test_auth_status_sensor_attributes_return_none_when_unavailable() -> None:
     """Missing status snapshots result in no extra attributes."""
 
     coordinator = SimpleNamespace(api_status=None, fcm_status=None)
-    entry = SimpleNamespace(entry_id="entry-id")
+    entry = make_config_entry(entry_id="entry-id")
     sensor = GoogleFindMyAuthStatusSensor(
         coordinator,
         entry,
@@ -195,7 +197,7 @@ def test_service_diagnostic_sensors_share_service_device_identifiers() -> None:
     """Service diagnostics attach the same identifier set to the hub device."""
 
     coordinator = SimpleNamespace(api_status=None, fcm_status=None)
-    entry = SimpleNamespace(entry_id="entry-id")
+    entry = make_config_entry(entry_id="entry-id")
     coordinator.config_entry = entry
     polling = GoogleFindMyPollingSensor(
         coordinator,

--- a/tests/test_ble_battery_sensor.py
+++ b/tests/test_ble_battery_sensor.py
@@ -33,6 +33,7 @@ from custom_components.googlefindmy.sensor import (
     BLE_BATTERY_DESCRIPTION,
     GoogleFindMyBLEBatterySensor,
 )
+from tests.helpers.config_entries_stub import make_config_entry
 
 # ---------------------------------------------------------------------------
 # Constants used to build test payloads
@@ -139,7 +140,7 @@ def _fake_coordinator(
 ) -> SimpleNamespace:
     """Create a minimal coordinator stub for sensor tests."""
     return SimpleNamespace(
-        config_entry=SimpleNamespace(entry_id=entry_id),
+        config_entry=make_config_entry(entry_id=entry_id),
         is_device_present=lambda did: present,
         is_device_visible_in_subentry=lambda key, did: visible,
         async_update_listeners=lambda: None,

--- a/tests/test_button_restore_state.py
+++ b/tests/test_button_restore_state.py
@@ -17,6 +17,7 @@ from custom_components.googlefindmy.const import (
     SERVICE_SUBENTRY_KEY,
     TRACKER_SUBENTRY_KEY,
 )
+from tests.helpers.config_entries_stub import make_config_entry
 
 
 @pytest.mark.asyncio
@@ -26,7 +27,7 @@ async def test_button_restores_last_pressed(monkeypatch: pytest.MonkeyPatch) -> 
     hass = SimpleNamespace(data={DOMAIN: {}}, services=SimpleNamespace(), loop=None)
     coordinator = SimpleNamespace(
         hass=hass,
-        config_entry=SimpleNamespace(entry_id="entry-id"),
+        config_entry=make_config_entry(entry_id="entry-id"),
         is_device_visible_in_subentry=lambda *_args: True,
         can_request_location=lambda _dev_id: True,
         async_request_refresh=AsyncMock(),
@@ -66,7 +67,7 @@ async def test_button_records_last_pressed_on_press() -> None:
     )
     coordinator = SimpleNamespace(
         hass=hass,
-        config_entry=SimpleNamespace(entry_id="entry-id"),
+        config_entry=make_config_entry(entry_id="entry-id"),
         is_device_visible_in_subentry=lambda *_args: True,
         can_play_sound=lambda _dev_id: True,
         async_request_refresh=AsyncMock(),

--- a/tests/test_button_setup.py
+++ b/tests/test_button_setup.py
@@ -14,6 +14,7 @@ from typing import Any
 import pytest
 
 from tests.helpers import compile_class_method_from_module
+from tests.helpers.config_entries_stub import make_config_entry
 
 pytestmark = pytest.mark.asyncio
 
@@ -223,7 +224,7 @@ async def test_blank_device_name_populates_buttons(
     class _StubCoordinator(button_module.GoogleFindMyCoordinator):
         def __init__(self, devices: list[dict[str, Any]]) -> None:
             self.hass = SimpleNamespace()
-            self.config_entry = SimpleNamespace(entry_id="entry-id")
+            self.config_entry = make_config_entry(entry_id="entry-id")
             self.data = devices
             self._listeners: list[Any] = []
 
@@ -312,7 +313,7 @@ async def test_locate_button_available_when_push_unready() -> None:
     class _CoordinatorStub:
         def __init__(self) -> None:
             self.hass = SimpleNamespace()
-            self.config_entry = SimpleNamespace(entry_id="entry-id")
+            self.config_entry = make_config_entry(entry_id="entry-id")
             self.data = [{"id": "device-1", "name": "Tracker"}]
             self._listeners: list[Any] = []
             self._is_polling = False
@@ -365,7 +366,7 @@ async def test_locate_button_unavailable_on_gate_error() -> None:
     class _CoordinatorStub:
         def __init__(self) -> None:
             self.hass = SimpleNamespace()
-            self.config_entry = SimpleNamespace(entry_id="entry-id")
+            self.config_entry = make_config_entry(entry_id="entry-id")
             self.data = [{"id": "device-1", "name": "Tracker"}]
             self._listeners: list[Any] = []
             self._is_polling = False

--- a/tests/test_config_entry_startup.py
+++ b/tests/test_config_entry_startup.py
@@ -4,12 +4,12 @@ import asyncio
 import functools
 import importlib
 from collections.abc import Callable
-from types import SimpleNamespace
 from typing import Any
 
 import pytest
 
 from custom_components.googlefindmy.const import TRACKER_SUBENTRY_KEY
+from tests.helpers.config_entries_stub import make_config_entry
 from tests.test_hass_data_layout import _prepare_async_setup_entry_harness
 
 
@@ -116,7 +116,7 @@ async def test_coordinator_first_refresh_fallback(
 
     class _Harness(coordinator_module.GoogleFindMyCoordinator):
         def __init__(self) -> None:
-            self.config_entry = SimpleNamespace(entry_id="entry-test")
+            self.config_entry = make_config_entry(entry_id="entry-test")
 
         async def async_refresh(self) -> None:  # type: ignore[override]
             called.append(None)

--- a/tests/test_config_flow_hub_entry.py
+++ b/tests/test_config_flow_hub_entry.py
@@ -16,6 +16,7 @@ from custom_components.googlefindmy.const import (
     SUBENTRY_TYPE_SERVICE,
     SUBENTRY_TYPE_TRACKER,
 )
+from tests.helpers.config_entries_stub import make_config_entry
 from tests.helpers.config_flow import (
     ConfigEntriesDomainUniqueIdLookupMixin,
     ConfigEntriesFlowManagerStub,
@@ -69,7 +70,7 @@ async def test_hub_flow_creates_entry_when_requested(
 
     caplog.set_level(logging.INFO)
 
-    entry = SimpleNamespace(entry_id="entry-123", data={}, options={}, subentries={})
+    entry = make_config_entry(entry_id="entry-123", subentries={})
 
     class _ConfigEntriesManager(ConfigEntriesDomainUniqueIdLookupMixin):
         def __init__(self) -> None:
@@ -152,7 +153,7 @@ async def test_hub_subentry_flow_logs_and_delegates(
     )
 
     handler = object.__new__(config_flow.HubSubentryFlowHandler)
-    handler.config_entry = SimpleNamespace(entry_id="entry-1")  # type: ignore[attr-defined]
+    handler.config_entry = make_config_entry(entry_id="entry-1")  # type: ignore[attr-defined]
     handler.subentry = None  # type: ignore[attr-defined]
     handler.hass = SimpleNamespace()  # type: ignore[assignment]
 

--- a/tests/test_config_flow_reconfigure.py
+++ b/tests/test_config_flow_reconfigure.py
@@ -22,15 +22,16 @@ from custom_components.googlefindmy.const import (
     OPT_GOOGLE_HOME_FILTER_ENABLED,
     OPT_MAP_VIEW_TOKEN_EXPIRATION,
 )
+from tests.helpers.config_entries_stub import make_config_entry
 from tests.helpers.config_flow import (
     ConfigEntriesDomainUniqueIdLookupMixin,
     attach_config_entries_flow_manager,
     set_config_flow_unique_id,
 )
-from tests.test_config_flow_subentry_sync import _ConfigEntriesManagerStub, _EntryStub
+from tests.test_config_flow_subentry_sync import _ConfigEntriesManagerStub
 
 
-def _build_reconfigure_flow(entry: _EntryStub) -> config_flow.ConfigFlow:
+def _build_reconfigure_flow(entry: SimpleNamespace) -> config_flow.ConfigFlow:
     flow = config_flow.ConfigFlow()
     hass = SimpleNamespace()
 
@@ -42,7 +43,7 @@ def _build_reconfigure_flow(entry: _EntryStub) -> config_flow.ConfigFlow:
             assert domain == config_flow.DOMAIN
             return [entry]
 
-        def async_get_entry(self, entry_id: str) -> _EntryStub | None:
+        def async_get_entry(self, entry_id: str) -> SimpleNamespace | None:
             if entry_id == entry.entry_id:
                 return entry
             return None
@@ -75,7 +76,7 @@ def _build_reconfigure_flow(entry: _EntryStub) -> config_flow.ConfigFlow:
 async def test_reconfigure_flow_skips_already_configured_abort() -> None:
     """Reconfigure source should route to async_step_reconfigure without aborting."""
 
-    entry = _EntryStub()
+    entry = make_config_entry(entry_id="entry-1", title="Find My", subentries={}, runtime_data=SimpleNamespace())
     entry.data[CONF_GOOGLE_EMAIL] = "existing@example.com"
     entry.unique_id = entry.data[CONF_GOOGLE_EMAIL]
 
@@ -100,19 +101,19 @@ async def test_reconfigure_flow_skips_already_configured_abort() -> None:
 async def test_reconfigure_reload_recreates_subentries_and_platforms() -> None:
     """Reload after reconfigure should recreate subentries with stable IDs."""
 
-    entry = _EntryStub()
+    entry = make_config_entry(entry_id="entry-1", title="Find My", subentries={}, runtime_data=SimpleNamespace())
     entry.data[CONF_GOOGLE_EMAIL] = "existing@example.com"
     flow = config_flow.ConfigFlow()
     hass = SimpleNamespace()
     hass.config_entries = _ConfigEntriesManagerStub(entry)
     hass.config_entries.forward_setup_calls: list[
-        tuple[_EntryStub, tuple[str, ...]]
+        tuple[SimpleNamespace, tuple[str, ...]]
     ] = []
     hass.config_entries.setup_calls = []
     hass.verify_event_loop_thread = lambda *_args, **_kwargs: None
 
     async def _forward_setups(
-        entry_to_forward: _EntryStub, platforms: tuple[str, ...]
+        entry_to_forward: SimpleNamespace, platforms: tuple[str, ...]
     ) -> None:
         hass.config_entries.forward_setup_calls.append(
             (entry_to_forward, tuple(platforms))
@@ -198,7 +199,7 @@ async def test_reconfigure_reload_logs_false(caplog: pytest.LogCaptureFixture) -
 
     caplog.set_level(logging.WARNING)
 
-    entry = _EntryStub()
+    entry = make_config_entry(entry_id="entry-1", title="Find My", subentries={}, runtime_data=SimpleNamespace())
     entry.data[CONF_GOOGLE_EMAIL] = "existing@example.com"
 
     flow = config_flow.ConfigFlow()
@@ -229,7 +230,7 @@ async def test_reconfigure_reload_logs_false(caplog: pytest.LogCaptureFixture) -
 async def test_reconfigure_forces_device_list_refresh() -> None:
     """Mark forced device list refresh on reconfigure and call coordinator hook."""
 
-    entry = _EntryStub()
+    entry = make_config_entry(entry_id="entry-1", title="Find My", subentries={}, runtime_data=SimpleNamespace())
     entry.data[CONF_GOOGLE_EMAIL] = "existing@example.com"
 
     refresh_calls: list[tuple[str | None, bool]] = []
@@ -293,7 +294,7 @@ async def test_reconfigure_reload_logs_deferred_failures(
 
     caplog.set_level(logging.WARNING)
 
-    entry = _EntryStub()
+    entry = make_config_entry(entry_id="entry-1", title="Find My", subentries={}, runtime_data=SimpleNamespace())
     entry.data[CONF_GOOGLE_EMAIL] = "existing@example.com"
 
     flow = config_flow.ConfigFlow()
@@ -352,7 +353,7 @@ async def test_reconfigure_reload_logs_when_scheduler_missing(
 
     caplog.set_level(logging.ERROR)
 
-    entry = _EntryStub()
+    entry = make_config_entry(entry_id="entry-1", title="Find My", subentries={}, runtime_data=SimpleNamespace())
     entry.data[CONF_GOOGLE_EMAIL] = "existing@example.com"
 
     flow = config_flow.ConfigFlow()

--- a/tests/test_config_flow_subentry_sync.py
+++ b/tests/test_config_flow_subentry_sync.py
@@ -41,6 +41,7 @@ from custom_components.googlefindmy.const import (
     TRACKER_SUBENTRY_KEY,
     service_device_identifier,
 )
+from tests.helpers.config_entries_stub import make_config_entry
 from tests.helpers.config_flow import (
     ConfigEntriesDomainUniqueIdLookupMixin,
     attach_config_entries_flow_manager,
@@ -62,7 +63,7 @@ def _stable_subentry_id(entry_id: str, key: str) -> str:
 class _ConfigEntriesManagerStub(ConfigEntriesDomainUniqueIdLookupMixin):
     """Stub mimicking Home Assistant's config entries manager."""
 
-    def __init__(self, entry: _EntryStub) -> None:
+    def __init__(self, entry: SimpleNamespace) -> None:
         self._entry = entry
         self.created: list[dict[str, Any]] = []
         self.updated: list[dict[str, Any]] = []
@@ -78,13 +79,13 @@ class _ConfigEntriesManagerStub(ConfigEntriesDomainUniqueIdLookupMixin):
 
     def async_entry_for_domain_unique_id(
         self, domain: str, unique_id: str
-    ) -> _EntryStub | None:
+    ) -> SimpleNamespace | None:
         return cast(
-            _EntryStub | None,
+            SimpleNamespace | None,
             super().async_entry_for_domain_unique_id(domain, unique_id),
         )
 
-    def async_get_entry(self, entry_id: str) -> _EntryStub | None:
+    def async_get_entry(self, entry_id: str) -> SimpleNamespace | None:
         if entry_id == self._entry.entry_id:
             return self._entry
         return None
@@ -99,7 +100,7 @@ class _ConfigEntriesManagerStub(ConfigEntriesDomainUniqueIdLookupMixin):
         self.setup_calls.append(entry_id)
         return True
 
-    def async_update_entry(self, entry: _EntryStub, **kwargs: Any) -> None:
+    def async_update_entry(self, entry: SimpleNamespace, **kwargs: Any) -> None:
         assert entry is self._entry
         payload = dict(kwargs)
         self.entry_updates.append(payload)
@@ -112,7 +113,7 @@ class _ConfigEntriesManagerStub(ConfigEntriesDomainUniqueIdLookupMixin):
 
     def async_create_subentry(
         self,
-        entry: _EntryStub,
+        entry: SimpleNamespace,
         *,
         data: dict[str, Any],
         title: str,
@@ -132,7 +133,7 @@ class _ConfigEntriesManagerStub(ConfigEntriesDomainUniqueIdLookupMixin):
         return self.async_add_subentry(entry, subentry)
 
     def async_add_subentry(
-        self, entry: _EntryStub, subentry: ConfigSubentry
+        self, entry: SimpleNamespace, subentry: ConfigSubentry
     ) -> ConfigSubentry:
         assert entry is self._entry
         if isinstance(subentry.unique_id, str):
@@ -158,7 +159,7 @@ class _ConfigEntriesManagerStub(ConfigEntriesDomainUniqueIdLookupMixin):
 
     def async_update_subentry(
         self,
-        entry: _EntryStub,
+        entry: SimpleNamespace,
         subentry: ConfigSubentry,
         *,
         data: dict[str, Any],
@@ -192,7 +193,7 @@ class _ConfigEntriesManagerStub(ConfigEntriesDomainUniqueIdLookupMixin):
         )
 
     async def async_remove_subentry(
-        self, entry: _EntryStub, *, subentry_id: str
+        self, entry: SimpleNamespace, *, subentry_id: str
     ) -> bool:
         assert entry is self._entry
         removed = self._entry.subentries.pop(subentry_id, None)
@@ -205,7 +206,7 @@ class _ConfigEntriesManagerStub(ConfigEntriesDomainUniqueIdLookupMixin):
 class _HassStub:
     """Home Assistant stub exposing config entry helpers to the flow."""
 
-    def __init__(self, entry: _EntryStub) -> None:
+    def __init__(self, entry: SimpleNamespace) -> None:
         self.config_entries = _ConfigEntriesManagerStub(entry)
         self.data: dict[str, Any] = {DOMAIN: {"entries": {entry.entry_id: entry}}}
 
@@ -213,20 +214,7 @@ class _HassStub:
         return asyncio.create_task(coro)
 
 
-class _EntryStub:
-    """Lightweight config entry stub with mutable subentries."""
-
-    def __init__(self) -> None:
-        self.entry_id = "entry-1"
-        self.title = "Find My"
-        self.data: dict[str, Any] = {}
-        self.options: dict[str, Any] = {}
-        self.subentries: dict[str, ConfigSubentry] = {}
-        self.runtime_data = SimpleNamespace()
-        self.version = 1
-
-
-def _build_flow(entry: _EntryStub) -> config_flow.ConfigFlow:
+def _build_flow(entry: SimpleNamespace) -> config_flow.ConfigFlow:
     flow = config_flow.ConfigFlow()
     hass = _HassStub(entry)
     flow.hass = hass  # type: ignore[assignment]
@@ -251,7 +239,12 @@ def _build_flow(entry: _EntryStub) -> config_flow.ConfigFlow:
 async def test_device_selection_creates_feature_groups_with_flags() -> None:
     """Sync helper should create service and tracker subentries with expected flags."""
 
-    entry = _EntryStub()
+    entry = make_config_entry(
+        entry_id="entry-1",
+        title="Find My",
+        subentries={},
+        runtime_data=SimpleNamespace(),
+    )
     flow = _build_flow(entry)
     context_map = flow._ensure_subentry_context()
 
@@ -310,7 +303,12 @@ async def test_device_selection_creates_feature_groups_with_flags() -> None:
 async def test_subentry_manager_deduplicates_colliding_tracker_entries() -> None:
     """ConfigEntrySubEntryManager should remove duplicates before retrying updates."""
 
-    entry = _EntryStub()
+    entry = make_config_entry(
+        entry_id="entry-1",
+        title="Find My",
+        subentries={},
+        runtime_data=SimpleNamespace(),
+    )
     tracker_unique_id = f"{entry.entry_id}-{TRACKER_SUBENTRY_KEY}"
     canonical = ConfigSubentry(
         data=MappingProxyType(
@@ -378,7 +376,12 @@ async def test_subentry_manager_deduplicates_colliding_tracker_entries() -> None
 def test_subentry_manager_normalizes_group_keys_by_type() -> None:
     """Service/tracker subentries should use canonical group keys."""
 
-    entry = _EntryStub()
+    entry = make_config_entry(
+        entry_id="entry-1",
+        title="Find My",
+        subentries={},
+        runtime_data=SimpleNamespace(),
+    )
     service_subentry = ConfigSubentry(
         data=MappingProxyType(
             {
@@ -425,7 +428,12 @@ def test_subentry_manager_normalizes_group_keys_by_type() -> None:
 def test_reconfigure_context_prefers_canonical_subentry_keys() -> None:
     """Reconfigure context should seed IDs using canonical group keys."""
 
-    entry = _EntryStub()
+    entry = make_config_entry(
+        entry_id="entry-1",
+        title="Find My",
+        subentries={},
+        runtime_data=SimpleNamespace(),
+    )
     service_subentry = ConfigSubentry(
         data=MappingProxyType(
             {
@@ -469,7 +477,12 @@ def test_reconfigure_context_prefers_canonical_subentry_keys() -> None:
 async def test_device_selection_updates_existing_feature_group() -> None:
     """Sync helper should update an existing subentry with new feature flags."""
 
-    entry = _EntryStub()
+    entry = make_config_entry(
+        entry_id="entry-1",
+        title="Find My",
+        subentries={},
+        runtime_data=SimpleNamespace(),
+    )
     existing = ConfigSubentry(
         data=MappingProxyType(
             {
@@ -528,7 +541,12 @@ def test_service_device_binding_clears_stale_subentry(
 ) -> None:
     """Service device updates must clear stale config_subentry_id bindings."""
 
-    entry = _EntryStub()
+    entry = make_config_entry(
+        entry_id="entry-1",
+        title="Find My",
+        subentries={},
+        runtime_data=SimpleNamespace(),
+    )
     hass = SimpleNamespace()
 
     expected_identifiers = {service_device_identifier(entry.entry_id)}
@@ -575,7 +593,12 @@ def test_service_device_binding_sets_add_config_entry_id(
 ) -> None:
     """Service device binding must use add_config_entry_id when subentries exist."""
 
-    entry = _EntryStub()
+    entry = make_config_entry(
+        entry_id="entry-1",
+        title="Find My",
+        subentries={},
+        runtime_data=SimpleNamespace(),
+    )
     entry.service_subentry_id = "service-subentry"
     hass = SimpleNamespace()
 
@@ -624,7 +647,12 @@ def test_service_device_binding_retries_with_legacy_keywords(
 ) -> None:
     """Direct binding calls should retry with legacy kwargs on TypeError."""
 
-    entry = _EntryStub()
+    entry = make_config_entry(
+        entry_id="entry-1",
+        title="Find My",
+        subentries={},
+        runtime_data=SimpleNamespace(),
+    )
     entry.service_subentry_id = "service-subentry"
     hass = SimpleNamespace()
 
@@ -681,7 +709,12 @@ async def test_subentry_manager_adopts_existing_owner_on_repeated_collision(
 ) -> None:
     """Repeated unique_id collisions should adopt the existing owner subentry."""
 
-    entry = _EntryStub()
+    entry = make_config_entry(
+        entry_id="entry-1",
+        title="Find My",
+        subentries={},
+        runtime_data=SimpleNamespace(),
+    )
     shared_unique_id = f"{entry.entry_id}-{SERVICE_SUBENTRY_KEY}"
     owner = ConfigSubentry(
         data=MappingProxyType({"group_key": "service-legacy"}),
@@ -750,7 +783,12 @@ async def test_subentry_manager_adoption_missing_owner_raises(
 ) -> None:
     """Adoption should raise a HomeAssistantError when no owner exists."""
 
-    entry = _EntryStub()
+    entry = make_config_entry(
+        entry_id="entry-1",
+        title="Find My",
+        subentries={},
+        runtime_data=SimpleNamespace(),
+    )
     existing = ConfigSubentry(
         data=MappingProxyType({"group_key": SERVICE_SUBENTRY_KEY}),
         subentry_type=SUBENTRY_TYPE_SERVICE,
@@ -784,7 +822,12 @@ async def test_subentry_manager_adoption_missing_owner_raises(
 async def test_subentry_manager_preserves_adopted_owner_during_cleanup() -> None:
     """Adopted subentries must not be removed via stale alias cleanup."""
 
-    entry = _EntryStub()
+    entry = make_config_entry(
+        entry_id="entry-1",
+        title="Find My",
+        subentries={},
+        runtime_data=SimpleNamespace(),
+    )
     shared_unique_id = f"{entry.entry_id}-{SERVICE_SUBENTRY_KEY}"
     owner = ConfigSubentry(
         data=MappingProxyType({"group_key": SERVICE_SUBENTRY_KEY}),
@@ -818,7 +861,12 @@ async def test_subentry_manager_preserves_adopted_owner_during_cleanup() -> None
 def test_supported_subentry_types_returns_empty_to_hide_ui() -> None:
     """Config flow should return empty dict to hide manual subentry UI buttons."""
 
-    entry = _EntryStub()
+    entry = make_config_entry(
+        entry_id="entry-1",
+        title="Find My",
+        subentries={},
+        runtime_data=SimpleNamespace(),
+    )
     mapping = config_flow.ConfigFlow.async_get_supported_subentry_types(entry)
 
     # Must return empty dict to hide "Add hub feature group" and
@@ -831,7 +879,12 @@ def test_supported_subentry_types_returns_empty_to_hide_ui() -> None:
 async def test_async_step_migrate_creates_subentries_and_moves_options() -> None:
     """Migration flow should consolidate options and sync feature subentries."""
 
-    entry = _EntryStub()
+    entry = make_config_entry(
+        entry_id="entry-1",
+        title="Find My",
+        subentries={},
+        runtime_data=SimpleNamespace(),
+    )
     entry.version = 0
     entry.data = {
         CONF_GOOGLE_EMAIL: "Legacy@Example.com",
@@ -898,7 +951,12 @@ async def test_soft_migrate_data_to_options_tracks_option_keys(
 
     dynamic_option = "semantic_locations_v2"
     dynamic_value = {"home": "device-home"}
-    entry = _EntryStub()
+    entry = make_config_entry(
+        entry_id="entry-1",
+        title="Find My",
+        subentries={},
+        runtime_data=SimpleNamespace(),
+    )
     entry.data = {dynamic_option: dynamic_value}
 
     class _ConfigEntriesStub:
@@ -928,7 +986,12 @@ async def test_soft_migrate_data_to_options_tracks_option_keys(
 async def test_soft_migrate_data_to_options_copies_semantic_locations() -> None:
     """Soft migration should move semantic location mappings into options."""
 
-    entry = _EntryStub()
+    entry = make_config_entry(
+        entry_id="entry-1",
+        title="Find My",
+        subentries={},
+        runtime_data=SimpleNamespace(),
+    )
     semantic_locations = {"home": {"lat": 1.0, "lon": 2.0}}
     entry.data = {OPT_SEMANTIC_LOCATIONS: semantic_locations}
 

--- a/tests/test_connectivity_sensor.py
+++ b/tests/test_connectivity_sensor.py
@@ -8,6 +8,7 @@ import pytest
 
 from custom_components.googlefindmy.Auth.fcm_receiver_ha import FcmReceiverHA
 from custom_components.googlefindmy.binary_sensor import GoogleFindMyConnectivitySensor
+from tests.helpers.config_entries_stub import make_config_entry
 
 
 def _build_sensor(coordinator: Any) -> GoogleFindMyConnectivitySensor:
@@ -33,7 +34,7 @@ def test_connectivity_sensor_tracks_push_and_attributes() -> None:
         last_poll_result="failed",
         is_fcm_connected=True,
         fcm_status=SimpleNamespace(changed_at=1_650_000_000.0),
-        config_entry=SimpleNamespace(entry_id="entry"),
+        config_entry=make_config_entry(entry_id="entry"),
     )
 
     sensor = _build_sensor(coordinator)
@@ -68,7 +69,7 @@ async def test_health_changes_notify_coordinators(
 
             notifications.append(True)
 
-    coordinator = _Coordinator(config_entry=SimpleNamespace(entry_id="entry-a"))
+    coordinator = _Coordinator(config_entry=make_config_entry(entry_id="entry-a"))
     receiver.register_coordinator(coordinator)
 
     receiver._update_entry_health("entry-a", True)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -10,6 +10,7 @@ import pytest
 from custom_components.googlefindmy.Auth.token_cache import TokenCache
 from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
 from custom_components.googlefindmy.coordinator import identity as coordinator_identity
+from tests.helpers.config_entries_stub import make_config_entry
 
 
 class _Recorder:
@@ -281,7 +282,7 @@ def test_coordinator_propagates_timestamps_to_identity(
     coordinator._enabled_poll_device_ids = {"device-1"}
     coordinator._last_device_list = []
     coordinator.data = []
-    coordinator.config_entry = SimpleNamespace(entry_id="entry-id", options={})
+    coordinator.config_entry = make_config_entry(entry_id="entry-id")
     coordinator.hass = SimpleNamespace(data={})
     coordinator._extract_our_identifier = lambda device: device.custom_fields.get(
         "canonical_id"
@@ -342,7 +343,7 @@ def test_coordinator_persists_camelCase_identity_keys(
     coordinator._enabled_poll_device_ids = {"device-1"}
     coordinator._last_device_list = []
     coordinator.data = []
-    coordinator.config_entry = SimpleNamespace(entry_id="entry-id", options={})
+    coordinator.config_entry = make_config_entry(entry_id="entry-id")
     coordinator.hass = SimpleNamespace(data={})
     coordinator._extract_our_identifier = lambda device: device.custom_fields.get(
         "canonical_id"
@@ -412,7 +413,7 @@ def test_coordinator_yields_encrypted_only_identities(
     coordinator._enabled_poll_device_ids = {"device-1"}
     coordinator._last_device_list = []
     coordinator.data = []
-    coordinator.config_entry = SimpleNamespace(entry_id="entry-id", options={})
+    coordinator.config_entry = make_config_entry(entry_id="entry-id")
     coordinator.hass = SimpleNamespace(data={})
     coordinator._extract_our_identifier = lambda device: device.custom_fields.get(
         "canonical_id"
@@ -475,7 +476,7 @@ def test_coordinator_decrypts_registry_only_encrypted_identity_keys(
     coordinator._enabled_poll_device_ids = {"device-1"}
     coordinator._last_device_list = []
     coordinator.data = []
-    coordinator.config_entry = SimpleNamespace(entry_id="entry-id", options={})
+    coordinator.config_entry = make_config_entry(entry_id="entry-id")
     coordinator.hass = SimpleNamespace(data={})
     coordinator._extract_our_identifier = lambda device: device.custom_fields.get(
         "canonical_id"
@@ -566,7 +567,7 @@ def test_coordinator_yields_identities_without_pair_date(
     coordinator._enabled_poll_device_ids = {"device-1"}
     coordinator._last_device_list = []
     coordinator.data = []
-    coordinator.config_entry = SimpleNamespace(entry_id="entry-id", options={})
+    coordinator.config_entry = make_config_entry(entry_id="entry-id")
     coordinator.hass = SimpleNamespace(data={})
     coordinator._extract_our_identifier = lambda device: device.custom_fields.get(
         "canonical_id"
@@ -620,7 +621,7 @@ def test_active_device_identities_assigns_correct_timestamps_per_device(
         {"id": "device-2", "identity_key": b"\x02", "pair_date": 200},
     ]
     coordinator.data = []
-    coordinator.config_entry = SimpleNamespace(entry_id="entry-id", options={})
+    coordinator.config_entry = make_config_entry(entry_id="entry-id")
     coordinator.hass = SimpleNamespace(data={})
     coordinator._extract_our_identifier = lambda device: device.custom_fields.get(
         "canonical_id"
@@ -670,7 +671,7 @@ def test_active_device_identities_handles_missing_custom_fields(
         {"id": "device-1", "identity_key": b"\x01", "pair_date": 100}
     ]
     coordinator.data = []
-    coordinator.config_entry = SimpleNamespace(entry_id="entry-id", options={})
+    coordinator.config_entry = make_config_entry(entry_id="entry-id")
     coordinator.hass = SimpleNamespace(data={})
     coordinator._extract_our_identifier = lambda device: getattr(
         device, "canonical_id", None
@@ -719,7 +720,7 @@ def test_active_device_identities_uses_cache_when_not_in_poll_list(
     coordinator._enabled_poll_device_ids = {"canonical/device-1"}
     coordinator._last_device_list = []
     coordinator.data = []
-    coordinator.config_entry = SimpleNamespace(entry_id="entry-id", options={})
+    coordinator.config_entry = make_config_entry(entry_id="entry-id")
     coordinator.hass = SimpleNamespace(data={})
     coordinator._extract_our_identifier = lambda device: device.custom_fields.get(
         "canonical_id"

--- a/tests/test_coordinator_key_priority.py
+++ b/tests/test_coordinator_key_priority.py
@@ -1,8 +1,7 @@
-from types import SimpleNamespace
-
 import pytest
 
 import custom_components.googlefindmy.coordinator as coordinator_module
+from tests.helpers.config_entries_stub import make_config_entry
 
 
 class _StubDevice:
@@ -39,7 +38,7 @@ def _build_coordinator(
         coordinator_module.GoogleFindMyCoordinator
     )
     coordinator.hass = _StubHass()
-    coordinator.config_entry = SimpleNamespace(entry_id="entry-1")
+    coordinator.config_entry = make_config_entry(entry_id="entry-1")
     coordinator._enabled_poll_device_ids = {"device-1"}
     coordinator._get_ignored_set = set
     coordinator._extract_our_identifier = lambda device: getattr(

--- a/tests/test_coordinator_priority.py
+++ b/tests/test_coordinator_priority.py
@@ -1,10 +1,10 @@
 import logging
-from types import SimpleNamespace
 from typing import Any
 
 import pytest
 
 import custom_components.googlefindmy.coordinator as coordinator_module
+from tests.helpers.config_entries_stub import make_config_entry
 
 
 class _StubDevice:
@@ -41,7 +41,7 @@ def _build_coordinator(
         coordinator_module.GoogleFindMyCoordinator
     )
     coordinator.hass = _StubHass()
-    coordinator.config_entry = SimpleNamespace(entry_id="entry-1")
+    coordinator.config_entry = make_config_entry(entry_id="entry-1")
     coordinator._enabled_poll_device_ids = {"device-1"}
     coordinator._get_ignored_set = set
     coordinator._extract_our_identifier = lambda device: getattr(

--- a/tests/test_coordinator_snapshot.py
+++ b/tests/test_coordinator_snapshot.py
@@ -10,13 +10,13 @@ from types import SimpleNamespace
 import pytest
 
 from custom_components.googlefindmy.const import DOMAIN
-from tests.helpers.config_entries_stub import make_config_entry
 from custom_components.googlefindmy.coordinator import (
     GoogleFindMyCoordinator,
     _as_ha_attributes,
     _sync_get_last_gps_from_history,
 )
 from custom_components.googlefindmy.coordinator import registry as coordinator_registry
+from tests.helpers.config_entries_stub import make_config_entry
 
 
 class _DummyState:

--- a/tests/test_coordinator_snapshot.py
+++ b/tests/test_coordinator_snapshot.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 import pytest
 
 from custom_components.googlefindmy.const import DOMAIN
+from tests.helpers.config_entries_stub import make_config_entry
 from custom_components.googlefindmy.coordinator import (
     GoogleFindMyCoordinator,
     _as_ha_attributes,
@@ -92,7 +93,7 @@ def test_snapshot_uses_entry_scoped_unique_id(monkeypatch: pytest.MonkeyPatch) -
     coordinator.allow_history_fallback = False
     coordinator._device_location_data = {}
     coordinator.location_poll_interval = 30
-    coordinator.config_entry = SimpleNamespace(entry_id="entry-1")
+    coordinator.config_entry = make_config_entry(entry_id="entry-1")
 
     result = asyncio.run(
         coordinator._async_build_device_snapshot_with_fallbacks(
@@ -143,7 +144,7 @@ def test_snapshot_preserves_recorded_last_seen(monkeypatch: pytest.MonkeyPatch) 
     coordinator.allow_history_fallback = False
     coordinator._device_location_data = {}
     coordinator.location_poll_interval = 30
-    coordinator.config_entry = SimpleNamespace(entry_id="entry-1")
+    coordinator.config_entry = make_config_entry(entry_id="entry-1")
 
     result = asyncio.run(
         coordinator._async_build_device_snapshot_with_fallbacks(
@@ -175,7 +176,7 @@ def test_snapshot_logs_formats_when_entity_missing(
     coordinator.allow_history_fallback = False
     coordinator._device_location_data = {}
     coordinator.location_poll_interval = 30
-    coordinator.config_entry = SimpleNamespace(entry_id="entry-1")
+    coordinator.config_entry = make_config_entry(entry_id="entry-1")
 
     caplog.set_level("DEBUG")
 

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -16,6 +16,7 @@ import pytest
 from custom_components.googlefindmy.const import DOMAIN, TRACKER_SUBENTRY_KEY
 from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
 from custom_components.googlefindmy.coordinator import registry as coordinator_registry
+from tests.helpers.config_entries_stub import make_config_entry
 
 
 class _EntityRegistryStub:
@@ -80,7 +81,7 @@ def test_find_tracker_entity_entry_uses_fallback(
 
     coordinator = GoogleFindMyCoordinator.__new__(GoogleFindMyCoordinator)
     coordinator.hass = SimpleNamespace()
-    coordinator.config_entry = SimpleNamespace(entry_id="entry-42")
+    coordinator.config_entry = make_config_entry(entry_id="entry-42")
     coordinator.get_device_display_name = lambda device_id: f"Tracker {device_id}"
 
     entry = coordinator.find_tracker_entity_entry("tracker-42")

--- a/tests/test_dual_key_strategy.py
+++ b/tests/test_dual_key_strategy.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-
 import custom_components.googlefindmy.coordinator as coordinator_module
+from tests.helpers.config_entries_stub import make_config_entry
 
 
 class _StubDevice:
@@ -39,7 +38,7 @@ def _build_coordinator(monkeypatch):
         coordinator_module.GoogleFindMyCoordinator
     )
     coordinator.hass = _StubHass()
-    coordinator.config_entry = SimpleNamespace(entry_id="entry-1")
+    coordinator.config_entry = make_config_entry(entry_id="entry-1")
     coordinator._enabled_poll_device_ids = {"device-1"}
     coordinator._get_ignored_set = set
     coordinator._extract_our_identifier = lambda device: getattr(

--- a/tests/test_duplicate_device_entities.py
+++ b/tests/test_duplicate_device_entities.py
@@ -13,6 +13,7 @@ from custom_components.googlefindmy.const import (
     SERVICE_SUBENTRY_KEY,
     TRACKER_SUBENTRY_KEY,
 )
+from tests.helpers.config_entries_stub import make_config_entry
 
 
 def test_duplicate_devices_seed_only_once(
@@ -34,7 +35,7 @@ def test_duplicate_devices_seed_only_once(
             self._snapshot = list(devices)
             self._listeners: list[Callable[[], None]] = []
             self.hass = SimpleNamespace()
-            self.config_entry = SimpleNamespace(entry_id="entry-id")
+            self.config_entry = make_config_entry(entry_id="entry-id")
             self.stats: dict[str, int] = {}
             self._device_names: dict[str, str] = {}
             self._device_location_data: dict[str, Any] = {}

--- a/tests/test_fcm_receiver.py
+++ b/tests/test_fcm_receiver.py
@@ -15,6 +15,7 @@ from custom_components.googlefindmy.Auth.firebase_messaging.fcmregister import (
 )
 from custom_components.googlefindmy.const import DOMAIN
 from custom_components.googlefindmy.exceptions import FatalRegistrationError
+from tests.helpers.config_entries_stub import make_config_entry
 
 _MODULE = importlib.import_module("custom_components.googlefindmy")
 _async_acquire_shared_fcm = cast(
@@ -41,10 +42,6 @@ class _DummyCache:
 
     async def set(self, key: str, value: Any) -> None:
         self._data[key] = value
-
-
-class _DummyEntry(SimpleNamespace):
-    entry_id: str
 
 
 class _ReadyableReceiver(FcmReceiverHA):
@@ -83,8 +80,8 @@ class _DefaultAwareReceiver(_ReadyableReceiver):
 async def test_entry_scoped_receivers_use_entry_cache() -> None:
     hass = SimpleNamespace(data={DOMAIN: {}})
 
-    entry_a = _DummyEntry(entry_id="entry-a")
-    entry_b = _DummyEntry(entry_id="entry-b")
+    entry_a = make_config_entry(entry_id="entry-a")
+    entry_b = make_config_entry(entry_id="entry-b")
 
     creds_a = {"fcm": {"registration": {"token": "token-a"}}}
     creds_b = {"fcm": {"registration": {"token": "token-b"}}}
@@ -120,8 +117,8 @@ async def test_entry_scoped_receivers_use_entry_cache() -> None:
 async def test_acquire_new_entry_keeps_existing_receiver() -> None:
     hass = SimpleNamespace(data={DOMAIN: {}})
 
-    entry_a = _DummyEntry(entry_id="entry-a")
-    entry_b = _DummyEntry(entry_id="entry-b")
+    entry_a = make_config_entry(entry_id="entry-a")
+    entry_b = make_config_entry(entry_id="entry-b")
 
     creds_a = {"fcm": {"registration": {"token": "token-a"}}}
     creds_b = {"fcm": {"registration": {"token": "token-b"}}}
@@ -161,8 +158,8 @@ async def test_acquire_new_entry_keeps_existing_receiver() -> None:
 async def test_new_entry_ignores_legacy_alias_when_receivers_present() -> None:
     hass = SimpleNamespace(data={DOMAIN: {}})
 
-    entry_a = _DummyEntry(entry_id="entry-a")
-    entry_b = _DummyEntry(entry_id="entry-b")
+    entry_a = make_config_entry(entry_id="entry-a")
+    entry_b = make_config_entry(entry_id="entry-b")
 
     creds_a = {"fcm": {"registration": {"token": "token-a"}}}
     creds_b = {"fcm": {"registration": {"token": "token-b"}}}
@@ -201,7 +198,7 @@ async def test_new_entry_ignores_legacy_alias_when_receivers_present() -> None:
 async def test_legacy_fcm_receiver_alias_preserved() -> None:
     hass = SimpleNamespace(data={DOMAIN: {}})
 
-    entry = _DummyEntry(entry_id="entry-a")
+    entry = make_config_entry(entry_id="entry-a")
     creds = {"fcm": {"registration": {"token": "token-a"}}}
     cache = _DummyCache(entry.entry_id, creds)
 
@@ -288,7 +285,7 @@ def test_domain_provider_sets_default_entry_on_selected_receiver() -> None:
 
 
 async def _async_release(
-    receiver: FcmReceiverHA, hass: Any, entry: _DummyEntry
+    receiver: FcmReceiverHA, hass: Any, entry: SimpleNamespace
 ) -> None:
     receiver.request_stop()
     await _async_release_shared_fcm(hass, entry)

--- a/tests/test_key_propagation_flow.py
+++ b/tests/test_key_propagation_flow.py
@@ -10,6 +10,7 @@ import custom_components.googlefindmy.coordinator as coordinator_module
 from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker import (
     decrypt_locations as decrypt_module,
 )
+from tests.helpers.config_entries_stub import make_config_entry
 
 
 class _StatusEnum:
@@ -38,7 +39,7 @@ def _build_coordinator(
         coordinator_module.GoogleFindMyCoordinator
     )
     coordinator.hass = SimpleNamespace(async_create_task=lambda coro: coro, data={})
-    coordinator.config_entry = SimpleNamespace(entry_id="entry-1")
+    coordinator.config_entry = make_config_entry(entry_id="entry-1")
     coordinator._enabled_poll_device_ids = set()
     coordinator._get_ignored_set = set
     coordinator.data = []

--- a/tests/test_map_view_features.py
+++ b/tests/test_map_view_features.py
@@ -25,6 +25,7 @@ from custom_components.googlefindmy.const import (
     map_token_hex_digest,
     map_token_secret_seed,
 )
+from tests.helpers.config_entries_stub import make_config_entry
 
 
 class _StubConfigEntries:
@@ -115,14 +116,6 @@ class _StubHass:
         return func(*args)
 
 
-class _StubEntry:
-    def __init__(self, entry_id: str, runtime_data: Any) -> None:
-        self.entry_id = entry_id
-        self.data: dict[str, Any] = {}
-        self.options: dict[str, Any] = {}
-        self.runtime_data = runtime_data
-
-
 def _install_history_stub(
     monkeypatch: pytest.MonkeyPatch,
     entity_id: str,
@@ -175,7 +168,7 @@ async def test_get_invalid_token_returns_unauthorized(
 ) -> None:
     """Return 401 when token does not match any entry."""
 
-    entry = _StubEntry("entry-id", runtime_data=None)
+    entry = make_config_entry(entry_id="entry-id", runtime_data=None)
     hass = _StubHass([entry])
     view = map_view.GoogleFindMyMapView(hass)
 
@@ -192,7 +185,7 @@ async def test_get_authorized_includes_leaflet(monkeypatch: pytest.MonkeyPatch) 
 
     device_id = "device123"
     coordinator = SimpleNamespace(data=[{"id": device_id, "name": "Test Device"}])
-    entry = _StubEntry("entry-id", runtime_data=coordinator)
+    entry = make_config_entry(entry_id="entry-id", runtime_data=coordinator)
     hass = _StubHass([entry])
 
     def _resolve() -> type[Any]:
@@ -232,7 +225,7 @@ async def test_get_skips_foreign_registry_entries(
 
     device_id = "device456"
     coordinator = SimpleNamespace(data=[{"id": device_id, "name": "Foreign Device"}])
-    entry = _StubEntry("entry-id", runtime_data=coordinator)
+    entry = make_config_entry(entry_id="entry-id", runtime_data=coordinator)
     hass = _StubHass([entry])
 
     def _resolve() -> type[Any]:
@@ -291,7 +284,7 @@ async def test_get_prefers_matching_entry_over_foreign_match(
 
     device_id = "device789"
     coordinator = SimpleNamespace(data=[{"id": device_id, "name": "Scoped Device"}])
-    entry = _StubEntry("entry-id", runtime_data=coordinator)
+    entry = make_config_entry(entry_id="entry-id", runtime_data=coordinator)
     hass = _StubHass([entry])
 
     def _resolve() -> type[Any]:
@@ -343,7 +336,7 @@ async def test_registry_labels_fill_blank_coordinator_names(
 
     device_id = "device987"
     coordinator = SimpleNamespace(data=[{"id": device_id, "name": "   "}])
-    entry = _StubEntry("entry-id", runtime_data=coordinator)
+    entry = make_config_entry(entry_id="entry-id", runtime_data=coordinator)
     hass = _StubHass([entry])
 
     def _resolve() -> type[Any]:
@@ -389,7 +382,7 @@ async def test_missing_registry_and_coordinator_use_unknown(
 
     device_id = "device000"
     coordinator = SimpleNamespace(data=[])
-    entry = _StubEntry("entry-id", runtime_data=coordinator)
+    entry = make_config_entry(entry_id="entry-id", runtime_data=coordinator)
     hass = _StubHass([entry])
 
     def _resolve() -> type[Any]:

--- a/tests/test_options_flow_semantic_locations.py
+++ b/tests/test_options_flow_semantic_locations.py
@@ -13,34 +13,25 @@ from custom_components.googlefindmy.const import (
     DEFAULT_SEMANTIC_DETECTION_RADIUS,
     OPT_SEMANTIC_LOCATIONS,
 )
+from tests.helpers.config_entries_stub import make_config_entry
 from tests.helpers.config_flow import prepare_flow_hass_config_entries
-
-
-class _SemanticEntry:
-    """Minimal ConfigEntry stub for semantic location options flows."""
-
-    def __init__(self, *, options: dict[str, Any] | None = None) -> None:
-        self.entry_id = "entry-semantic"
-        self.title = "Semantic"
-        self.data: dict[str, Any] = {}
-        self.options: dict[str, Any] = dict(options or {})
 
 
 class _SemanticConfigEntries:
     """Record options updates and reloads for verification."""
 
-    def __init__(self, entry: _SemanticEntry) -> None:
+    def __init__(self, entry: SimpleNamespace) -> None:
         self._entry = entry
         self.updated_options: list[dict[str, Any]] = []
         self.reloaded: list[str] = []
 
-    def async_get_entry(self, entry_id: str) -> _SemanticEntry | None:
+    def async_get_entry(self, entry_id: str) -> SimpleNamespace | None:
         if entry_id == self._entry.entry_id:
             return self._entry
         return None
 
     def async_update_entry(
-        self, entry: _SemanticEntry, *, options: dict[str, Any] | None = None
+        self, entry: SimpleNamespace, *, options: dict[str, Any] | None = None
     ) -> None:
         assert entry is self._entry
         if options is not None:
@@ -71,7 +62,7 @@ class _FakeStates:
 class _HassStub:
     """Minimal Home Assistant stub for semantic options flows."""
 
-    def __init__(self, entry: _SemanticEntry, *, home_radius: float = 90.0) -> None:
+    def __init__(self, entry: SimpleNamespace, *, home_radius: float = 90.0) -> None:
         self.config_entries = _SemanticConfigEntries(entry)
         prepare_flow_hass_config_entries(
             self, lambda: self.config_entries, frame_module=frame
@@ -104,7 +95,9 @@ class _HassStub:
 async def test_semantic_locations_options_lifecycle() -> None:
     """Options flow should add, guard, and remove semantic locations."""
 
-    entry = _SemanticEntry(
+    entry = make_config_entry(
+        entry_id="entry-semantic",
+        title="Semantic",
         options={
             OPT_SEMANTIC_LOCATIONS: {
                 "Office": {"latitude": 1.0, "longitude": 2.0, "accuracy": 3.0}
@@ -187,7 +180,7 @@ async def test_semantic_locations_options_lifecycle() -> None:
 async def test_semantic_location_defaults_floor_accuracy() -> None:
     """Defaults should treat semantic detections as broad (>=50m) receivers."""
 
-    entry = _SemanticEntry()
+    entry = make_config_entry(entry_id="entry-semantic", title="Semantic")
     hass = _HassStub(entry, home_radius=10.0)
 
     flow = config_flow.OptionsFlowHandler()
@@ -216,7 +209,9 @@ async def test_semantic_location_defaults_floor_accuracy() -> None:
 async def test_semantic_location_edit_prefills_existing_values() -> None:
     """Editing should default to the stored semantic location coordinates."""
 
-    entry = _SemanticEntry(
+    entry = make_config_entry(
+        entry_id="entry-semantic",
+        title="Semantic",
         options={
             OPT_SEMANTIC_LOCATIONS: {
                 "Büro": {"latitude": 50.0, "longitude": 10.0, "accuracy": 7.0}

--- a/tests/test_remove_entry_cleanup.py
+++ b/tests/test_remove_entry_cleanup.py
@@ -11,6 +11,7 @@ import pytest
 import custom_components.googlefindmy as integration
 from custom_components.googlefindmy import DOMAIN
 from custom_components.googlefindmy.const import OPT_DELETE_CACHES_ON_REMOVE
+from tests.helpers.config_entries_stub import make_config_entry
 
 
 class _TokenCacheStub:
@@ -47,22 +48,11 @@ class _GoogleHomeFilterStub:
         self.shutdown_called = True
 
 
-class _EntryStub:
-    """Config entry stub used in removal tests."""
-
-    def __init__(self) -> None:
-        self.entry_id = "entry-remove"
-        self.data: dict[str, Any] = {}
-        self.options: dict[str, Any] = {}
-        self.title = "Find My Entry"
-        self.runtime_data: Any | None = None
-
-
 class _HassStub:
     """Home Assistant stub exposing the data layout used by async_remove_entry."""
 
     def __init__(
-        self, entry: _EntryStub, runtime_data: integration.RuntimeData
+        self, entry: SimpleNamespace, runtime_data: integration.RuntimeData
     ) -> None:
         self.data: dict[str, Any] = {
             DOMAIN: {
@@ -87,7 +77,7 @@ def _no_fcm_release(monkeypatch: pytest.MonkeyPatch) -> list[None]:
 
 
 def _setup_runtime(
-    entry: _EntryStub,
+    entry: SimpleNamespace,
 ) -> tuple[
     _CoordinatorStub, _TokenCacheStub, _GoogleHomeFilterStub, integration.RuntimeData
 ]:
@@ -116,7 +106,10 @@ def test_async_remove_entry_purges_store_and_creates_issue(
 
     monkeypatch.setattr(integration, "_unregister_instance", lambda _entry_id: None)
 
-    entry = _EntryStub()
+    entry = make_config_entry(
+        entry_id="entry-remove",
+        title="Find My Entry",
+    )
     coordinator, token_cache, google_home_filter, runtime_data = _setup_runtime(entry)
     hass = _HassStub(entry, runtime_data)
 
@@ -145,7 +138,10 @@ def test_async_remove_entry_respects_retention_option(
 
     monkeypatch.setattr(integration, "_unregister_instance", lambda _entry_id: None)
 
-    entry = _EntryStub()
+    entry = make_config_entry(
+        entry_id="entry-remove",
+        title="Find My Entry",
+    )
     entry.options[OPT_DELETE_CACHES_ON_REMOVE] = False
     coordinator, token_cache, google_home_filter, runtime_data = _setup_runtime(entry)
     hass = _HassStub(entry, runtime_data)
@@ -192,7 +188,10 @@ def test_async_remove_entry_fallback_store_remove(
 
     monkeypatch.setattr(integration, "Store", _StoreStub)
 
-    entry = _EntryStub()
+    entry = make_config_entry(
+        entry_id="entry-remove",
+        title="Find My Entry",
+    )
     coordinator = _CoordinatorStub()
     google_home_filter = _GoogleHomeFilterStub()
     runtime_data = integration.RuntimeData(

--- a/tests/test_sensor_eid_coverage.py
+++ b/tests/test_sensor_eid_coverage.py
@@ -42,6 +42,7 @@ from custom_components.googlefindmy.sensor import (
     STATS_DESCRIPTIONS,
     _subentry_type,
 )
+from tests.helpers.config_entries_stub import make_config_entry
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -305,7 +306,7 @@ class TestStatsSensorNativeValue:
             hass=_fake_hass(),
             stats=stats if stats is not None else {},
             last_update_success=True,
-            config_entry=SimpleNamespace(entry_id="test_entry"),
+            config_entry=make_config_entry(entry_id="test_entry"),
         )
         # We can't call __init__ directly (needs entity base), so mock it
         sensor = GoogleFindMyStatsSensor.__new__(GoogleFindMyStatsSensor)
@@ -1013,7 +1014,7 @@ class TestLastSeenValueConversion:
         coordinator = SimpleNamespace(
             hass=_fake_hass(),
             last_update_success=True,
-            config_entry=SimpleNamespace(entry_id="test_entry"),
+            config_entry=make_config_entry(entry_id="test_entry"),
         )
 
         def get_snapshot(key=None, *, feature=None):
@@ -1157,7 +1158,7 @@ class TestLastSeenAvailability:
         coordinator = SimpleNamespace(
             hass=_fake_hass(),
             last_update_success=True,
-            config_entry=SimpleNamespace(entry_id="test_entry"),
+            config_entry=make_config_entry(entry_id="test_entry"),
         )
 
         def get_snapshot(key=None, *, feature=None):
@@ -1245,7 +1246,7 @@ class TestSemanticLabelSensor:
         coordinator = SimpleNamespace(
             hass=_fake_hass(),
             last_update_success=True,
-            config_entry=SimpleNamespace(entry_id="test_entry"),
+            config_entry=make_config_entry(entry_id="test_entry"),
         )
 
         if no_getter:
@@ -1396,7 +1397,7 @@ class TestBLEBatterySensor:
         coordinator = SimpleNamespace(
             hass=sensor.hass,
             last_update_success=True,
-            config_entry=SimpleNamespace(entry_id="test_entry"),
+            config_entry=make_config_entry(entry_id="test_entry"),
         )
 
         def get_snapshot(key=None, *, feature=None):
@@ -1547,7 +1548,7 @@ class TestLastSeenAvailableFunctional:
         coordinator = SimpleNamespace(
             hass=_fake_hass(),
             last_update_success=coordinator_success,
-            config_entry=SimpleNamespace(entry_id="test_entry"),
+            config_entry=make_config_entry(entry_id="test_entry"),
         )
         coordinator.is_device_visible_in_subentry = lambda k, d: has_device
 
@@ -1636,7 +1637,7 @@ class TestBLEBatteryAvailableFunctional:
         coordinator = SimpleNamespace(
             hass=_fake_hass(),
             last_update_success=coordinator_success,
-            config_entry=SimpleNamespace(entry_id="test_entry"),
+            config_entry=make_config_entry(entry_id="test_entry"),
         )
         coordinator.is_device_visible_in_subentry = lambda k, d: has_device
 
@@ -1708,7 +1709,7 @@ class TestLastSeenExtraAttributes:
         coordinator = SimpleNamespace(
             hass=_fake_hass(),
             last_update_success=True,
-            config_entry=SimpleNamespace(entry_id="test_entry"),
+            config_entry=make_config_entry(entry_id="test_entry"),
         )
 
         def get_location_data(key, dev_id):

--- a/tests/test_stats_sensor_updates.py
+++ b/tests/test_stats_sensor_updates.py
@@ -25,6 +25,7 @@ from custom_components.googlefindmy.sensor import (
     GoogleFindMyStatsSensor,
 )
 from tests.helpers import drain_loop
+from tests.helpers.config_entries_stub import make_config_entry
 
 if "homeassistant.components.sensor" not in sys.modules:
     sensor_module = ModuleType("homeassistant.components.sensor")
@@ -173,14 +174,6 @@ class _StubHass:
         return self.loop.create_task(coro, name=name)
 
 
-class _StubConfigEntry:
-    """Minimal ConfigEntry-like stub with deterministic identifiers."""
-
-    def __init__(self) -> None:
-        self.entry_id = "entry-stats"
-        self.data = {CONF_GOOGLE_EMAIL: "user@example.com"}
-
-
 class _StubCache:
     """No-op cache implementation satisfying coordinator expectations."""
 
@@ -222,7 +215,10 @@ def test_increment_stat_notifies_registered_stats_sensor(
     try:
         hass = _StubHass(loop)
         coordinator = GoogleFindMyCoordinator(hass, cache=_StubCache())
-        coordinator.config_entry = _StubConfigEntry()
+        coordinator.config_entry = make_config_entry(
+            entry_id="entry-stats",
+            data={CONF_GOOGLE_EMAIL: "user@example.com"},
+        )
 
         # Prevent background tasks from interfering with the test cleanup.
         monkeypatch.setattr(
@@ -276,7 +272,10 @@ def test_increment_stat_persists_stats(monkeypatch: pytest.MonkeyPatch) -> None:
         hass = _StubHass(loop)
         cache = _StubCache()
         coordinator = GoogleFindMyCoordinator(hass, cache=cache)
-        coordinator.config_entry = _StubConfigEntry()
+        coordinator.config_entry = make_config_entry(
+            entry_id="entry-stats",
+            data={CONF_GOOGLE_EMAIL: "user@example.com"},
+        )
         coordinator._stats_debounce_seconds = 0
 
         # Ensure debounced writes run immediately without scheduling real tasks.
@@ -315,7 +314,10 @@ def test_history_fallback_increments_history_stat(
             cache=cache,
             allow_history_fallback=True,
         )
-        coordinator.config_entry = _StubConfigEntry()
+        coordinator.config_entry = make_config_entry(
+            entry_id="entry-stats",
+            data={CONF_GOOGLE_EMAIL: "user@example.com"},
+        )
 
         # Disable persistence side effects for deterministic assertions.
         monkeypatch.setattr(coordinator, "_schedule_stats_persist", lambda: None)
@@ -397,7 +399,10 @@ def test_stats_sensor_device_info_uses_service_identifiers() -> None:
     try:
         hass = _StubHass(loop)
         coordinator = GoogleFindMyCoordinator(hass, cache=_StubCache())
-        coordinator.config_entry = _StubConfigEntry()
+        coordinator.config_entry = make_config_entry(
+            entry_id="entry-stats",
+            data={CONF_GOOGLE_EMAIL: "user@example.com"},
+        )
         subentry_identifier = coordinator.stable_subentry_identifier(
             key=SERVICE_SUBENTRY_KEY
         )
@@ -435,7 +440,10 @@ def test_semantic_label_sensor_exposes_observations() -> None:
     try:
         hass = _StubHass(loop)
         coordinator = GoogleFindMyCoordinator(hass, cache=_StubCache())
-        coordinator.config_entry = _StubConfigEntry()
+        coordinator.config_entry = make_config_entry(
+            entry_id="entry-stats",
+            data={CONF_GOOGLE_EMAIL: "user@example.com"},
+        )
 
         subentry_identifier = coordinator.stable_subentry_identifier(
             key=SERVICE_SUBENTRY_KEY

--- a/tests/test_system_health.py
+++ b/tests/test_system_health.py
@@ -16,32 +16,15 @@ from custom_components.googlefindmy.const import (
     DATA_SECRET_BUNDLE,
     DOMAIN,
 )
+from tests.helpers.config_entries_stub import make_config_entry
 
 EXPECTED_DEVICE_COUNT = 2
-
-
-class _FakeConfigEntry:
-    """Minimal ConfigEntry stub for system health tests."""
-
-    def __init__(self) -> None:
-        self.entry_id = "entry-test"
-        self.domain = DOMAIN
-        self.title = "Google Find My (user@example.com)"
-        self.data = {
-            CONF_GOOGLE_EMAIL: "user@example.com",
-            DATA_SECRET_BUNDLE: {"username": "user@example.com"},
-        }
-        self.options: dict[str, object] = {}
-        self.runtime_data = None
-        self.disabled_by = None
-        self.state = ConfigEntryState.LOADED
-        self.subentries: dict[str, Any] = {}
 
 
 class _FakeConfigEntriesManager:
     """Expose the integration config entry to the system health handler."""
 
-    def __init__(self, entry: _FakeConfigEntry) -> None:
+    def __init__(self, entry: SimpleNamespace) -> None:
         self._entries = [entry]
         self.setup_calls: list[str] = []
 
@@ -50,7 +33,7 @@ class _FakeConfigEntriesManager:
             return list(self._entries)
         return []
 
-    def async_get_entry(self, entry_id: str) -> _FakeConfigEntry | None:
+    def async_get_entry(self, entry_id: str) -> SimpleNamespace | None:
         if entry_id == self._entries[0].entry_id:
             return self._entries[0]
         return None
@@ -97,7 +80,17 @@ class _FakeHass:
     """Home Assistant core stub exposing data for the handler."""
 
     def __init__(self, coordinator: _FakeCoordinator) -> None:
-        entry = _FakeConfigEntry()
+        entry = make_config_entry(
+            entry_id="entry-test",
+            domain=DOMAIN,
+            title="Google Find My (user@example.com)",
+            data={
+                CONF_GOOGLE_EMAIL: "user@example.com",
+                DATA_SECRET_BUNDLE: {"username": "user@example.com"},
+            },
+            state=ConfigEntryState.LOADED,
+            subentries={},
+        )
         self.config_entries = _FakeConfigEntriesManager(entry)
         self.data = {
             DOMAIN: {

--- a/tests/test_uwt_mode_binary_sensor.py
+++ b/tests/test_uwt_mode_binary_sensor.py
@@ -13,6 +13,7 @@ from custom_components.googlefindmy.binary_sensor import (
 )
 from custom_components.googlefindmy.const import DATA_EID_RESOLVER, DOMAIN
 from custom_components.googlefindmy.eid_resolver import BLEBatteryState
+from tests.helpers.config_entries_stub import make_config_entry
 
 # ---------------------------------------------------------------------------
 # Helpers (same pattern as test_ble_battery_sensor.py)
@@ -65,7 +66,7 @@ def _fake_coordinator(
 ) -> SimpleNamespace:
     """Create a minimal coordinator stub for sensor tests."""
     return SimpleNamespace(
-        config_entry=SimpleNamespace(entry_id=entry_id),
+        config_entry=make_config_entry(entry_id=entry_id),
         is_device_present=lambda did: present,
         is_device_visible_in_subentry=lambda key, did: visible,
         async_update_listeners=lambda: None,


### PR DESCRIPTION
## Summary

This PR introduces a single canonical `make_config_entry()` fixture for the test suite and migrates all ad-hoc `ConfigEntry` stub patterns to it.

Background: #172 added defensive `_opt()` accessors and a parallel guard in `coordinator/main.py` because partial `SimpleNamespace` mocks were breaking ConfigEntry access in tests. That fix stays. This PR removes the *structural* cause — 41 ad-hoc `SimpleNamespace(entry_id=…)` stubs across 28 files, plus 7 named stub classes, all with diverging schemas.

**No production code changes.** All commits are test-only.

## Commits in this bundle

| # | SHA | What |
|---|-----|------|
| 1 | `9e828431` | `test(helpers)`: add canonical `make_config_entry` fixture |
| 2 | `34ce215d` | `docs(tests)`: document `make_config_entry` convention in `AGENTS.md` |
| 3 | `39e70fa7` | `docs(tests)`: refine convention wording |
| 4 | `b670e415` | `test(helpers)`: migrate 16 stubs to `make_config_entry` (wave 1) |
| 5 | `6ba99c5f` | `test(helpers)`: migrate 10 stubs to `make_config_entry` (wave 2) |
| 6 | `76a515d6` | `style(tests)`: fix isort order in `test_coordinator_snapshot.py` |
| 7 | `dab648e6` | `test(helpers)`: migrate 15 stubs to `make_config_entry` (wave 3) |
| 8 | `21ba58e2` | `test`: migrate 7 named ConfigEntry stub classes to `make_config_entry()` |
| 9 | `5af3881f` | `fix(tests)`: migrate `_EntryStub` import in `test_config_flow_reconfigure` |

## Why a single canonical fixture

The pre-existing patterns drifted across files:

```python
# A: SimpleNamespace with entry_id only — fails on .options access
entry = SimpleNamespace(entry_id="abc")

# B: SimpleNamespace with partial dict — fails on .data.get()
entry = SimpleNamespace(entry_id="abc", data={"foo": 1})

# C: ad-hoc named class — re-declared in 7 modules with diverging surface
class _EntryStub: ...
```

The consequence: defensive accessors (`_opt()`, `getattr(..., None)`) had to multiply in production code to absorb the test stub shape. Each new `ConfigEntry` surface touched by a test required either a stub upgrade or another defensive layer.

`make_config_entry()` fixes this at the source:

- `data` and `options` are always present and always `dict` (never `None`, never a `MagicMock`)
- Exposes the `ConfigEntry` surface tests actually touch (`entry_id`, `data`, `options`, `runtime_data`, `subentries`, `version`, `minor_version`, `domain`, `title`, `unique_id`, `state`, `source`)
- Unknown kwargs pass through via `**extra` for forward compatibility

## What is covered

- New factory: `tests/helpers/config_entries_stub.py` (`make_config_entry`)
- 10 contract tests: `tests/helpers/test_config_entries_stub.py`
- Documentation: `tests/AGENTS.md` records the convention
- 41 ad-hoc `SimpleNamespace(entry_id=…)` call sites migrated (waves 1+2+3)
- 7 named stub classes migrated (e.g. `_DummyEntry`, `_EntryStub`)
- One import hotfix: `test_config_flow_reconfigure` was re-importing a now-removed `_EntryStub`
- isort hygiene on `test_coordinator_snapshot.py` (CI was failing on import ordering)

Net change: **+439 / −192** across **28 files**. No file outside `tests/` is touched.

## Test plan

- [ ] CI green on this PR (`semantic-pr`, `pip-audit`, `ha-dep-check`, `pytest`, `ruff`)
- [ ] No production code changes; behavior identical to the post-#172 line
- [ ] All migrated tests pass under Python 3.13 (the repo's required version)

## Notes

- A custom AST lint guard to enforce the `make_config_entry()` convention was considered and deliberately deferred. The convention is documented in `tests/AGENTS.md`; review feedback can re-introduce stragglers via PR comments. Adding a project-specific linter for a single, post-migration pattern would carry maintenance cost without a recurring drift source.
- All commits in this bundle are test-only and revertible commit-by-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)