### PR TITLE
Forward-port 1.7.1: FCM cascading-failure defense, restart-required Repairs, polling/sound/sensor fixes + Class-A test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,7 +414,7 @@ jobs:
           PYTHONPATH: .
         run: |
           set -o pipefail
-          poetry run pytest -q --cov --cov-report=xml --cov-report=term --cov-fail-under=63 2>&1 | tee pytest_output.log
+          poetry run pytest -q --cov --cov-report=xml --cov-report=term --cov-fail-under=67 2>&1 | tee pytest_output.log
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ A comprehensive Home Assistant custom integration for Google's FindMy Device net
 ---
 <img src="https://github.com/BSkando/GoogleFindMy-HA/blob/main/icon.png" width="30"> [![GitHub Repo stars](https://img.shields.io/github/stars/BSkando/GoogleFindMy-HA?style=for-the-badge&logo=github)](https://github.com/BSkando/GoogleFindMy-HA) [![Home Assistant Community Forum](https://img.shields.io/badge/Home%20Assistant-Community%20Forum-blue?style=for-the-badge&logo=home-assistant)](https://community.home-assistant.io/t/google-findmy-find-hub-integration/931136) [![Continuous integration status](https://github.com/BSkando/GoogleFindMy-HA/actions/workflows/ci.yml/badge.svg)](https://github.com/BSkando/GoogleFindMy-HA/actions/workflows/ci.yml) [![Buy me a coffee](https://img.shields.io/badge/Coffee-Addiction!-yellow?style=for-the-badge&logo=buy-me-a-coffee)](https://www.buymeacoffee.com/bskando) <img src="https://github.com/BSkando/GoogleFindMy-HA/blob/main/icon.png" width="30">
 
->[!CAUTION]
->**Home Assistant Core 2025.10 or newer is required.** The integration relies on Core-managed config subentry scheduling and device-registry hooks introduced alongside the 2025.10 cycle. Older builds lack the platform-loading behavior and registry keywords exercised by the tracker/service subentries and are **not supported**.
+>[!TIP]
+>**Home Assistant Core 2025.10 or newer is recommended.** The functional minimum is **2025.8.0** (enforced in `hacs.json` and `pyproject.toml`): that release provides the config subentry flow maturity and the `async_added_to_hass` behavior the tracker/service subentries depend on. The Core-managed config subentry model itself has been available since the 2025.3 cycle. Running 2025.10 or newer is recommended for the bug fixes and stability improvements made since 2025.8, not because of a hard API requirement.
 
 ### Continuous integration checks
 

--- a/README.md
+++ b/README.md
@@ -324,6 +324,13 @@ The integration provides a couple of Home Assistant Actions for use with automat
 - Check if devices have moved recently (Find My devices may not update GPS when stationary)
 - Check battery levels (low battery may disable GPS reporting)
 
+### Location updates stopped after an upgrade
+Location data is fetched **outbound** from Home Assistant to Google (FCM push plus Nova/SPOT polling); it does **not** depend on your Home Assistant internal or external URL configuration. If updates stop after upgrading the integration:
+1. **Reload the integration** (Settings → Devices & Services → Google Find My Device → ⋮ → Reload) or restart Home Assistant. This re-establishes the FCM connection and refreshes tokens, which resolves most post-upgrade stalls.
+2. If updates are still missing, review the logs for authentication errors and re-authenticate if prompted (see [Authentication Expires Repeatedly](#authentication-expires-repeatedly)).
+
+> **Note on the internal/external URL:** Your Home Assistant internal/external URL only affects the clickable **Map View links** on each device page, not location reception. Changing it can appear to "fix" updates because it triggers a reload or restart, but it is the restart that restores tracking, not the URL value. A configuration such as internal `http://ip-address:8123` plus external `https://your-domain:8123` is perfectly valid.
+
 ### FCM Connection Problems
 - Extended timeout allows up to 60 seconds for device response
 - Check firewall settings for Firebase Cloud Messaging

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -161,6 +161,26 @@ else:
 _LOGGER = logging.getLogger(__name__)
 
 
+# AP4 (finding 4c): the driving supervisor generation for the in-flight FCM
+# handshake. The vendored ``firebase_messaging`` client invokes
+# ``credentials_updated_callback`` SYNCHRONOUSLY from inside
+# ``checkin_or_register`` / ``reregister_keeping_identity`` (same task). The
+# credentials callback closure is bound at client-build time and is shared
+# across a fast reload (``unregister_coordinator`` bumps the generation but does
+# NOT pop the reused client), so the closure alone cannot tell which supervisor
+# drives the current handshake. ``_register_for_fcm_entry`` publishes its
+# captured generation here for the duration of the await; the callback reads it
+# and gates its writes on the *triggering* generation. A ContextVar (not a plain
+# attribute) is required: many awaits inside firebase separate the publish from
+# the callback, so a concurrent supervisor task must not clobber the value --
+# task-local isolation does exactly that. Outside any handshake (a live-
+# connection cred refresh) the default ``None`` preserves the historical
+# tombstone-only behaviour.
+_FCM_DRIVING_GENERATION: contextvars.ContextVar[tuple[str, int | None] | None] = (
+    contextvars.ContextVar("fcm_driving_generation", default=None)
+)
+
+
 # Iter-12 (Codex follow-up): the short-run crash cap needs to know
 # whether the FCM client ever reached ``FcmPushClientRunState.STARTED``
 # during a run, even when the entire CREATED -> STARTED -> CRASH
@@ -422,6 +442,91 @@ class FcmReceiverHA:
         # the coordinator and the diagnostic binary sensor for the entire
         # latch lifetime, even across non-cap fatal overwrites.
         self._short_run_cap_messages: dict[str, str] = {}
+
+        # AP4 (finding 4a): tombstone set of entry_ids whose synchronous
+        # teardown (``unregister_coordinator``) has already purged their
+        # per-entry state. ``unregister_coordinator`` does not await the
+        # still-running supervisor task, which writes per-entry state (fatal
+        # counts, cap latch, creds) largely outside ``self._lock`` and could
+        # otherwise re-create exactly what the purge removed. While an entry is
+        # tombstoned those supervisor writes are skipped; ``register_coordinator``
+        # clears the tombstone on the next setup so a reload restores normal
+        # writes while a real removal stays clean.
+        self._unregistered: set[str] = set()
+
+        # AP4 (finding 4b): per-entry supervisor generation. The boolean
+        # tombstone above is cleared by ``register_coordinator`` on the next
+        # setup, but every unload also calls ``request_stop()`` which only
+        # *cancels* the prior supervisor without awaiting it. A fast reload can
+        # therefore clear the tombstone while the cancelled supervisor is still
+        # unwinding, re-opening the teardown race for that stale task. Each
+        # teardown bumps this counter; a supervisor captures the value current
+        # when it starts, so a superseded supervisor's writes stay suppressed by
+        # generation even after the tombstone is cleared for the new
+        # incarnation. The credentials-updated callback cannot capture this at
+        # build time (its FCM client -- and the bound closure -- is reused across
+        # a fast reload, so the build-time snapshot would suppress the LIVE
+        # incarnation's legitimate writes). Instead it reads the *driving*
+        # generation that ``_register_for_fcm_entry`` publishes in
+        # ``_FCM_DRIVING_GENERATION`` around each handshake (finding 4c): a
+        # cancelled-but-unwinding supervisor that fires the callback mid-checkin
+        # is then recognised as superseded, while a live handshake (matching
+        # generation) or an out-of-band refresh (no driving generation -> the
+        # boolean tombstone window only) still writes.
+        self._entry_generation: dict[str, int] = {}
+
+    def _entry_writes_suppressed(
+        self, entry_id: str, generation: int | None = None
+    ) -> bool:
+        """Return True when a per-entry write must be dropped (AP4).
+
+        Two independent conditions suppress a write:
+
+        * The entry is tombstoned by a synchronous teardown (boolean
+          ``_unregistered``); cleared by ``register_coordinator`` on the next
+          setup. This covers the teardown window and the reused FCM client's
+          credentials callback.
+        * A ``generation`` is supplied and no longer matches the entry's current
+          generation, meaning the caller belongs to a superseded supervisor that
+          was cancelled but is still unwinding. This keeps a stale supervisor's
+          writes suppressed even after the tombstone is cleared for a new
+          incarnation (finding 4b).
+
+        Callers without a captured generation (e.g. the credentials callback)
+        pass ``None`` and get the pure tombstone-window behaviour.
+
+        Use this to gate *write* side effects that RE-CREATE per-entry state
+        (token routing, fatal-error publication, cap-fire). For *removal* side
+        effects that are teardown-safe in the tombstone window but harmful only
+        when a stale generation would clobber the live incarnation, gate on
+        ``_entry_generation_superseded`` instead.
+        """
+        if entry_id in self._unregistered:
+            return True
+        return self._entry_generation_superseded(entry_id, generation)
+
+    def _entry_generation_superseded(
+        self, entry_id: str, generation: int | None
+    ) -> bool:
+        """Return True when ``generation`` belongs to a superseded supervisor.
+
+        This checks ONLY the generation-mismatch condition (a stale supervisor
+        that captured an old generation and lost ownership to a live incarnation
+        after a fast reload), NOT the boolean tombstone window. A caller without
+        a captured generation (the public re-register / credentials path) is a
+        live operation and is never "superseded", so it returns False.
+
+        It is the narrow guard for *removal* side effects (clearing the fatal
+        latch, deleting the reauth repair, resetting shared retry counters):
+        those are teardown-safe while an entry is merely tombstoned (it is going
+        away and ``unregister_coordinator`` already reset it), but must be
+        skipped when an old generation would wipe the LIVE generation's
+        diagnostics.
+        """
+        return (
+            generation is not None
+            and generation != self._entry_generation.get(entry_id, 0)
+        )
 
     def _clear_fatal_error_for_entry(
         self,
@@ -734,6 +839,26 @@ class FcmReceiverHA:
                 except Exception as err:  # noqa: BLE001
                     _LOGGER.debug("Cache provider reset failed: %s", err)
 
+    @contextmanager
+    def _driving_generation_scope(
+        self, entry_id: str, generation: int | None
+    ) -> Iterator[None]:
+        """Publish the driving supervisor generation for one FCM handshake.
+
+        ``firebase_messaging`` fires ``credentials_updated_callback``
+        synchronously from inside the awaited ``checkin_or_register`` /
+        ``reregister_keeping_identity`` (same task). The callback closure is
+        shared across a fast reload, so it gates on this published generation
+        instead of a stale build-time snapshot. See ``_FCM_DRIVING_GENERATION``
+        for the full rationale (finding 4c). Reset in ``finally`` so a nested or
+        sibling handshake never inherits a leaked value.
+        """
+        token = _FCM_DRIVING_GENERATION.set((entry_id, generation))
+        try:
+            yield
+        finally:
+            _FCM_DRIVING_GENERATION.reset(token)
+
     def _monotonic_from_wall_time(
         self, wall_time: float, monotonic_now: float
     ) -> float | None:
@@ -945,35 +1070,120 @@ class FcmReceiverHA:
         _LOGGER.info("FCM receiver initialized (multi-client ready)")
         return True
 
-    async def _ensure_client_for_entry(
+    async def _load_entry_creds_for_build(
         self, entry_id: str, cache: TokenCache | None
+    ) -> tuple[MutableJSONMapping | None, bool]:
+        """Resolve entry creds for a client build (the sole suspension point).
+
+        Returns ``(creds, loaded_from_cache)``. ``creds`` falls back to the
+        in-memory map, then the pending-creds buffer, then is overridden by a
+        successful awaited cache read. ``loaded_from_cache`` is True only when
+        that read produced a fresh credentials dict, so the caller knows it may
+        pop the pending-creds entry as part of its guarded commit.
+
+        The ``await`` here is the only suspension point in
+        ``_ensure_client_for_entry``'s critical section; the caller MUST
+        re-validate ``_entry_writes_suppressed`` after this returns, because a
+        synchronous teardown can land while this coroutine is parked on it.
+        """
+        creds = self.creds.get(entry_id)
+        if creds is None:
+            pending = self._pending_creds.get(entry_id)
+            if isinstance(pending, dict):
+                creds = pending
+        loaded_from_cache = False
+        try:
+            if cache is not None:
+                val = await cache.get("fcm_credentials")
+                if isinstance(val, str):
+                    val = json.loads(val)
+                if isinstance(val, dict):
+                    creds = val
+                    loaded_from_cache = True
+        except Exception as err:  # noqa: BLE001 - best-effort creds load
+            _LOGGER.debug(
+                "Failed to load entry-scoped FCM creds for %s: %s", entry_id, err
+            )
+        return creds, loaded_from_cache
+
+    async def _ensure_client_for_entry(
+        self, entry_id: str, cache: TokenCache | None, generation: int | None = None
     ) -> FcmPushClient[Any] | None:
-        """Create or return the FCM client for the given entry (idempotent)."""
+        """Create or return the FCM client for the given entry (idempotent).
+
+        ``generation`` is the supervisor's captured generation snapshot (or
+        ``None`` for live callers such as manual-locate registration). It gates
+        the *build* path through ``_entry_writes_suppressed`` (finding 5).
+        """
         if cache is not None:
             self._ensure_cache_entry_id(cache, entry_id)
         async with self._lock:
+            # AP6 (finding 5 + finding 6): gate BEFORE the existing-client fast
+            # path. A tombstoned entry or a superseded supervisor generation
+            # must never receive a client handle -- not even an already-built
+            # one. Two races collapse into this single chokepoint:
+            #
+            #   * finding 5 (build path): ``register_coordinator`` dispatches the
+            #     supervisor asynchronously; if ``unregister_coordinator``
+            #     tombstones the entry before that queued coroutine runs
+            #     (unload-before-dispatch), the build below would revive a
+            #     torn-down entry's ``self.pcs``/``self.creds``.
+            #   * finding 6 (read path): after a fast reload the new incarnation
+            #     installs a fresh client under ``entry_id``; a stale supervisor
+            #     (old generation) then calls in here. If the existing-client
+            #     early return ran first it would hand that stale supervisor the
+            #     LIVE client, which it later stops + discards on its own
+            #     suppression branch. ``_discard_own_client`` compares by
+            #     identity, but the handle IS the live client, so the identity
+            #     guard cannot save it -- the new incarnation loses its client.
+            #
+            # The generation guard in ``_register_for_fcm_entry`` fires one step
+            # too late for both. Gating first closes the build path AND the read
+            # path here. The supervisor loop treats this None as terminal (it
+            # built no own client, so there is nothing to clean up).
+            if self._entry_writes_suppressed(entry_id, generation):
+                _LOGGER.debug(
+                    "[entry=%s] Skipping FCM client handover for suppressed entry "
+                    "(tombstoned or superseded generation)",
+                    entry_id,
+                )
+                return None
+
+            # Idempotent read: an already-built client for a live, current
+            # generation is returned as-is (a read, not a re-creation).
             if entry_id in self.pcs:
                 return self.pcs[entry_id]
 
-            # Load entry-scoped credentials if present
-            creds = self.creds.get(entry_id)
-            if creds is None:
-                pending = self._pending_creds.get(entry_id)
-                if isinstance(pending, dict):
-                    creds = pending
-            try:
-                if cache is not None:
-                    val = await cache.get("fcm_credentials")
-                    if isinstance(val, str):
-                        val = json.loads(val)
-                    if isinstance(val, dict):
-                        creds = val
-                        self.creds[entry_id] = creds
-                        self._pending_creds.pop(entry_id, None)
-            except Exception as err:
+            # Resolve entry creds at the sole suspension point (the awaited cache
+            # read). Extracted into a named seam so this build chokepoint stays
+            # within its branch budget and the await is isolated; the store into
+            # ``self.creds[entry_id]`` is deferred to the single guarded commit
+            # below, because writing entry-state mid-method would let a teardown
+            # landing during the await re-create exactly what it just purged.
+            creds, loaded_from_cache = await self._load_entry_creds_for_build(
+                entry_id, cache
+            )
+
+            # AP7 (finding 7): re-validate suppression AFTER the await, BEFORE any
+            # per-entry store. ``self._lock`` is an asyncio lock -- it serialises
+            # other coroutines but does NOT exclude the SYNCHRONOUS
+            # ``unregister_coordinator`` (``async_on_unload``), which takes no
+            # lock. The ``await cache.get(...)`` above is the sole suspension
+            # point in this critical section; while parked there a teardown can
+            # tombstone the entry and ``_purge_entry_tokens`` it, so the first
+            # gate's verdict is stale on resume. Committing the stores below now
+            # would resurrect the purged ``self.pcs``/``self.creds`` -- the
+            # TOCTOU-over-await sibling of the fast-path race the first gate
+            # closes. Drop the handover; live callers treat None gracefully and a
+            # superseded supervisor terminates on it.
+            if self._entry_writes_suppressed(entry_id, generation):
                 _LOGGER.debug(
-                    "Failed to load entry-scoped FCM creds for %s: %s", entry_id, err
+                    "[entry=%s] Dropping FCM client handover after creds load; "
+                    "entry was suppressed (tombstoned or superseded) during the "
+                    "cache await",
+                    entry_id,
                 )
+                return None
 
             # Build register config (shared across entries)
             if not HAVE_FCM_PUSH_CLIENT:
@@ -1021,9 +1231,35 @@ class FcmReceiverHA:
                 )
                 return None
 
+            # Single guarded commit: every per-entry store happens here, after
+            # the post-await re-validation -- never mid-method. The pending-creds
+            # pop is part of the commit because it only applies when the cache
+            # load above produced fresh credentials.
             self.pcs[entry_id] = pc
             self.creds[entry_id] = creds if isinstance(creds, dict) else None
+            if loaded_from_cache:
+                self._pending_creds.pop(entry_id, None)
             return pc
+
+    def _discard_own_client(
+        self, entry_id: str, pc: FcmPushClient[Any]
+    ) -> None:
+        """Remove *pc* from ``self.pcs`` only if it is still the live client.
+
+        A supervisor cleans up the client it built by popping ``self.pcs``
+        under ``self._lock``. A key-only ``pop(entry_id)`` is identity-blind:
+        when a fast reload bumps the generation and the new incarnation has
+        already installed a fresh client under the same ``entry_id`` (via
+        ``_ensure_client_for_entry``), a stale supervisor reaching its cleanup
+        would evict the LIVE client, leaving the new generation without an FCM
+        client until its next restart. Comparing by identity ensures each
+        supervisor only discards the client it owns; a superseded supervisor
+        leaves the live client untouched.
+
+        Caller must hold ``self._lock``.
+        """
+        if self.pcs.get(entry_id) is pc:
+            self.pcs.pop(entry_id, None)
 
     def _async_raise_reauth_issue(self, entry_id: str, *, reason: str) -> None:
         """Surface a fixable repair that drives the user into the reauth flow.
@@ -1070,6 +1306,13 @@ class FcmReceiverHA:
         if entry_id in self.supervisors and not self.supervisors[entry_id].done():
             return
 
+        # AP4 (finding 4b): capture the generation current at start. Every
+        # per-entry write below is gated on this snapshot, so once a teardown
+        # bumps the generation this (now superseded) supervisor stops writing
+        # even after ``register_coordinator`` clears the boolean tombstone for
+        # the next incarnation.
+        generation = self._entry_generation.get(entry_id, 0)
+
         # AP5 (finding 4b): a prior stop (request_stop on unload, or the cap
         # teardown) leaves the entry's event *set* without installing a fresh
         # one. The old ``setdefault`` then handed that set event to the new
@@ -1106,8 +1349,20 @@ class FcmReceiverHA:
             entry_start: float = 0.0
             try:
                 while not stop_evt.is_set():
-                    pc = await self._ensure_client_for_entry(entry_id, cache)
+                    pc = await self._ensure_client_for_entry(
+                        entry_id, cache, generation
+                    )
                     if not pc:
+                        # finding 6: the build chokepoint now returns None for a
+                        # tombstoned entry or a superseded generation BEFORE
+                        # handing out any client. That is terminal for this
+                        # supervisor -- it must stop, not spin: no own client was
+                        # built (nothing to clean up) and the outer finally is
+                        # suppression-aware. A None from a transient build
+                        # failure (push-client support absent, factory error) is
+                        # NOT suppression and keeps retrying with backoff.
+                        if self._entry_writes_suppressed(entry_id, generation):
+                            break
                         nudged = await _nudge_sleep(backoff)
                         if nudged:
                             backoff = 1.0
@@ -1116,7 +1371,9 @@ class FcmReceiverHA:
                         continue
 
                     try:
-                        ok_reg = await self._register_for_fcm_entry(entry_id)
+                        ok_reg = await self._register_for_fcm_entry(
+                            entry_id, generation
+                        )
                     except FatalRegistrationError as err:
                         message = str(err) or "FCM registration failed"
                         # Publish to ``_fatal_errors`` only once the retry
@@ -1136,7 +1393,7 @@ class FcmReceiverHA:
                             pass
                         finally:
                             async with self._lock:
-                                self.pcs.pop(entry_id, None)
+                                self._discard_own_client(entry_id, pc)
 
                         is_auth = getattr(err, "is_auth_error", False)
                         counter_key = (
@@ -1147,6 +1404,21 @@ class FcmReceiverHA:
                         fatal_count = (
                             self._fatal_retry_counts.get(counter_key, 0) + 1
                         )
+                        # AP4 race guard: a teardown or a supersede may have
+                        # purged/re-owned this entry mid-flight. A suppressed
+                        # supervisor is stale for the ENTIRE retry-budget
+                        # handling, not just the counter write below: the give-up
+                        # branches publish ``_fatal_error`` / ``_fatal_errors``
+                        # and raise the reauth repair, and ``fatal_count`` is read
+                        # from the shared ``_fatal_retry_counts`` map the LIVE
+                        # generation may already own after a fast reload. Letting
+                        # a stale generation reach the give-up branches would
+                        # surface a reauth/fatal error against the live entry.
+                        # Bail out entirely; the supervisor terminates via the
+                        # surrounding loop's finally cleanup (the failed client
+                        # was already stopped and popped above).
+                        if self._entry_writes_suppressed(entry_id, generation):
+                            break
                         self._fatal_retry_counts[counter_key] = fatal_count
 
                         if is_auth:
@@ -1171,7 +1443,7 @@ class FcmReceiverHA:
                                 )
                                 break
 
-                            await self._invalidate_fcm_tokens(entry_id)
+                            await self._invalidate_fcm_tokens(entry_id, generation)
 
                             delay = 60.0 * fatal_count
                             _LOGGER.warning(
@@ -1222,6 +1494,31 @@ class FcmReceiverHA:
                             await asyncio.sleep(delay)
                             continue
 
+                    # AP4 (finding: stale registration success at the caller).
+                    # ``_register_for_fcm_entry`` guards its own per-entry writes,
+                    # but its boolean return cannot tell this caller that the
+                    # generation was superseded (or the entry tombstoned)
+                    # mid-flight. Without this guard a stale supervisor would run
+                    # the success path below -- deleting the LIVE generation's
+                    # reauth repair issue, bumping start metrics and
+                    # (re)starting + monitoring the stale client -- or, on a
+                    # transient ``ok_reg`` False, burn the shared retry budget for
+                    # an entry it no longer owns. Returning False instead would be
+                    # wrong: it routes into the backoff/retry path, but a
+                    # superseded generation must terminate, not retry. Bail out
+                    # like the fatal-retry break above; the surrounding finally
+                    # skips the stale health write under the same suppression
+                    # guard.
+                    if self._entry_writes_suppressed(entry_id, generation):
+                        try:
+                            await pc.stop()
+                        except Exception:
+                            pass
+                        finally:
+                            async with self._lock:
+                                self._discard_own_client(entry_id, pc)
+                        break
+
                     if not ok_reg:
                         try:
                             await pc.stop()
@@ -1229,7 +1526,7 @@ class FcmReceiverHA:
                             pass
                         finally:
                             async with self._lock:
-                                self.pcs.pop(entry_id, None)
+                                self._discard_own_client(entry_id, pc)
                         delay = backoff + random.uniform(0.1, 0.3) * backoff  # nosec B311
                         if backoff >= _BACKOFF_WARNING_THRESHOLD_S:
                             _LOGGER.warning(
@@ -1312,8 +1609,25 @@ class FcmReceiverHA:
                         state = getattr(pc, "run_state", None)
                         do_listen = getattr(pc, "do_listen", False)
                         monotonic_now = time.monotonic()
-                        last_activity = self._update_last_activity_for_entry(
-                            entry_id, pc, monotonic_now
+                        # AP4 (finding 4b, related sweep): a superseded or
+                        # tombstoned supervisor must not refresh per-entry
+                        # activity/health here. Those writes resurrect exactly
+                        # the snapshots ``_purge_entry_tokens`` dropped -- a stale
+                        # ``_entry_health`` makes the first healthy transition of
+                        # the next incarnation look like a no-change and
+                        # suppresses its listener push (the AP2 class named in
+                        # finding 2b). Skip the writes while suppressed; the
+                        # restart decision below still uses ``state`` /
+                        # ``do_listen``.
+                        writes_suppressed = self._entry_writes_suppressed(
+                            entry_id, generation
+                        )
+                        last_activity = (
+                            None
+                            if writes_suppressed
+                            else self._update_last_activity_for_entry(
+                                entry_id, pc, monotonic_now
+                            )
                         )
                         stale_after = max(self._activity_stale_after_s, 0.0)
                         # Iter-11: track ``became_started`` symmetrically to
@@ -1349,7 +1663,8 @@ class FcmReceiverHA:
                                 or (monotonic_now - last_activity <= stale_after)
                             )
                         )
-                        self._update_entry_health(entry_id, healthy)
+                        if not writes_suppressed:
+                            self._update_entry_health(entry_id, healthy)
                         if state is None:
                             _LOGGER.info(
                                 "[entry=%s] FCM client state unknown; scheduling restart",
@@ -1427,7 +1742,7 @@ class FcmReceiverHA:
                             entry_id,
                             credential_error,
                         )
-                        await self._invalidate_fcm_tokens(entry_id)
+                        await self._invalidate_fcm_tokens(entry_id, generation)
                         short_run_counter = 0
                     elif not became_started:
                         # Pre-start failure (no connected/listening state
@@ -1453,30 +1768,37 @@ class FcmReceiverHA:
                                 f"(persistent poison message suspected)"
                             )
                             _LOGGER.error("[entry=%s] %s", entry_id, message)
-                            self._fatal_errors[entry_id] = message
-                            # Defense 2 iter-8: latch the cap state. While
-                            # this latch is set, ``_clear_fatal_error_for_entry``
-                            # is a no-op (registration / credential-update paths
-                            # cannot clear the fatal map or the Repairs issue
-                            # before a real healthy supervisor run proves the
-                            # poison message is gone).
-                            self._short_run_cap_latched.add(entry_id)
-                            # Iter-16 (Codex follow-up): snapshot the
-                            # cap-fire message so the pass-through clear
-                            # branch in ``_clear_fatal_error_for_entry`` can
-                            # restore it after a non-cap fatal overwrote
-                            # ``_fatal_errors[entry_id]``. Released in the
-                            # same two places that release the latch.
-                            self._short_run_cap_messages[entry_id] = message
-                            if self._hass:
-                                ir.async_create_issue(
-                                    self._hass,
-                                    DOMAIN,
-                                    f"fcm_short_run_crash_loop_{entry_id}",
-                                    is_fixable=False,
-                                    severity=ir.IssueSeverity.ERROR,
-                                    translation_key="fcm_short_run_crash_loop",
-                                )
+                            # AP4 race guard: a teardown may have purged this
+                            # entry while the monitor loop was running. Skip the
+                            # cap latch / fatal map / Repairs issue so they are
+                            # not resurrected for a dead entry; the terminal
+                            # break below still stops this supervisor.
+                            if not self._entry_writes_suppressed(entry_id, generation):
+                                self._fatal_errors[entry_id] = message
+                                # Defense 2 iter-8: latch the cap state. While
+                                # this latch is set,
+                                # ``_clear_fatal_error_for_entry`` is a no-op
+                                # (registration / credential-update paths cannot
+                                # clear the fatal map or the Repairs issue before
+                                # a real healthy supervisor run proves the poison
+                                # message is gone).
+                                self._short_run_cap_latched.add(entry_id)
+                                # Iter-16 (Codex follow-up): snapshot the
+                                # cap-fire message so the pass-through clear
+                                # branch in ``_clear_fatal_error_for_entry`` can
+                                # restore it after a non-cap fatal overwrote
+                                # ``_fatal_errors[entry_id]``. Released in the
+                                # same two places that release the latch.
+                                self._short_run_cap_messages[entry_id] = message
+                                if self._hass:
+                                    ir.async_create_issue(
+                                        self._hass,
+                                        DOMAIN,
+                                        f"fcm_short_run_crash_loop_{entry_id}",
+                                        is_fixable=False,
+                                        severity=ir.IssueSeverity.ERROR,
+                                        translation_key="fcm_short_run_crash_loop",
+                                    )
                             # Cleanup the client before breaking out so
                             # the loop exit doesn't leave a half-stopped pc.
                             try:
@@ -1485,8 +1807,14 @@ class FcmReceiverHA:
                                 pass
                             finally:
                                 async with self._lock:
-                                    self.pcs.pop(entry_id, None)
-                                self._update_entry_health(entry_id, False)
+                                    self._discard_own_client(entry_id, pc)
+                                # AP4 (finding 4b, related sweep): suppress the
+                                # stale-health write for a superseded/tombstoned
+                                # supervisor (resurrection class, finding 2b).
+                                if not self._entry_writes_suppressed(
+                                    entry_id, generation
+                                ):
+                                    self._update_entry_health(entry_id, False)
                             # Defense 2 iter-9 (Codex follow-up): the cap is
                             # a TERMINAL state for this supervisor. ``break``
                             # alone only exits the inner monitor loop and
@@ -1528,36 +1856,49 @@ class FcmReceiverHA:
                         # ``self._hass is not None`` and intentionally also
                         # runs when no latch was set (cheap idempotent UI
                         # cleanup).
-                        cap_was_latched = entry_id in self._short_run_cap_latched
-                        if cap_was_latched:
-                            self._short_run_cap_latched.discard(entry_id)
-                            # Iter-16: a healthy run is also the moment to
-                            # retire the cap-fire snapshot so the
-                            # pass-through clear branch cannot re-introduce
-                            # it after the latch is gone.
-                            self._short_run_cap_messages.pop(entry_id, None)
-                            cap_message = self._fatal_errors.get(entry_id)
-                            if cap_message and cap_message.startswith(
-                                CRASH_LOOP_FATAL_PREFIX
-                            ):
-                                self._fatal_errors.pop(entry_id, None)
-                                self._fatal_error = next(
-                                    iter(self._fatal_errors.values()), None
-                                )
-                                _LOGGER.info(
-                                    "[entry=%s] FCM short-run cap latch released "
-                                    "by healthy supervisor run",
-                                    entry_id,
-                                )
-                        if self._hass is not None:
-                            try:
-                                ir.async_delete_issue(
-                                    self._hass,
-                                    DOMAIN,
-                                    f"fcm_short_run_crash_loop_{entry_id}",
-                                )
-                            except Exception:  # noqa: BLE001
-                                pass
+                        # AP4 (finding 4b, related sweep): a superseded or
+                        # tombstoned supervisor must not release the LIVE
+                        # generation's cap latch / fatal map / Repairs issue.
+                        # This mirrors the cap-FIRE guard above: a stale healthy
+                        # run is not proof the live incarnation's poison-message
+                        # condition is gone, and an old generation finishing a
+                        # healthy run after a fast reload would otherwise wipe the
+                        # new generation's diagnostics. The closure-local
+                        # ``short_run_counter`` reset above stays unguarded (it
+                        # cannot leak across incarnations).
+                        if not self._entry_writes_suppressed(entry_id, generation):
+                            cap_was_latched = (
+                                entry_id in self._short_run_cap_latched
+                            )
+                            if cap_was_latched:
+                                self._short_run_cap_latched.discard(entry_id)
+                                # Iter-16: a healthy run is also the moment to
+                                # retire the cap-fire snapshot so the
+                                # pass-through clear branch cannot re-introduce
+                                # it after the latch is gone.
+                                self._short_run_cap_messages.pop(entry_id, None)
+                                cap_message = self._fatal_errors.get(entry_id)
+                                if cap_message and cap_message.startswith(
+                                    CRASH_LOOP_FATAL_PREFIX
+                                ):
+                                    self._fatal_errors.pop(entry_id, None)
+                                    self._fatal_error = next(
+                                        iter(self._fatal_errors.values()), None
+                                    )
+                                    _LOGGER.info(
+                                        "[entry=%s] FCM short-run cap latch "
+                                        "released by healthy supervisor run",
+                                        entry_id,
+                                    )
+                            if self._hass is not None:
+                                try:
+                                    ir.async_delete_issue(
+                                        self._hass,
+                                        DOMAIN,
+                                        f"fcm_short_run_crash_loop_{entry_id}",
+                                    )
+                                except Exception:  # noqa: BLE001
+                                    pass
 
                     # Cleanup before restart
                     try:
@@ -1566,8 +1907,12 @@ class FcmReceiverHA:
                         pass
                     finally:
                         async with self._lock:
-                            self.pcs.pop(entry_id, None)
-                        self._update_entry_health(entry_id, False)
+                            self._discard_own_client(entry_id, pc)
+                        # AP4 (finding 4b, related sweep): suppress the
+                        # stale-health write for a superseded/tombstoned
+                        # supervisor (resurrection class, finding 2b).
+                        if not self._entry_writes_suppressed(entry_id, generation):
+                            self._update_entry_health(entry_id, False)
 
                     if not stop_evt.is_set():
                         delay = backoff + random.uniform(0.1, 0.3) * backoff  # nosec B311
@@ -1586,7 +1931,16 @@ class FcmReceiverHA:
                 _LOGGER.error("[entry=%s] FCM supervisor crashed: %s", entry_id, err)
             finally:
                 _LOGGER.info("[entry=%s] FCM supervisor stopped", entry_id)
-                self._update_entry_health(entry_id, False)
+                # AP4 (finding 4b, related sweep): a supervisor cancelled by a
+                # teardown/reload must not write a stale "unhealthy" snapshot
+                # here -- ``_purge_entry_tokens`` just dropped ``_entry_health``
+                # for this entry, and re-creating it as False would suppress the
+                # first healthy transition of the next incarnation (the AP2
+                # resurrection class). Skip the write once this supervisor is
+                # superseded or the entry is tombstoned; a genuine shutdown
+                # (no generation bump, no tombstone) still records it.
+                if not self._entry_writes_suppressed(entry_id, generation):
+                    self._update_entry_health(entry_id, False)
                 self._retry_nudge_evts.pop(entry_id, None)
 
         task = asyncio.create_task(
@@ -1638,7 +1992,9 @@ class FcmReceiverHA:
             gcm.get("security_token")
         )
 
-    async def _invalidate_fcm_tokens(self, entry_id: str) -> None:
+    async def _invalidate_fcm_tokens(
+        self, entry_id: str, generation: int | None = None
+    ) -> None:
         """Clear renewable FCM tokens, preserving a *usable* GCM identity.
 
         When the GCM block still carries a complete device identity
@@ -1649,7 +2005,17 @@ class FcmReceiverHA:
         ``reregister_keeping_identity()`` raise ``KeyError`` forever (Codex
         follow-up), so dropping it forces ``_register_for_fcm_entry`` onto the
         full ``checkin_or_register()`` handshake.
+
+        ``generation`` is the supervisor's captured generation (AP4 finding 4b).
+        The public ``async_reregister_fcm`` path is a live operation and passes
+        ``None`` (tombstone-window check only); a supervisor passes its snapshot
+        so a superseded run cannot write back the creds the teardown dropped.
         """
+        # AP4 race guard: never persist creds for an entry the teardown already
+        # purged (a still-running or superseded supervisor must not write back
+        # the credentials _purge_entry_tokens dropped).
+        if self._entry_writes_suppressed(entry_id, generation):
+            return
         creds = self.creds.get(entry_id)
         if creds and isinstance(creds, dict):
             # Renewable FCM parts always go.
@@ -1757,8 +2123,16 @@ class FcmReceiverHA:
             err,
         )
 
-    async def _register_for_fcm_entry(self, entry_id: str) -> bool:
-        """Single registration attempt for a specific entry."""
+    async def _register_for_fcm_entry(
+        self, entry_id: str, generation: int | None = None
+    ) -> bool:
+        """Single registration attempt for a specific entry.
+
+        ``generation`` is the supervisor's captured generation (AP4 finding 4b);
+        it gates the success-path routing writes so a superseded supervisor
+        cannot resurrect routing state after the boolean tombstone is cleared.
+        Callers outside a supervisor pass ``None`` (tombstone-window check only).
+        """
         pc = self.pcs.get(entry_id)
         if not pc:
             return False
@@ -1771,28 +2145,48 @@ class FcmReceiverHA:
                 and "gcm" in creds
                 and "fcm" not in creds
             )
-            if needs_reregister:
-                _LOGGER.info(
-                    "[entry=%s] Partial credentials detected; "
-                    "re-registering with existing device identity",
-                    entry_id,
-                )
-                token_or_creds = await pc.reregister_keeping_identity()
-            else:
-                token_or_creds = await pc.checkin_or_register()
+            # Publish this supervisor's captured generation for the handshake so
+            # the synchronously-fired credentials callback gates on the driving
+            # generation, not the reused client's stale build-time one (4c).
+            with self._driving_generation_scope(entry_id, generation):
+                if needs_reregister:
+                    _LOGGER.info(
+                        "[entry=%s] Partial credentials detected; "
+                        "re-registering with existing device identity",
+                        entry_id,
+                    )
+                    token_or_creds = await pc.reregister_keeping_identity()
+                else:
+                    token_or_creds = await pc.checkin_or_register()
 
             if token_or_creds:
                 _LOGGER.info("[entry=%s] FCM registered successfully", entry_id)
-                token = self.get_fcm_token(entry_id)
-                if token:
-                    self._update_token_routing(token, {entry_id})
-                    await self._persist_routing_token(entry_id, token)
-                self._clear_fatal_error_for_entry(
-                    entry_id, reason="Registration succeeded"
-                )
-                # Reset fatal retry counters on success
-                self._fatal_retry_counts.pop(f"{entry_id}:auth", None)
-                self._fatal_retry_counts.pop(f"{entry_id}:endpoint", None)
+                # AP4 race guard (two tiers): a teardown or a supersede may have
+                # purged or re-owned this entry while this attempt was in flight.
+                #
+                # * Routing writes RE-CREATE the per-entry state
+                #   ``_purge_entry_tokens`` removed, so they are skipped whenever
+                #   writes are suppressed (tombstone window OR superseded gen).
+                # * The clears / counter resets only REMOVE state, so they stay
+                #   teardown-safe in the pure-tombstone window (the entry is going
+                #   away and ``unregister_coordinator`` already reset it). But a
+                #   SUPERSEDED generation finishing after a fast reload must NOT
+                #   run them: that would wipe the LIVE generation's fatal latch,
+                #   reauth repair and retry counters (finding: guard all stale
+                #   success side effects). Gate them on the narrow generation
+                #   check so the documented teardown-safe-clear behaviour is kept.
+                if not self._entry_writes_suppressed(entry_id, generation):
+                    token = self.get_fcm_token(entry_id)
+                    if token:
+                        self._update_token_routing(token, {entry_id})
+                        await self._persist_routing_token(entry_id, token)
+                if not self._entry_generation_superseded(entry_id, generation):
+                    self._clear_fatal_error_for_entry(
+                        entry_id, reason="Registration succeeded"
+                    )
+                    # Reset fatal retry counters on success
+                    self._fatal_retry_counts.pop(f"{entry_id}:auth", None)
+                    self._fatal_retry_counts.pop(f"{entry_id}:endpoint", None)
                 return True
             _LOGGER.warning("[entry=%s] FCM registration returned no token", entry_id)
             return False
@@ -1818,11 +2212,11 @@ class FcmReceiverHA:
             # a single non-fatal result. Fatal paths
             # (FatalRegistrationError / ClientError / FcmRegisterHTTPError) are
             # handled above and never reach here.
-            await self._classify_registration_exception(entry_id, err)
+            await self._classify_registration_exception(entry_id, err, generation)
             return False
 
     async def _classify_registration_exception(
-        self, entry_id: str, err: BaseException
+        self, entry_id: str, err: BaseException, generation: int | None = None
     ) -> None:
         """Classify a non-fatal registration exception (AP6, finding 3a).
 
@@ -1843,6 +2237,11 @@ class FcmReceiverHA:
         * anything else — unexpected; logged at error (not silently swallowed as
           benign) but left non-fatal so a single surprise cannot crash the
           supervisor.
+
+        ``generation`` is the calling supervisor's captured generation (AP4
+        finding 4b); it is forwarded to ``_invalidate_fcm_tokens`` so a
+        superseded supervisor cannot write back the creds a teardown dropped.
+        Callers outside a supervisor pass ``None`` (tombstone-window check only).
         """
         if isinstance(err, (TimeoutError, RuntimeError)):
             _LOGGER.info(
@@ -1858,7 +2257,7 @@ class FcmReceiverHA:
                 type(err).__name__,
                 err,
             )
-            await self._invalidate_fcm_tokens(entry_id)
+            await self._invalidate_fcm_tokens(entry_id, generation)
         else:
             _LOGGER.error(
                 "[entry=%s] FCM registration unexpected error: %s", entry_id, err
@@ -1895,6 +2294,19 @@ class FcmReceiverHA:
         cache = getattr(coordinator, "cache", None)
         if entry is None:
             return
+
+        # AP4 (finding 4a): a setup (initial or reload) un-tombstones the entry
+        # so the *new* incarnation's writes take effect again. This is the
+        # single reset point: it runs synchronously before the supervisor is
+        # (re)dispatched below. Clearing the boolean tombstone alone would
+        # re-open the race for a prior supervisor that request_stop only
+        # cancelled (not awaited) and which is still unwinding; finding 4b
+        # closes that gap via the generation captured per supervisor, so a
+        # superseded run stays suppressed by generation even though the
+        # tombstone is cleared here. The generation is intentionally NOT reset:
+        # the next supervisor reads the post-teardown value and is allowed,
+        # while the stale one keeps its old (now mismatched) snapshot.
+        self._unregistered.discard(entry.entry_id)
 
         self._entry_to_tokens.setdefault(entry.entry_id, set())
 
@@ -2012,6 +2424,21 @@ class FcmReceiverHA:
                 self._entry_caches[entry_id] = replacement
             else:
                 self._entry_caches.pop(entry_id, None)
+                # AP4 (finding 4a): tombstone the entry BEFORE purging so any
+                # write from the still-running supervisor task (this method is
+                # synchronous and does not await it) is dropped instead of
+                # re-creating the state purged below. Cleared by
+                # register_coordinator on the next setup (reload-safe).
+                self._unregistered.add(entry_id)
+                # AP4 (finding 4b): bump the generation BEFORE the tombstone is
+                # later cleared by ``register_coordinator``. ``request_stop()``
+                # only cancels the prior supervisor without awaiting it, so this
+                # bump is what keeps that cancelled-but-unwinding supervisor's
+                # writes suppressed once the tombstone is gone -- it captured the
+                # old generation, which no longer matches.
+                self._entry_generation[entry_id] = (
+                    self._entry_generation.get(entry_id, 0) + 1
+                )
                 self._purge_entry_tokens(entry_id)
                 # Hard-reset on unregister: this fires via ``async_on_unload``
                 # on EVERY unload (reload AND removal), so it only resets the
@@ -2631,6 +3058,38 @@ class FcmReceiverHA:
 
     def _on_credentials_updated_for_entry(self, entry_id: str, creds: Any) -> None:
         """Update in-memory creds for the entry and persist asynchronously."""
+        # AP4 race guard (two tiers): the old FCM client is not awaited during
+        # the synchronous teardown in ``unregister_coordinator``, so it can still
+        # fire this credentials-updated callback *after* ``_purge_entry_tokens``
+        # cleared the entry. Without this guard the callback would re-write
+        # ``self.creds[entry_id]``, restore token routing and queue persistence /
+        # pending creds, making a removed entry look known again to
+        # ``async_reregister_fcm``.
+        #
+        # The tombstone alone is insufficient on a fast reload (finding 4c):
+        # ``unregister_coordinator`` bumps the generation but does NOT pop the
+        # reused client, and ``register_coordinator`` clears the tombstone for
+        # the new incarnation while a cancelled-but-unwinding supervisor is still
+        # inside ``checkin_or_register`` on that same client. Its synchronously-
+        # fired callback would then pass a tombstone-only gate and clobber the
+        # LIVE generation's creds, routing and fatal latch -- exactly the writes
+        # ``_register_for_fcm_entry`` guards post-await. Resolve the *driving*
+        # generation published by the supervisor for this handshake and gate on
+        # it: a superseded supervisor is suppressed, a live handshake (matching
+        # generation) and an out-of-band refresh (no driving generation -> pure
+        # tombstone window) still write. ``register_coordinator`` clears the
+        # tombstone on the next setup so a genuine reload still accepts creds.
+        driving = _FCM_DRIVING_GENERATION.get()
+        generation = (
+            driving[1] if driving is not None and driving[0] == entry_id else None
+        )
+        if self._entry_writes_suppressed(entry_id, generation):
+            _LOGGER.debug(
+                "[entry=%s] Ignoring credentials-updated callback for suppressed "
+                "entry (tombstoned or superseded generation)",
+                entry_id,
+            )
+            return
         normalized: Any = creds
         if isinstance(normalized, str):
             try:
@@ -2720,6 +3179,22 @@ class FcmReceiverHA:
         Returns True if re-registration was initiated (supervisor restarted),
         False if the entry is not known to this receiver.
         """
+        # A torn-down entry must never be revived from here. unregister_coordinator
+        # (sync, via async_on_unload) tombstones the entry and purges its creds, but
+        # it cannot await pc.stop(), so the live client lingers in self.pcs until the
+        # cancelled supervisor (or async_stop) drains it. The creds/pcs membership
+        # guard below would still pass on that residual client and restart a
+        # supervisor for an entry mid-teardown (zombie). _unregistered is the single
+        # source of truth for "torn down" (see _entry_writes_suppressed); consult it
+        # first and bail before doing any teardown work. Cleared by
+        # register_coordinator on the next setup.
+        if entry_id in self._unregistered:
+            _LOGGER.debug(
+                "[entry=%s] Cannot re-register FCM: entry torn down (tombstoned)",
+                entry_id,
+            )
+            return False
+
         if entry_id not in self.pcs and entry_id not in self.creds:
             _LOGGER.warning(
                 "[entry=%s] Cannot re-register FCM: entry not known to receiver",
@@ -2809,9 +3284,84 @@ class FcmReceiverHA:
         self.last_stop_monotonic = time.monotonic()
         _LOGGER.info("FCM receiver stopped")
 
+    def _purge_entry_debounce(self, entry_id: str) -> None:
+        """Cancel and drop the debounce trias for *entry_id* (AP7).
+
+        The push-path debounce maps (``_pending`` / ``_pending_targets`` /
+        ``_flush_tasks``) are keyed by ``(source_entry, device_id)`` and are only
+        ever cleaned per key inside ``_flush``. No teardown path iterates them
+        by entry, so a flush task still pending at unregister keeps running and
+        may write to an already-removed coordinator, while ``_pending`` /
+        ``_pending_targets`` leak until the next flush. ``task.cancel()`` is safe
+        from sync code and idempotent.
+
+        Two membership relations matter (Codex follow-up):
+
+        * **Keyed by this entry** (``key[0] == entry_id``): drop the whole trias.
+        * **A recipient of another entry's flush** (``entry_id`` is a member of
+          ``_pending_targets[key]`` for a key owned by a *different* source
+          entry): the debounce key is the source entry, not every recipient, so
+          a fan-out keyed elsewhere can still target this entry. Remove it from
+          those target sets; if that empties the set the flush has no remaining
+          recipients, so cancel and drop it (an empty set fans out to no one,
+          while ``None`` means broadcast). Broadcast fallbacks (target set is
+          ``None``) are device-scoped, not entry-scoped, and are left untouched.
+
+        Without the second relation a reload within the debounce window could
+        deliver a pre-teardown payload to the new coordinator of this entry.
+        """
+        for key in [key for key in self._flush_tasks if key[0] == entry_id]:
+            task = self._flush_tasks.pop(key, None)
+            if task is not None:
+                task.cancel()
+        pending_keys = {
+            key
+            for key in (*self._pending, *self._pending_targets)
+            if key[0] == entry_id
+        }
+        for key in pending_keys:
+            self._pending.pop(key, None)
+            self._pending_targets.pop(key, None)
+
+        # Drop this entry from the target sets of flushes keyed by other
+        # entries. Keys owned by this entry were already removed above, so any
+        # key remaining here is keyed by a different source entry.
+        for key in list(self._pending_targets):
+            targets = self._pending_targets.get(key)
+            if not targets or entry_id not in targets:
+                continue  # broadcast (None) or not a recipient
+            targets.discard(entry_id)
+            if targets:
+                continue  # other recipients remain; keep the flush
+            # No recipients left: cancel and drop the orphaned flush.
+            self._pending_targets.pop(key, None)
+            self._pending.pop(key, None)
+            task = self._flush_tasks.pop(key, None)
+            if task is not None:
+                task.cancel()
+
     def _purge_entry_tokens(self, entry_id: str) -> None:
-        """Remove all routing references for a given entry."""
+        """Remove all routing references and per-entry runtime state for an entry."""
         self._entry_last_activity_monotonic.pop(entry_id, None)
+        # AP1 (finding 2a): fatal retry counters are only cleared on the success
+        # path (registration ok), so they leak per teardown without this.
+        self._fatal_retry_counts.pop(f"{entry_id}:auth", None)
+        self._fatal_retry_counts.pop(f"{entry_id}:endpoint", None)
+        # AP2 (finding 2b): per-entry health snapshots are written by
+        # _update_entry_health but never purged; a stale snapshot makes the
+        # first healthy transition after a same-id reload look like a no-change
+        # and suppresses its listener push.
+        self._entry_health.pop(entry_id, None)
+        self._entry_last_connected_wall.pop(entry_id, None)
+        # AP3 (finding 2c): in-memory creds keep async_reregister_fcm's guard
+        # (entry_id in self.creds) True after teardown, which can revive a dead
+        # entry (zombie supervisor). The on-disk cache is untouched, so a reload
+        # reloads creds via _ensure_client_for_entry.
+        self.creds.pop(entry_id, None)
+        self._pending_creds.pop(entry_id, None)
+        # AP7 (finding 2d): cancel pending debounce flush tasks and drop their
+        # payloads so a flush cannot fire at an already-removed coordinator.
+        self._purge_entry_debounce(entry_id)
         tokens = self._entry_to_tokens.pop(entry_id, set())
         self._pending_routing_tokens.pop(entry_id, None)
         if not tokens:

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -1070,7 +1070,18 @@ class FcmReceiverHA:
         if entry_id in self.supervisors and not self.supervisors[entry_id].done():
             return
 
-        stop_evt = self._stop_evts.setdefault(entry_id, asyncio.Event())
+        # AP5 (finding 4b): a prior stop (request_stop on unload, or the cap
+        # teardown) leaves the entry's event *set* without installing a fresh
+        # one. The old ``setdefault`` then handed that set event to the new
+        # supervisor, whose ``while not stop_evt.is_set()`` exited immediately
+        # (wedged restart after a reload). Replace the event only when it is
+        # missing or already set; a still-unset event is kept so a deliberately
+        # pre-installed one (and the still-running old supervisor, which holds
+        # its own reference) keeps working.
+        stop_evt = self._stop_evts.get(entry_id)
+        if stop_evt is None or stop_evt.is_set():
+            stop_evt = asyncio.Event()
+            self._stop_evts[entry_id] = stop_evt
 
         async def _supervisor() -> None:  # noqa: PLR0912, PLR0915
             nudge_evt = self._retry_nudge_evts.setdefault(
@@ -1406,7 +1417,8 @@ class FcmReceiverHA:
                         # against the same credentials would loop until the
                         # short-run crash cap fires; instead invalidate the key
                         # material so the next registration regenerates it
-                        # (android_id/security_token preserved) and do NOT
+                        # (a valid GCM identity is preserved, a corrupt one
+                        # dropped) and do NOT
                         # charge this run to the crash cap -- corrective action
                         # is being taken, this is not a poison-message loop.
                         _LOGGER.error(
@@ -1583,22 +1595,88 @@ class FcmReceiverHA:
         self.supervisors[entry_id] = task
         _LOGGER.info("Started FCM supervisor for entry %s", entry_id)
 
-    async def _invalidate_fcm_tokens(self, entry_id: str) -> None:
-        """Clear renewable FCM tokens while preserving GCM device identity.
+    @staticmethod
+    def _is_reregisterable_id(value: Any) -> bool:
+        """Return True when ``value`` survives the reregister path's ``int()``.
 
-        After this, the next registration attempt will use
-        ``reregister_keeping_identity()`` to get fresh FCM tokens with
-        the same android_id/security_token.
+        ``FcmRegister._get_checkin_payload`` re-uses a cached identity only when
+        both fields are truthy *and* ``int()``-convertible (it runs
+        ``int(android_id)`` / ``int(security_token)``). A truthy-but-malformed
+        value — e.g. a non-numeric string ``"sec-tok"`` or a list — passes the
+        truthiness gate but raises ``ValueError``/``TypeError`` on ``int()``,
+        trapping the supervisor in the same retry loop. A corrupted payload may
+        also carry a float infinity (``1e309`` / ``Infinity`` in JSON), which is
+        truthy and not a bool but raises ``OverflowError`` on ``int()`` — the
+        same trap, so it is rejected here too. ``bool`` is rejected explicitly:
+        it is an ``int`` subclass but never a real device identity.
+        """
+        if not value or isinstance(value, bool):
+            return False
+        try:
+            int(value)
+        except (ValueError, TypeError, OverflowError):
+            return False
+        return True
+
+    @classmethod
+    def _gcm_identity_is_complete(cls, gcm: dict[str, Any]) -> bool:
+        """Return True when a GCM block carries a re-registerable identity.
+
+        ``FcmRegister.reregister_keeping_identity()`` subscripts
+        ``credentials["gcm"]["android_id"]`` and ``["security_token"]`` *without*
+        guarding (and only falls back to a full register when the ``gcm`` key is
+        entirely absent). A partial block — e.g. an ``android_id`` with no
+        ``security_token`` — raises ``KeyError`` on every retry, and a block
+        whose values are present but not ``int()``-convertible raises
+        ``ValueError``/``TypeError`` instead (see ``_is_reregisterable_id``).
+        Only a block carrying both ``int()``-convertible values can be preserved
+        across an FCM-token invalidation; anything else must be dropped so the
+        next attempt performs a full fresh handshake instead of looping on the
+        same broken identity.
+        """
+        return cls._is_reregisterable_id(gcm.get("android_id")) and cls._is_reregisterable_id(
+            gcm.get("security_token")
+        )
+
+    async def _invalidate_fcm_tokens(self, entry_id: str) -> None:
+        """Clear renewable FCM tokens, preserving a *usable* GCM identity.
+
+        When the GCM block still carries a complete device identity
+        (android_id + security_token), only the renewable FCM parts are stripped
+        so the next attempt can take the fast ``reregister_keeping_identity()``
+        path. When the identity itself is incomplete/corrupt, the whole ``gcm``
+        block is dropped instead: keeping it would make
+        ``reregister_keeping_identity()`` raise ``KeyError`` forever (Codex
+        follow-up), so dropping it forces ``_register_for_fcm_entry`` onto the
+        full ``checkin_or_register()`` handshake.
         """
         creds = self.creds.get(entry_id)
         if creds and isinstance(creds, dict):
-            # Remove FCM-related parts, keep GCM device identity
+            # Renewable FCM parts always go.
             creds.pop("fcm", None)
             creds.pop("keys", None)
+
             gcm = creds.get("gcm")
-            if isinstance(gcm, dict):
+            if isinstance(gcm, dict) and self._gcm_identity_is_complete(gcm):
+                # Identity is usable: strip only the renewable GCM token parts
+                # and keep android_id/security_token for a fast re-register.
                 gcm.pop("token", None)
                 gcm.pop("app_id", None)
+                _LOGGER.info(
+                    "[entry=%s] Invalidated FCM tokens; "
+                    "android_id/security_token preserved for re-registration",
+                    entry_id,
+                )
+            else:
+                # Identity is missing/partial/corrupt: drop the whole block so
+                # the next attempt does a full registration rather than replaying
+                # the same KeyError-raising creds.
+                creds.pop("gcm", None)
+                _LOGGER.warning(
+                    "[entry=%s] Corrupt or incomplete GCM identity; dropped device "
+                    "identity to force a full FCM re-registration",
+                    entry_id,
+                )
 
             # Persist partial credentials so restarts also trigger re-register
             entry_cache = self._entry_caches.get(entry_id)
@@ -1607,12 +1685,6 @@ class FcmReceiverHA:
                     await entry_cache.set("fcm_credentials", creds)
                 except Exception:
                     pass
-
-            _LOGGER.info(
-                "[entry=%s] Invalidated FCM tokens; "
-                "android_id/security_token preserved for re-registration",
-                entry_id,
-            )
 
     @staticmethod
     def _raise_if_fatal_client_error(
@@ -1737,18 +1809,60 @@ class FcmReceiverHA:
             # retry budget (with _invalidate_fcm_tokens) runs.
             self._raise_if_fatal_http_error(entry_id, err)
             return False
-        except (TimeoutError, RuntimeError, Exception) as err:  # noqa: BLE001
-            # Transient errors (TimeoutError, RuntimeError from firebase_messaging)
-            # are logged at info level; other exceptions at error level.
-            if isinstance(err, (TimeoutError, RuntimeError)):
-                _LOGGER.info(
-                    "[entry=%s] FCM registration failed (transient): %s - will retry",
-                    entry_id,
-                    err,
-                )
-            else:
-                _LOGGER.error("[entry=%s] FCM registration error: %s", entry_id, err)
+        except Exception as err:  # noqa: BLE001
+            # AP6 (finding 3a): the previous combined
+            # ``(TimeoutError, RuntimeError, Exception)`` made the specific types
+            # redundant and treated every non-fatal error the same. Delegate the
+            # classification to a dedicated helper (extract-method keeps this
+            # function under PLR0911 and makes the rule unit-testable) and return
+            # a single non-fatal result. Fatal paths
+            # (FatalRegistrationError / ClientError / FcmRegisterHTTPError) are
+            # handled above and never reach here.
+            await self._classify_registration_exception(entry_id, err)
             return False
+
+    async def _classify_registration_exception(
+        self, entry_id: str, err: BaseException
+    ) -> None:
+        """Classify a non-fatal registration exception (AP6, finding 3a).
+
+        Splits the formerly conflated catch-all into three honest classes:
+
+        * ``TimeoutError`` / ``RuntimeError`` — genuinely transient (network
+          timeout, or firebase_messaging "...token missing..."); just retry.
+        * ``KeyError`` / ``ValueError`` / ``TypeError`` — structural credential
+          corruption (``reregister_keeping_identity()`` /
+          ``checkin_or_register()`` raise ``KeyError`` on corrupt
+          ``credentials["gcm"][...]`` and ``ValueError``/``TypeError`` on
+          malformed/JSON-broken creds; ``json.JSONDecodeError`` is a
+          ``ValueError``). NOT transient: retrying replays the same broken creds
+          forever with no visible fatal state. Escalate by invalidating the FCM
+          tokens, which preserves a *complete* GCM identity but drops a
+          partial/corrupt one, so the next attempt performs a fresh handshake
+          instead of looping. Conservative: only these well-defined types.
+        * anything else — unexpected; logged at error (not silently swallowed as
+          benign) but left non-fatal so a single surprise cannot crash the
+          supervisor.
+        """
+        if isinstance(err, (TimeoutError, RuntimeError)):
+            _LOGGER.info(
+                "[entry=%s] FCM registration failed (transient): %s - will retry",
+                entry_id,
+                err,
+            )
+        elif isinstance(err, (KeyError, ValueError, TypeError)):
+            _LOGGER.error(
+                "[entry=%s] FCM registration hit corrupt credentials (%s): %s "
+                "- invalidating FCM tokens to force re-registration",
+                entry_id,
+                type(err).__name__,
+                err,
+            )
+            await self._invalidate_fcm_tokens(entry_id)
+        else:
+            _LOGGER.error(
+                "[entry=%s] FCM registration unexpected error: %s", entry_id, err
+            )
 
     # Public entrypoint kept for back-compat (starts supervisors lazily if needed)
     async def _start_listening(self) -> None:
@@ -2598,8 +2712,10 @@ class FcmReceiverHA:
     async def async_reregister_fcm(self, entry_id: str) -> bool:
         """Public API: invalidate FCM tokens and re-register for a specific entry.
 
-        Preserves the GCM device identity (android_id/security_token) and
-        obtains fresh GCM + FCM tokens via ``reregister_keeping_identity()``.
+        Preserves a *complete* GCM device identity (android_id/security_token)
+        for a fast ``reregister_keeping_identity()``; a partial/corrupt identity
+        is dropped so the next attempt does a full ``checkin_or_register()``
+        handshake instead of looping on broken creds.
 
         Returns True if re-registration was initiated (supervisor restarted),
         False if the entry is not known to this receiver.

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -440,6 +440,17 @@ class FcmReceiverHA:
         condition is gone (e.g. user re-registers credentials and FCM starts
         successfully again).
 
+        A hard-reset teardown (``force=True``) additionally releases the
+        short-run cap latch (see below). It deliberately does NOT delete the
+        entry-scoped *fixable* reauth repairs: ``force=True`` is reached from
+        ``unregister_coordinator``, which fires on EVERY unload, including the
+        reload Home Assistant performs right after a successful reauth flow.
+        Deleting them here would dismiss a still-active prompt before the new
+        supervisor has proven recovery. Those repairs are retired by the
+        supervisor success path on reload and by
+        ``async_delete_entry_repair_issues`` on actual entry removal (Codex
+        PR #1104 follow-up).
+
         Defense 2 iter-8 (Codex second finding): a successful FCM
         re-registration is NOT a recovery proof for the short-run crash cap.
         While ``_short_run_cap_latched`` contains *entry_id* this method must
@@ -523,15 +534,74 @@ class FcmReceiverHA:
         if removed:
             self._fatal_error = next(iter(self._fatal_errors.values()), None)
 
-        if self._hass is not None:
+        self._delete_repair_issues_for_entry(entry_id)
+
+    def _delete_repair_issues_for_entry(self, entry_id: str) -> None:
+        """Retire the transient short-run-crash-loop repair for a cleared entry.
+
+        This is the DELETE half of the ``fcm_short_run_crash_loop_{entry_id}``
+        CREATE/DELETE pair with the fatal-error map: any path that clears the
+        in-memory latch must also delete the user-visible UI artefact, or the
+        Repairs panel keeps a stale non-fixable error after the underlying
+        condition is gone.
+
+        It deliberately does NOT touch the *fixable* reauth repairs
+        (``fcm_reauth_required_{entry_id}`` / legacy ``fcm_stuck_{entry_id}``).
+        Those outlive a reload on purpose and are retired only by the supervisor
+        success path (reload recovery) or
+        ``async_delete_entry_repair_issues`` (actual entry removal). See those
+        for the full lifecycle rationale (Codex PR #1104 follow-up).
+
+        The deletion is best-effort UI cleanup; failures are logged and
+        swallowed so a registry hiccup never blocks the in-memory state reset.
+        """
+        if self._hass is None:
+            return
+
+        try:
+            ir.async_delete_issue(
+                self._hass, DOMAIN, f"fcm_short_run_crash_loop_{entry_id}"
+            )
+        except Exception:  # noqa: BLE001 - best-effort UI cleanup
+            _LOGGER.debug(
+                "[entry=%s] Failed to delete short-run crash-loop repair issue",
+                entry_id,
+                exc_info=True,
+            )
+
+    @staticmethod
+    def async_delete_entry_repair_issues(hass: HomeAssistant, entry_id: str) -> None:
+        """Delete every entry-scoped FCM Repairs issue for a REMOVED config entry.
+
+        Call this ONLY from ``async_remove_entry`` (actual removal). On removal
+        no supervisor will run again, so the entry-scoped repairs must be retired
+        explicitly or they stay pinned in the Repairs panel for a config entry
+        that no longer exists. This covers the *fixable* reauth prompt
+        (``fcm_reauth_required_{entry_id}``), its legacy non-fixable predecessor
+        (``fcm_stuck_{entry_id}``) and the transient short-run crash-loop
+        diagnostic (``fcm_short_run_crash_loop_{entry_id}``).
+
+        A reload must NOT use this: there ``unregister_coordinator`` fires via
+        ``async_on_unload`` while the entry lives on, and the supervisor success
+        path clears the reauth repair once FCM re-registers. Deleting it on
+        reload would dismiss a still-active prompt before the new supervisor has
+        proven recovery (Codex PR #1104 follow-up).
+
+        All deletions are best-effort UI cleanup; failures are swallowed so a
+        registry hiccup never blocks entry removal.
+        """
+        for issue_id in (
+            f"fcm_short_run_crash_loop_{entry_id}",
+            f"fcm_reauth_required_{entry_id}",
+            f"fcm_stuck_{entry_id}",
+        ):
             try:
-                ir.async_delete_issue(
-                    self._hass, DOMAIN, f"fcm_short_run_crash_loop_{entry_id}"
-                )
+                ir.async_delete_issue(hass, DOMAIN, issue_id)
             except Exception:  # noqa: BLE001 - best-effort UI cleanup
                 _LOGGER.debug(
-                    "[entry=%s] Failed to delete short-run repair issue",
+                    "[entry=%s] Failed to delete repair issue %s on removal",
                     entry_id,
+                    issue_id,
                     exc_info=True,
                 )
 
@@ -955,6 +1025,44 @@ class FcmReceiverHA:
             self.creds[entry_id] = creds if isinstance(creds, dict) else None
             return pc
 
+    def _async_raise_reauth_issue(self, entry_id: str, *, reason: str) -> None:
+        """Surface a fixable repair that drives the user into the reauth flow.
+
+        All three terminal give-up points collapse into a single issue id
+        (``fcm_reauth_required_{entry_id}``) because the corrective action is
+        identical: re-authenticate / re-register. The fix flow in
+        ``repairs.py`` calls ``entry.async_start_reauth`` on confirmation.
+
+        The escalation thresholds are NOT re-invented here. They are the
+        existing retry caps consumed at the call sites:
+
+        * ``_MAX_FATAL_ENDPOINT_RETRIES`` (7) -- with the ``min(300, 30*n)``
+          backoff this is ~630 s of sustained 404 endpoint exhaustion before
+          give-up; a transient Google endpoint rotation clears well before it.
+        * ``_MAX_FATAL_AUTH_RETRIES`` (3) -- 401 token-renewal exhaustion.
+        * ``_BACKOFF_WARNING_THRESHOLD_S`` (64 s, ~6 failed registrations) --
+          the registration backoff warning point.
+
+        Because the repair hangs off those existing give-up/warning points, a
+        transient failure (count still below the cap) never raises it. The
+        recovery delete on a successful (re-)registration clears it again.
+
+        ``reason`` is a non-localised diagnostic hint forwarded via ``data``
+        so the fix flow / diagnostics can tell the three origins apart; the
+        fix flow itself only consumes ``entry_id``.
+        """
+        if not self._hass:
+            return
+        ir.async_create_issue(
+            self._hass,
+            DOMAIN,
+            f"fcm_reauth_required_{entry_id}",
+            is_fixable=True,
+            severity=ir.IssueSeverity.ERROR,
+            translation_key="fcm_reauth_required",
+            data={"entry_id": entry_id, "reason": reason},
+        )
+
     async def _start_supervisor_for_entry(  # noqa: PLR0915
         self, entry_id: str, cache: TokenCache | None
     ) -> None:
@@ -1043,6 +1151,13 @@ class FcmReceiverHA:
                                     entry_id,
                                     fatal_count,
                                 )
+                                # Auth retry budget exhausted
+                                # (``_MAX_FATAL_AUTH_RETRIES``): offer the
+                                # fixable reauth repair instead of giving up
+                                # silently.
+                                self._async_raise_reauth_issue(
+                                    entry_id, reason="auth_401"
+                                )
                                 break
 
                             await self._invalidate_fcm_tokens(entry_id)
@@ -1071,6 +1186,15 @@ class FcmReceiverHA:
                                     "giving up.",
                                     entry_id,
                                     fatal_count,
+                                )
+                                # Endpoint retry budget exhausted
+                                # (``_MAX_FATAL_ENDPOINT_RETRIES`` == 7 ⇒
+                                # ~630 s of sustained 404 with the
+                                # ``min(300, 30*n)`` backoff): surface the
+                                # fixable reauth repair. This give-up was
+                                # previously a silent break with no issue.
+                                self._async_raise_reauth_issue(
+                                    entry_id, reason="endpoint_404"
                                 )
                                 break
 
@@ -1103,15 +1227,14 @@ class FcmReceiverHA:
                                 entry_id,
                                 delay,
                             )
-                            if self._hass:
-                                ir.async_create_issue(
-                                    self._hass,
-                                    DOMAIN,
-                                    f"fcm_stuck_{entry_id}",
-                                    is_fixable=False,
-                                    severity=ir.IssueSeverity.WARNING,
-                                    translation_key="fcm_connection_stuck",
-                                )
+                            # Registration backoff warning point
+                            # (``_BACKOFF_WARNING_THRESHOLD_S``): escalate to
+                            # the same fixable reauth repair as the 404/401
+                            # give-up paths (was a non-fixable ``fcm_stuck``
+                            # warning offering no action path).
+                            self._async_raise_reauth_issue(
+                                entry_id, reason="registration_backoff"
+                            )
                         else:
                             _LOGGER.info(
                                 "[entry=%s] Re-trying FCM registration in %.1fs",
@@ -1127,6 +1250,15 @@ class FcmReceiverHA:
 
                     # Telemetry (aggregate counters)
                     if self._hass:
+                        # A successful (re-)registration resolves the fixable
+                        # reauth repair. Also delete the legacy non-fixable
+                        # ``fcm_stuck`` issue so it does not linger after an
+                        # upgrade from the previous key.
+                        ir.async_delete_issue(
+                            self._hass,
+                            DOMAIN,
+                            f"fcm_reauth_required_{entry_id}",
+                        )
                         ir.async_delete_issue(
                             self._hass, DOMAIN, f"fcm_stuck_{entry_id}"
                         )
@@ -1767,9 +1899,15 @@ class FcmReceiverHA:
             else:
                 self._entry_caches.pop(entry_id, None)
                 self._purge_entry_tokens(entry_id)
-                # Hard-reset on unregister: the entry is going away, so the
-                # short-run cap latch must be released together with the
-                # fatal-error map and the Repairs issue (force=True).
+                # Hard-reset on unregister: this fires via ``async_on_unload``
+                # on EVERY unload (reload AND removal), so it only resets the
+                # in-memory state -- the short-run cap latch, the fatal-error
+                # map and the transient short-run crash-loop Repairs issue
+                # (force=True). It must NOT delete the fixable reauth repairs:
+                # on a reauth-success reload the new supervisor still has to
+                # prove recovery first. Those are retired by the supervisor
+                # success path (reload) or ``async_delete_entry_repair_issues``
+                # (actual removal). See ``_clear_fatal_error_for_entry``.
                 self._clear_fatal_error_for_entry(
                     entry_id, reason="Entry unregistered", force=True
                 )

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -160,6 +160,84 @@ else:
 
 _LOGGER = logging.getLogger(__name__)
 
+
+# Iter-12 (Codex follow-up): the short-run crash cap needs to know
+# whether the FCM client ever reached ``FcmPushClientRunState.STARTED``
+# during a run, even when the entire CREATED -> STARTED -> CRASH
+# lifecycle happens between two monitor polls (``FCM_MONITOR_INTERVAL_S``
+# >= 0.5s). Sampling alone is too coarse for the very poison-message
+# loop the cap is meant to stop. A subclass with a ``__setattr__`` hook
+# latches ``_has_been_started`` the moment the vendored library assigns
+# ``run_state = STARTED`` -- independent of any polling cadence and
+# without modifying the vendored library itself. See
+# CA-DEFENSE-OBSERVABILITY-001.
+if HAVE_FCM_PUSH_CLIENT and FcmPushClientRunState is not None:
+    # Snapshot of the original class for runtime identity comparison.
+    # Tests substitute the module-level ``FcmPushClient`` symbol via
+    # monkeypatch (the documented seam) to inject test doubles; the
+    # factory below honours that substitution by class identity, not by
+    # subclass relation. See CA-SUBCLASS-IDENTITY-001.
+    _OriginalFcmPushClient: type[Any] | None = FcmPushClient
+
+    class _ObservableFcmPushClient(FcmPushClient[Any]):
+        """FcmPushClient subclass with a run_state observer latch.
+
+        See CA-DEFENSE-OBSERVABILITY-001.
+        """
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            # Seed the latch before super().__init__ so any attribute
+            # assignment performed by the parent's constructor still
+            # routes through our ``__setattr__`` without raising.
+            object.__setattr__(self, "_has_been_started", False)
+            super().__init__(*args, **kwargs)
+
+        def __setattr__(self, name: str, value: Any) -> None:
+            super().__setattr__(name, value)
+            if (
+                name == "run_state"
+                and FcmPushClientRunState is not None
+                and value == FcmPushClientRunState.STARTED
+            ):
+                # ``object.__setattr__`` to avoid recursion through this hook.
+                object.__setattr__(self, "_has_been_started", True)
+
+    _ObservableFcmPushClientCls: type[Any] | None = _ObservableFcmPushClient
+else:  # pragma: no cover - exercised only when the vendored library is absent
+    _OriginalFcmPushClient = None
+    _ObservableFcmPushClientCls = None
+
+
+def _FcmPushClientFactory(*args: Any, **kwargs: Any) -> FcmPushClient[Any]:
+    """Construct an FCM client at call time, honouring test substitutions.
+
+    Production: prefers the ``_ObservableFcmPushClient`` subclass so the
+    short-run crash cap can observe ``run_state -> STARTED`` transitions
+    that happen between monitor polls (CA-DEFENSE-OBSERVABILITY-001).
+
+    Tests: when the module-level ``FcmPushClient`` symbol has been
+    monkeypatched away from the original class (the documented test
+    seam), the factory instantiates the patched class DIRECTLY rather
+    than the production subclass. This preserves ``isinstance`` identity
+    for test doubles (CA-SUBCLASS-IDENTITY-001) instead of returning a
+    subclass that diverges from the patched symbol.
+    """
+
+    current = globals().get("FcmPushClient")
+    if (
+        _ObservableFcmPushClientCls is not None
+        and _OriginalFcmPushClient is not None
+        and current is _OriginalFcmPushClient
+    ):
+        return cast(
+            "FcmPushClient[Any]",
+            _ObservableFcmPushClientCls(*args, **kwargs),
+        )
+    if current is None:  # pragma: no cover - vendored library missing
+        raise RuntimeError("FcmPushClient is not available")
+    return cast("FcmPushClient[Any]", current(*args, **kwargs))
+
+
 type JSONDict = dict[str, Any]
 type MutableJSONMapping = MutableMapping[str, Any]
 
@@ -167,8 +245,31 @@ _MAX_SUPERVISOR_BACKOFF_S = 120.0    # cap retry delay at 2 minutes (was 4096s)
 _BACKOFF_WARNING_THRESHOLD_S = 64.0  # warn after ~6 failed attempts
 _MAX_FATAL_AUTH_RETRIES = 3       # 401: max retries (60s, 120s, then give up)
 _MAX_FATAL_ENDPOINT_RETRIES = 7   # 404: max retries (30s-300s, Google rotates endpoints)
+# Defense 2: supervisor-level crash cap as a bulkhead around the inner-loop
+# poison-message filter (``fcmpushclient._listen`` Defense 1+3). When the FCM
+# client connects but loses the run-loop within ``_SHORT_RUN_THRESHOLD_S``
+# repeatedly, a persistent poison condition is suspected and the supervisor
+# stops looping to prevent unbounded retry pressure on Google + log spam.
+_MAX_CONSECUTIVE_SHORT_RUNS = 10
+_SHORT_RUN_THRESHOLD_S = 30.0  # strictly < 30s between pc.start() and STOPPED = short run
 _HTTP_UNAUTHORIZED = 401
 _HTTP_NOT_FOUND = 404
+
+# Defense 2 iter-14 (Codex follow-up): the supervisor-level crash cap writes
+# its terminal state into ``_fatal_errors[entry_id]`` so the binary_sensor
+# diagnostic attribute and the "is FCM ready" check in
+# ``coordinator/polling.py`` see the listener as unavailable. However, the
+# coordinator's re-auth escalation in ``coordinator/polling.py`` also consumes
+# that map and, after _FCM_ERROR_RETRY_THRESHOLD consecutive update cycles,
+# raises ``ConfigEntryAuthFailed`` for ANY non-auth fatal it does not
+# explicitly classify. The crash-loop fatal is NOT an auth problem
+# (the user must reload / regenerate credentials per the repair issue, not
+# re-authenticate). To prevent users from being pushed into Home Assistant's
+# re-auth flow for what is really a poison-message defense, the cap-fire
+# branch tags its message with this prefix and the polling-side consumer
+# excludes it from the re-auth escalation. This module is the SSOT for the
+# prefix; the polling-side consumer imports it from here.
+CRASH_LOOP_FATAL_PREFIX = "FCM short-run crash loop:"
 
 
 async def _call_in_executor[**P, T](
@@ -292,10 +393,120 @@ class FcmReceiverHA:
         # Per-entry nudge events: allows coordinator to wake up a sleeping supervisor
         self._retry_nudge_evts: dict[str, asyncio.Event] = {}
 
+        # Defense 2 iter-8: persistent short-run cap latch.
+        #
+        # When the cap fires the entry is in a *poison-message crash loop*
+        # that only a real healthy supervisor run (>= _SHORT_RUN_THRESHOLD_S)
+        # can prove gone. A successful FCM re-registration alone is NOT a
+        # proof: registration only contacts the GCM endpoint, it does not
+        # show that the subsequent listener stays up long enough to drain
+        # the poisoned notification.
+        #
+        # The latch is therefore set together with the user-visible repair
+        # issue at cap-fire time and is the *only* thing that gates whether
+        # ``_clear_fatal_error_for_entry`` (which gets called from every
+        # registration-success path) is allowed to drop the fatal-error map
+        # entry and the Repairs UI artefact. Without this latch, any reload
+        # or credential update would clear the cap-related fatal state, the
+        # supervisor would start a fresh 10-run burst, and the user would
+        # see no visible fatal state in between (Codex defense-2 iter-8
+        # second finding).
+        self._short_run_cap_latched: set[str] = set()
+        # Defense 2 iter-16 (Codex follow-up): persistent snapshot of the
+        # cap-fire message per entry. Populated when the cap fires and used
+        # by ``_clear_fatal_error_for_entry`` to restore the cap fatal after
+        # a non-cap fatal (e.g. a terminal 401/404 from a subsequent
+        # re-registration) was cleared. Cleared in the same two places that
+        # release the latch: the healthy-run cleanup branch and any
+        # ``force=True`` teardown. This keeps the per-entry fatal visible to
+        # the coordinator and the diagnostic binary sensor for the entire
+        # latch lifetime, even across non-cap fatal overwrites.
+        self._short_run_cap_messages: dict[str, str] = {}
+
     def _clear_fatal_error_for_entry(
-        self, entry_id: str, *, reason: str | None = None
+        self,
+        entry_id: str,
+        *,
+        reason: str | None = None,
+        force: bool = False,
     ) -> None:
-        """Clear any latched fatal registration error for a config entry."""
+        """Clear any latched fatal registration error for a config entry.
+
+        Also removes the Defense 2 short-run-crash-loop repair issue from the
+        Home Assistant Issue Registry. The fatal-error map and the Issue
+        Registry entry are a CREATE/DELETE pair: any recovery path that clears
+        the in-memory latch must also delete the user-visible UI artefact, or
+        the Repairs panel keeps a stale non-fixable error after the underlying
+        condition is gone (e.g. user re-registers credentials and FCM starts
+        successfully again).
+
+        Defense 2 iter-8 (Codex second finding): a successful FCM
+        re-registration is NOT a recovery proof for the short-run crash cap.
+        While ``_short_run_cap_latched`` contains *entry_id* this method must
+        protect the cap state (latched fatal message + Repairs UI artefact)
+        from being silently cleared, so users keep seeing the fatal state
+        until a real healthy supervisor run (>= _SHORT_RUN_THRESHOLD_S) drops
+        the latch from the monitor loop. Hard-reset callers (entry unregister,
+        test cleanup, integration teardown) must opt in with ``force=True``.
+
+        Defense 2 iter-10 (Codex follow-up): the latch guard is intentionally
+        narrow. It is a no-op ONLY when the currently stored fatal IS the
+        cap-related message (``FCM short-run crash loop: ...``). Non-cap fatal
+        errors (e.g. a terminal 401/404 from a subsequent re-registration that
+        overwrote ``_fatal_errors[entry_id]``) must clear normally so a
+        credentials recovery is not blocked by an unrelated latch. The cap
+        latch, any cap-related fatal it still protects, and the Repairs UI
+        artefact remain in place in that case; only the unrelated fatal is
+        dropped.
+        """
+
+        if not force and entry_id in self._short_run_cap_latched:
+            current_fatal = self._fatal_errors.get(entry_id)
+            # No fatal stored, or the stored fatal IS the cap message:
+            # preserve everything (latch, message, Repairs UI artefact).
+            if current_fatal is None or current_fatal.startswith(
+                CRASH_LOOP_FATAL_PREFIX
+            ):
+                _LOGGER.debug(
+                    "[entry=%s] Skipping fatal-error clear; short-run cap latch "
+                    "active (reason=%s). Latch will be released by a healthy "
+                    "supervisor run.",
+                    entry_id,
+                    reason or "unspecified",
+                )
+                return
+
+            # Non-cap fatal stored while the cap latch is active. Clear the
+            # unrelated fatal but KEEP the cap latch and Repairs UI artefact
+            # intact, so the user-visible cap warning is not silently
+            # invalidated by an unrelated recovery path.
+            #
+            # Defense 2 iter-16 (Codex follow-up): the per-entry cap-fire
+            # message snapshot (``_short_run_cap_messages``) must be
+            # re-written into ``_fatal_errors`` so the coordinator and the
+            # diagnostic binary sensor continue to see the cap-fatal state
+            # during the recovery/retry window. Otherwise the latch would
+            # silently invalidate the per-entry fatal even though the
+            # in-memory latch and the Repairs UI artefact remain set.
+            _LOGGER.debug(
+                "[entry=%s] Cap latch active; clearing non-cap fatal "
+                "(reason=%s) while preserving cap latch and repair issue",
+                entry_id,
+                reason or "unspecified",
+            )
+            self._fatal_errors.pop(entry_id, None)
+            cap_message = self._short_run_cap_messages.get(entry_id)
+            if cap_message is not None:
+                self._fatal_errors[entry_id] = cap_message
+            self._fatal_error = next(iter(self._fatal_errors.values()), None)
+            return
+
+        if force:
+            self._short_run_cap_latched.discard(entry_id)
+            # Iter-16: drop the cap-fire snapshot in lockstep with the latch
+            # so a forced teardown also retires the message that the
+            # pass-through branch would otherwise restore.
+            self._short_run_cap_messages.pop(entry_id, None)
 
         removed = False
         if entry_id in self._fatal_errors:
@@ -311,6 +522,18 @@ class FcmReceiverHA:
 
         if removed:
             self._fatal_error = next(iter(self._fatal_errors.values()), None)
+
+        if self._hass is not None:
+            try:
+                ir.async_delete_issue(
+                    self._hass, DOMAIN, f"fcm_short_run_crash_loop_{entry_id}"
+                )
+            except Exception:  # noqa: BLE001 - best-effort UI cleanup
+                _LOGGER.debug(
+                    "[entry=%s] Failed to delete short-run repair issue",
+                    entry_id,
+                    exc_info=True,
+                )
 
     @staticmethod
     def _ensure_cache_entry_id(cache: Any, entry_id: str) -> None:
@@ -709,7 +932,7 @@ class FcmReceiverHA:
                     "CredentialsUpdatedCallable[MutableJSONMapping]",
                     _on_creds_updated_entry,
                 )
-                pc = FcmPushClient(
+                pc = _FcmPushClientFactory(
                     lambda payload,
                     persistent_id,
                     context,
@@ -756,6 +979,12 @@ class FcmReceiverHA:
                     return False
 
             backoff = 1.0
+            # Defense 2: per-supervisor closure state for the short-run
+            # crash cap. Kept closure-local (not on ``self``) so a
+            # re-registration that cancels this supervisor and spawns a
+            # new one cannot inherit a stale counter (CA-Audit B1).
+            short_run_counter: int = 0
+            entry_start: float = 0.0
             try:
                 while not stop_evt.is_set():
                     pc = await self._ensure_client_for_entry(entry_id, cache)
@@ -919,6 +1148,22 @@ class FcmReceiverHA:
                             "[entry=%s] FCM client failed to start: %s", entry_id, err
                         )
 
+                    # Defense 2 snapshot: timestamp the entry into the
+                    # monitor loop.
+                    #
+                    # Iter-11 (Codex follow-up): per-run latch tracking
+                    # whether the client ever reached a connected/listening
+                    # state. The cap is meant to detect a poison-message
+                    # crash loop (client connects, decodes, dies, repeat),
+                    # NOT ordinary connectivity outages where ``_listen()``
+                    # exhausts its 5 connection retries (~15-20s) without
+                    # ever reaching ``STARTED``. Without this gate, a normal
+                    # MCS-unreachable / Google outage would cap the
+                    # supervisor after 10 brief connection-failure runs and
+                    # permanently disable FCM push until reload.
+                    entry_start = time.monotonic()
+                    became_started = False
+
                     while not stop_evt.is_set():
                         await asyncio.sleep(max(FCM_MONITOR_INTERVAL_S, 0.5))
                         state = getattr(pc, "run_state", None)
@@ -928,6 +1173,27 @@ class FcmReceiverHA:
                             entry_id, pc, monotonic_now
                         )
                         stale_after = max(self._activity_stale_after_s, 0.0)
+                        # Iter-11: track ``became_started`` symmetrically to
+                        # the health probe (same fallback for libraries that
+                        # do not expose a ``run_state`` enum).
+                        if FcmPushClientRunState is None:
+                            if do_listen:
+                                became_started = True
+                        elif state == FcmPushClientRunState.STARTED:
+                            became_started = True
+                        # Iter-12 (Codex follow-up): sampling-gap defense.
+                        # When the full lifecycle ``CREATED -> STARTED ->
+                        # CRASH`` happens between two monitor polls (>=0.5s),
+                        # this loop reads STOPPED/!do_listen and ``became_started``
+                        # would remain false. The vendored client's
+                        # ``__setattr__`` hook latches ``_has_been_started``
+                        # the moment the library assigns ``run_state =
+                        # STARTED``, independent of polling cadence; mirror
+                        # that observation here so the cap branch correctly
+                        # classifies micro-window poison-message crashes.
+                        became_started = became_started or bool(
+                            getattr(pc, "_has_been_started", False)
+                        )
                         healthy = (
                             (
                                 FcmPushClientRunState is None
@@ -978,6 +1244,176 @@ class FcmReceiverHA:
                                 monotonic_now - last_activity,
                             )
                             break
+
+                    # Defense 2: short-run crash cap. Counts consecutive
+                    # monitor exits with ``run_duration <
+                    # _SHORT_RUN_THRESHOLD_S`` THAT ALSO reached
+                    # ``STARTED`` at least once during the run. After
+                    # ``_MAX_CONSECUTIVE_SHORT_RUNS`` such runs, surface a
+                    # non-fixable repair issue and stop the loop. The
+                    # comparison is strictly ``<`` (a 30.0s run counts as
+                    # healthy and resets the counter).
+                    #
+                    # Iter-11 (Codex follow-up): the ``became_started`` gate
+                    # ensures the cap is specific to the poison-message
+                    # scenario (client connects, decodes, dies, repeat) and
+                    # excludes pre-start connection/login failures. A burst
+                    # of MCS-unreachable failures (5 retries x ~3-4s each)
+                    # would otherwise be counted as short-run crashes and
+                    # permanently disable FCM push after one ordinary
+                    # network outage. Pre-start failures leave the counter
+                    # AND the latch UNTOUCHED so that (a) a poison-message
+                    # cascade interleaved with outages still accumulates
+                    # correctly, and (b) a long pre-start hang does not
+                    # falsely clear a real cap latch (no healthy proof).
+                    run_duration = time.monotonic() - entry_start
+                    credential_error = getattr(pc, "credential_error", None)
+                    if credential_error is not None:
+                        # Finding 1 (Codex): the listener surfaced corrupt FCM
+                        # key material via ``credential_error``. Restarting
+                        # against the same credentials would loop until the
+                        # short-run crash cap fires; instead invalidate the key
+                        # material so the next registration regenerates it
+                        # (android_id/security_token preserved) and do NOT
+                        # charge this run to the crash cap -- corrective action
+                        # is being taken, this is not a poison-message loop.
+                        _LOGGER.error(
+                            "[entry=%s] FCM credential material corrupt (%s); "
+                            "invalidating FCM tokens to force re-registration",
+                            entry_id,
+                            credential_error,
+                        )
+                        await self._invalidate_fcm_tokens(entry_id)
+                        short_run_counter = 0
+                    elif not became_started:
+                        # Pre-start failure (no connected/listening state
+                        # observed during this run). Do NOT touch the
+                        # short-run counter or the cap latch.
+                        pass
+                    elif run_duration < _SHORT_RUN_THRESHOLD_S:
+                        short_run_counter += 1
+                        # Test hook: expose the closure counter to stubs
+                        # without leaking it onto ``self``.
+                        observe = getattr(pc, "_observe_counter", None)
+                        if callable(observe):
+                            try:
+                                observe(short_run_counter)
+                            except Exception:  # noqa: BLE001
+                                pass
+                        if short_run_counter >= _MAX_CONSECUTIVE_SHORT_RUNS:
+                            message = (
+                                f"{CRASH_LOOP_FATAL_PREFIX} "
+                                f"{_MAX_CONSECUTIVE_SHORT_RUNS} consecutive "
+                                f"runs ended within "
+                                f"{_SHORT_RUN_THRESHOLD_S:.0f}s "
+                                f"(persistent poison message suspected)"
+                            )
+                            _LOGGER.error("[entry=%s] %s", entry_id, message)
+                            self._fatal_errors[entry_id] = message
+                            # Defense 2 iter-8: latch the cap state. While
+                            # this latch is set, ``_clear_fatal_error_for_entry``
+                            # is a no-op (registration / credential-update paths
+                            # cannot clear the fatal map or the Repairs issue
+                            # before a real healthy supervisor run proves the
+                            # poison message is gone).
+                            self._short_run_cap_latched.add(entry_id)
+                            # Iter-16 (Codex follow-up): snapshot the
+                            # cap-fire message so the pass-through clear
+                            # branch in ``_clear_fatal_error_for_entry`` can
+                            # restore it after a non-cap fatal overwrote
+                            # ``_fatal_errors[entry_id]``. Released in the
+                            # same two places that release the latch.
+                            self._short_run_cap_messages[entry_id] = message
+                            if self._hass:
+                                ir.async_create_issue(
+                                    self._hass,
+                                    DOMAIN,
+                                    f"fcm_short_run_crash_loop_{entry_id}",
+                                    is_fixable=False,
+                                    severity=ir.IssueSeverity.ERROR,
+                                    translation_key="fcm_short_run_crash_loop",
+                                )
+                            # Cleanup the client before breaking out so
+                            # the loop exit doesn't leave a half-stopped pc.
+                            try:
+                                await pc.stop()
+                            except Exception:  # noqa: BLE001
+                                pass
+                            finally:
+                                async with self._lock:
+                                    self.pcs.pop(entry_id, None)
+                                self._update_entry_health(entry_id, False)
+                            # Defense 2 iter-9 (Codex follow-up): the cap is
+                            # a TERMINAL state for this supervisor. ``break``
+                            # alone only exits the inner monitor loop and
+                            # falls through to the per-iteration restart
+                            # block (``if not stop_evt.is_set(): ...
+                            # _nudge_sleep(delay)``), which would spawn a
+                            # fresh FCM client and continue the retry
+                            # pressure / log spam the cap is meant to stop.
+                            # Set the stop event so the outer ``while not
+                            # stop_evt.is_set()`` exits, and pop the entry
+                            # from ``_stop_evts`` so a legitimate
+                            # re-registration / reload (which constructs a
+                            # fresh event via ``setdefault``) is not
+                            # short-circuited by the now-consumed event.
+                            stop_evt.set()
+                            self._stop_evts.pop(entry_id, None)
+                            break
+                    else:
+                        short_run_counter = 0  # healthy run resets the counter
+                        observe = getattr(pc, "_observe_counter", None)
+                        if callable(observe):
+                            try:
+                                observe(short_run_counter)
+                            except Exception:  # noqa: BLE001
+                                pass
+                        # Mirror the counter reset in the Issue Registry: if
+                        # the cap had previously fired on a prior supervisor
+                        # incarnation, a healthy run is the user-visible
+                        # signal that the condition is gone.
+                        #
+                        # Defense 2 iter-8: a healthy run is the ONLY proof
+                        # the system has that the poison-message condition is
+                        # gone, so this is also the only callsite that may
+                        # drop the cap latch. After dropping the latch, the
+                        # cap-related ``_fatal_errors`` entry is removed and
+                        # the aggregate ``_fatal_error`` re-derived (so the
+                        # System Health surface stops showing the stale
+                        # message). The Repairs delete below stays inside
+                        # ``self._hass is not None`` and intentionally also
+                        # runs when no latch was set (cheap idempotent UI
+                        # cleanup).
+                        cap_was_latched = entry_id in self._short_run_cap_latched
+                        if cap_was_latched:
+                            self._short_run_cap_latched.discard(entry_id)
+                            # Iter-16: a healthy run is also the moment to
+                            # retire the cap-fire snapshot so the
+                            # pass-through clear branch cannot re-introduce
+                            # it after the latch is gone.
+                            self._short_run_cap_messages.pop(entry_id, None)
+                            cap_message = self._fatal_errors.get(entry_id)
+                            if cap_message and cap_message.startswith(
+                                CRASH_LOOP_FATAL_PREFIX
+                            ):
+                                self._fatal_errors.pop(entry_id, None)
+                                self._fatal_error = next(
+                                    iter(self._fatal_errors.values()), None
+                                )
+                                _LOGGER.info(
+                                    "[entry=%s] FCM short-run cap latch released "
+                                    "by healthy supervisor run",
+                                    entry_id,
+                                )
+                        if self._hass is not None:
+                            try:
+                                ir.async_delete_issue(
+                                    self._hass,
+                                    DOMAIN,
+                                    f"fcm_short_run_crash_loop_{entry_id}",
+                                )
+                            except Exception:  # noqa: BLE001
+                                pass
 
                     # Cleanup before restart
                     try:
@@ -1331,7 +1767,12 @@ class FcmReceiverHA:
             else:
                 self._entry_caches.pop(entry_id, None)
                 self._purge_entry_tokens(entry_id)
-                self._clear_fatal_error_for_entry(entry_id, reason="Entry unregistered")
+                # Hard-reset on unregister: the entry is going away, so the
+                # short-run cap latch must be released together with the
+                # fatal-error map and the Repairs issue (force=True).
+                self._clear_fatal_error_for_entry(
+                    entry_id, reason="Entry unregistered", force=True
+                )
 
     # -------------------- Incoming notifications --------------------
 

--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
@@ -596,8 +596,15 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
             self._app_data_by_key(msg, "encryption"), "salt"
         )
         subtype = self._app_data_by_key(msg, "subtype")
-        if TYPE_CHECKING:
-            assert self.credentials
+        # Guard before dereferencing: ``credentials`` is ``MutableJSONMapping |
+        # None`` and a missing/empty value must short-circuit *before* the
+        # ``["gcm"]["app_id"]`` lookups below, mirroring the defensive check in
+        # ``_decrypt_raw_data`` (see the ``isinstance(self.credentials, dict)``
+        # guard). Previously this guard sat *after* the dereference and was thus
+        # unreachable dead code for the ``None``/``{}`` states it was meant to
+        # protect against.
+        if not self.credentials:
+            return
         if subtype != self.credentials["gcm"]["app_id"]:
             self._log_warn_with_limit(
                 "Subtype %s in data message does not match"
@@ -605,8 +612,6 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
                 subtype,
                 self.credentials["gcm"]["app_id"],
             )
-        if not self.credentials:
-            return
 
         decrypted = self._decrypt_raw_data(
             self.credentials, crypto_key, salt, msg.raw_data

--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
@@ -29,6 +29,7 @@
 from __future__ import annotations
 
 import asyncio
+import binascii
 import json
 import logging
 import random
@@ -84,6 +85,61 @@ http_decrypt: Callable[..., bytes] = http_ece.decrypt
 _logger = logging.getLogger(__name__)
 
 _LEGACY_MCS_PROTOCOL_VERSION = 38
+
+
+class CredentialDecryptionError(ValueError):
+    """Raised when stored FCM credential material cannot be decoded or parsed.
+
+    Subclass of ``ValueError`` for backward-compatibility with external
+    callers that catch broad ``ValueError``. Internal code (notably the
+    listener loop's poison-message defense) discriminates this type via
+    ``isinstance`` to distinguish per-message decode failures (which are
+    safely ACKed and skipped) from credential-corruption failures (which
+    must surface to the supervisor for re-registration).
+
+    Why a typed exception instead of a string-prefix marker: external
+    libraries such as ``cryptography`` and ``http_ece`` raise plain
+    ``ValueError`` without our markers; a ``str.startswith`` catch loses
+    them and silently treats credential corruption as per-message poison.
+    See CA-CRED-VS-MSG-DECRYPT-001 iter-3 lesson.
+    """
+
+
+def _safe_urlsafe_b64decode(value: str | bytes) -> bytes:
+    """Decode URL-safe base64 leniently (Python 3.14 compatibility shim).
+
+    Strips ASCII whitespace and re-appends ``=`` padding before delegating
+    to :func:`base64.urlsafe_b64decode`. Python 3.14 switched
+    ``binascii.a2b_base64`` to ``strict_mode=True`` by default, which
+    rejects payloads containing newlines, stray whitespace, or missing
+    padding -- exactly the conditions the wild FCM stream produces. This
+    helper restores the pre-3.14 lenient behaviour locally without altering
+    the global decoder state.
+
+    Defense layer 3 of the three-defense hotfix for the
+    ``fcmpushclient`` poison-message cascade (CA-CASCADING-FAILURE-001).
+    Defense 1 wraps credential-decode errors as
+    :class:`CredentialDecryptionError`; defense 2 caps the supervisor
+    restart loop. This helper closes the root cause: dirty base64 input
+    that the Python 3.14 strict decoder rejects unconditionally.
+
+    Raises ``binascii.Error`` only when the payload remains undecodable
+    after whitespace removal and padding normalisation. Raises
+    ``UnicodeError`` when ``str`` input contains non-ASCII characters
+    (``str.encode("ascii")`` fails before normalisation runs); callers in
+    a credential-decode path must catch both.
+    """
+    if isinstance(value, str):
+        raw = value.encode("ascii")
+    else:
+        raw = bytes(value)
+    # str.split() / bytes.split() with no args collapses every flavour of
+    # ASCII whitespace (space, tab, newline, CR, vtab, formfeed) -- this
+    # is exactly the set Python 3.14 strict mode now rejects.
+    stripped = b"".join(raw.split())
+    padded = stripped + b"=" * (-len(stripped) % 4)
+    return urlsafe_b64decode(padded)
+
 
 # MCS Message Types and Tags
 MCS_MESSAGE_TAG = {
@@ -215,6 +271,12 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
 
         self.run_state: FcmPushClientRunState = FcmPushClientRunState.CREATED
         self.tasks: list[asyncio.Task[None]] = []
+        # Set by ``_listen`` when stored FCM key material is found to be
+        # corrupt/undecodable. The supervisor reads this after the listener
+        # stops to invalidate the bad credentials and force re-registration,
+        # instead of restarting against the same poison key material until the
+        # short-run crash cap fires.
+        self.credential_error: CredentialDecryptionError | None = None
 
         # Locks
         self.stopping_lock: asyncio.Lock = asyncio.Lock()
@@ -434,21 +496,47 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
         salt_str: str,
         raw_data: bytes,
     ) -> bytes:
-        crypto_key = urlsafe_b64decode(crypto_key_str.encode("ascii") + b"=" * (-len(crypto_key_str) % 4))
-        salt = urlsafe_b64decode(salt_str.encode("ascii") + b"=" * (-len(salt_str) % 4))
+        # Header decode (crypto-key / salt) -- per-message surface.
+        # Failures here are per-message poison, not credential corruption:
+        # they fall through to the listener's poison-message defense
+        # (selective-ACK + skip) without going through the credential
+        # try-block below.
+        crypto_key = _safe_urlsafe_b64decode(crypto_key_str)
+        salt = _safe_urlsafe_b64decode(salt_str)
 
         keys_section = credentials.get("keys")
         if not isinstance(keys_section, Mapping):
-            raise ValueError("Credentials missing FCM key material")
+            raise CredentialDecryptionError("Credentials missing FCM key material")
 
         private_value = keys_section.get("private")
         secret_value = keys_section.get("secret")
         if not (isinstance(private_value, str) and isinstance(secret_value, str)):
-            raise ValueError("Invalid key values in credential payload")
+            raise CredentialDecryptionError(
+                "Credentials contain invalid key values"
+            )
 
-        der_data = urlsafe_b64decode(private_value.encode("ascii") + b"=" * (-len(private_value) % 4))
-        secret = urlsafe_b64decode(secret_value.encode("ascii") + b"=" * (-len(secret_value) % 4))
-        privkey = load_der_private_key(der_data, password=None)
+        try:
+            der_data = _safe_urlsafe_b64decode(private_value)
+            secret = _safe_urlsafe_b64decode(secret_value)
+        except (binascii.Error, UnicodeError) as cred_decode_err:
+            # binascii.Error: corrupt base64 payload.
+            # UnicodeError (covers UnicodeEncodeError/UnicodeDecodeError):
+            # non-ASCII bytes in cached keys.private/keys.secret; .encode("ascii")
+            # raises before urlsafe_b64decode is reached. Both are permanent
+            # credential-corruption faults, not per-message poison.
+            raise CredentialDecryptionError(
+                "Credentials key material failed base64 decode; re-registration required"
+            ) from cred_decode_err
+        try:
+            privkey = load_der_private_key(der_data, password=None)
+        except Exception as der_err:
+            # cryptography raises plain ValueError (corrupt DER), TypeError
+            # (wrong type), or UnsupportedAlgorithm — all permanent and all
+            # requiring re-registration. Broad catch is intentional: the
+            # only successful path is a valid DER private key.
+            raise CredentialDecryptionError(
+                "Credentials key material failed DER private-key parse; re-registration required"
+            ) from der_err
         decrypted = http_decrypt(
             raw_data,
             salt=salt,
@@ -742,6 +830,72 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
             )
         return connected
 
+    async def _ack_or_disconnect(self, persistent_id: str | None) -> bool:
+        """Best-effort selective-ACK for a poison message.
+
+        Returns ``True`` to continue the worker loop; ``False`` if the writer
+        half is dead and the supervisor should reconnect (caller breaks).
+        """
+        if not persistent_id:
+            return True
+        try:
+            await self._send_selective_ack(persistent_id)
+            return True
+        except (OSError, ssl.SSLError, ConnectionError):
+            return False
+
+    async def _process_one_inbound_message(self, msg: MessageProto) -> bool:
+        """Run ``_handle_message`` with poison-message defense.
+
+        Defense 1 (CA-CASCADING-FAILURE-001): per-message decode failures
+        (``binascii.Error`` padding faults under Python 3.14 strict mode,
+        ``RuntimeError`` from ``_app_data_by_key`` key lookups, generic
+        ``ValueError`` from header parsing, and ``http_ece.ECEException``
+        from a corrupt encrypted body / failed auth tag) are acknowledged
+        and skipped instead of crashing the worker loop. Credential-material
+        errors (``CredentialDecryptionError``) propagate so ``_listen``
+        records them and the supervisor invalidates the bad key material and
+        prompts re-registration.
+
+        Returns ``True`` to continue the loop, ``False`` to break (writer
+        half-dead during ack).
+        """
+        try:
+            await self._handle_message(msg)
+            return True
+        except CredentialDecryptionError:
+            # Credential corruption is permanent; let the supervisor see it
+            # (via ``_listen``'s dedicated handler) instead of silently ACKing
+            # every message that follows.
+            raise
+        except (ValueError, RuntimeError, http_ece.ECEException) as decrypt_err:
+            # Per-message poison: the exception-hierarchy UNION of every decode
+            # surface ``_handle_message`` touches.
+            #   * ValueError    -- header-param parse (``_extract_header_param``)
+            #                      plus ``binascii.Error`` padding faults and
+            #                      ``UnicodeError``; both are ValueError
+            #                      subclasses and need no separate arm.
+            #   * RuntimeError  -- ``_app_data_by_key`` missing-key lookup.
+            #   * ECEException  -- ``http_ece`` body decrypt / auth-tag failure.
+            #                      It is a SIBLING of ValueError under Exception
+            #                      (not a subclass), so it must be listed
+            #                      explicitly or it bypasses this poison defense
+            #                      entirely (Exception-Hierarchie-Audit lesson,
+            #                      CA-CASCADING-FAILURE-001).
+            # ``CredentialDecryptionError`` is a ValueError subclass but is
+            # matched by the more specific arm above and re-raised, so it never
+            # reaches here. ACK + skip so the FCM server stops redelivering and
+            # the supervisor's short-run crash cap is not tripped by a single
+            # bad message.
+            persistent_id = getattr(msg, "persistent_id", None)
+            self._log_warn_with_limit(
+                "Skipping FCM message that failed to decrypt "
+                "(persistent_id=%s): %s",
+                persistent_id,
+                decrypt_err,
+            )
+            return await self._ack_or_disconnect(persistent_id)
+
     async def _listen(self) -> None:
         """Listens for push notifications until an error or stop() occurs."""
         try:
@@ -760,7 +914,9 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
             while self.do_listen:
                 try:
                     if msg := await self._receive_msg():
-                        await self._handle_message(msg)
+                        if not await self._process_one_inbound_message(msg):
+                            self.do_listen = False
+                            break
 
                 except (ConnectionError, ssl.SSLError) as cex:
                     # Treat stream end/TLS quirks as normal stop; supervisor will restart
@@ -777,6 +933,20 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
         except asyncio.CancelledError:
             self.logger.debug("Listener task cancelled")
             raise
+        except CredentialDecryptionError as cred_err:
+            # Stored FCM key material is corrupt/undecodable. Record it as a
+            # DISTINCT credential fault instead of letting it fall through to
+            # the generic "Unknown error" arm below, so the supervisor can
+            # invalidate the bad key material and re-register rather than
+            # restarting the listener against the same poison credentials
+            # until the short-run crash cap fires.
+            self.logger.error(
+                "FCM credential material is corrupt and requires "
+                "re-registration: %s",
+                cred_err,
+            )
+            self.credential_error = cred_err
+            self.do_listen = False
         except ConnectionResetError:
             # Log a clean warning without noisy traceback; supervisor will reconnect.
             self.logger.warning(

--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
@@ -37,7 +37,7 @@ import ssl
 import struct
 import time
 import traceback
-from base64 import urlsafe_b64decode
+from base64 import b64decode
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from enum import Enum
@@ -109,7 +109,8 @@ def _safe_urlsafe_b64decode(value: str | bytes) -> bytes:
     """Decode URL-safe base64 leniently (Python 3.14 compatibility shim).
 
     Strips ASCII whitespace and re-appends ``=`` padding before delegating
-    to :func:`base64.urlsafe_b64decode`. Python 3.14 switched
+    to :func:`base64.b64decode` (``altchars=b"-_"`` for the URL-safe
+    alphabet, ``validate=True``; see below). Python 3.14 switched
     ``binascii.a2b_base64`` to ``strict_mode=True`` by default, which
     rejects payloads containing newlines, stray whitespace, or missing
     padding -- exactly the conditions the wild FCM stream produces. This
@@ -123,8 +124,19 @@ def _safe_urlsafe_b64decode(value: str | bytes) -> bytes:
     restart loop. This helper closes the root cause: dirty base64 input
     that the Python 3.14 strict decoder rejects unconditionally.
 
-    Raises ``binascii.Error`` only when the payload remains undecodable
-    after whitespace removal and padding normalisation. Raises
+    Decoding runs in *validating* mode so that input containing characters
+    outside the URL-safe base64 alphabet (after whitespace/padding
+    normalisation) raises ``binascii.Error`` instead of being silently
+    discarded. This is a correctness requirement, not just hygiene: a
+    credential field corrupted to pure non-alphabet punctuation (e.g.
+    ``b"!!!!"``) must reach the ``CredentialDecryptionError`` branch in
+    :meth:`_decrypt_raw_data` and trigger re-registration, rather than
+    decoding to garbage bytes and being mistaken for recoverable
+    per-message poison.
+
+    Raises ``binascii.Error`` when the payload remains undecodable after
+    whitespace removal and padding normalisation -- including any residual
+    non-alphabet character rejected by the validating decoder. Raises
     ``UnicodeError`` when ``str`` input contains non-ASCII characters
     (``str.encode("ascii")`` fails before normalisation runs); callers in
     a credential-decode path must catch both.
@@ -138,7 +150,17 @@ def _safe_urlsafe_b64decode(value: str | bytes) -> bytes:
     # is exactly the set Python 3.14 strict mode now rejects.
     stripped = b"".join(raw.split())
     padded = stripped + b"=" * (-len(stripped) % 4)
-    return urlsafe_b64decode(padded)
+    # Decode in *validating* mode (``validate=True``). The stdlib's
+    # ``urlsafe_b64decode`` forwards to the non-validating ``b64decode``,
+    # which silently DISCARDS characters outside the base64 alphabet instead
+    # of raising. Corrupt credential fields that degrade to pure punctuation
+    # (e.g. ``b"!!!!"``) would therefore decode to garbage bytes and slip
+    # past the ``CredentialDecryptionError`` branch in ``_decrypt_raw_data``,
+    # causing the listener to treat permanent credential corruption as
+    # recoverable per-message poison (ACK + skip) and never trigger
+    # re-registration. ``altchars=b"-_"`` keeps the URL-safe alphabet;
+    # ``validate=True`` makes any non-alphabet residue raise ``binascii.Error``.
+    return b64decode(padded, altchars=b"-_", validate=True)
 
 
 # MCS Message Types and Tags
@@ -511,9 +533,7 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
         private_value = keys_section.get("private")
         secret_value = keys_section.get("secret")
         if not (isinstance(private_value, str) and isinstance(secret_value, str)):
-            raise CredentialDecryptionError(
-                "Credentials contain invalid key values"
-            )
+            raise CredentialDecryptionError("Credentials contain invalid key values")
 
         try:
             der_data = _safe_urlsafe_b64decode(private_value)
@@ -894,8 +914,7 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
             # bad message.
             persistent_id = getattr(msg, "persistent_id", None)
             self._log_warn_with_limit(
-                "Skipping FCM message that failed to decrypt "
-                "(persistent_id=%s): %s",
+                "Skipping FCM message that failed to decrypt (persistent_id=%s): %s",
                 persistent_id,
                 decrypt_err,
             )
@@ -946,8 +965,7 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
             # restarting the listener against the same poison credentials
             # until the short-run crash cap fires.
             self.logger.error(
-                "FCM credential material is corrupt and requires "
-                "re-registration: %s",
+                "FCM credential material is corrupt and requires re-registration: %s",
                 cred_err,
             )
             self.credential_error = cred_err

--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
@@ -86,6 +86,20 @@ _logger = logging.getLogger(__name__)
 
 _LEGACY_MCS_PROTOCOL_VERSION = 38
 
+# A run of consecutive ECE (auth-tag / body) decrypt failures with no
+# successful decrypt in between means the stored DH / auth-secret key material
+# no longer matches the server-side registration: every push fails the auth tag
+# even though the credential fields are still syntactically valid base64/DER. A
+# SINGLE failure stays per-message poison (a corrupt individual body, ACK +
+# skip); only a sustained run escalates to ``CredentialDecryptionError`` so the
+# supervisor invalidates the stale tokens and re-registers, instead of ACKing
+# every undecryptable push forever and silently stalling location updates (Codex
+# follow-up on PR #181: "do not ACK every ECE decrypt failure"). This is a
+# DEDICATED counter rather than the connectivity-oriented
+# ``sequential_error_counters`` mechanism, whose escalation action is "stop the
+# listener", not "re-register the credentials".
+_MAX_CONSECUTIVE_DECRYPT_FAILURES = 5
+
 
 class CredentialDecryptionError(ValueError):
     """Raised when stored FCM credential material cannot be decoded or parsed.
@@ -299,6 +313,13 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
         # instead of restarting against the same poison key material until the
         # short-run crash cap fires.
         self.credential_error: CredentialDecryptionError | None = None
+        # Counts consecutive ECE (auth-tag/body) decrypt failures with no
+        # successful decrypt in between; reset to 0 on every successful decrypt
+        # (``_handle_data_message``). When it reaches
+        # ``_MAX_CONSECUTIVE_DECRYPT_FAILURES`` the poison-message arm escalates
+        # a stale-key run to ``CredentialDecryptionError`` so the supervisor
+        # re-registers, instead of ACKing every undecryptable push indefinitely.
+        self._consecutive_decrypt_failures: int = 0
 
         # Locks
         self.stopping_lock: asyncio.Lock = asyncio.Lock()
@@ -636,6 +657,15 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
         decrypted = self._decrypt_raw_data(
             self.credentials, crypto_key, salt, msg.raw_data
         )
+        # A successful decrypt proves the stored DH/auth-secret key material
+        # still matches the server registration: clear the stale-key escalation
+        # counter so a later ISOLATED corrupt body cannot accumulate toward an
+        # unwarranted re-registration. Only an uninterrupted run of decrypt
+        # failures (no success in between) signals stale credentials -- placing
+        # the reset here, gated on a real decrypt success, means heartbeats /
+        # deleted_messages / login traffic (which never reach this line) cannot
+        # falsely reset the counter.
+        self._consecutive_decrypt_failures = 0
 
         # Normalize decrypted payload to a dict (defensive against non-object JSON)
         decrypted_json: Any | None = None
@@ -875,12 +905,22 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
         Defense 1 (CA-CASCADING-FAILURE-001): per-message decode failures
         (``binascii.Error`` padding faults under Python 3.14 strict mode,
         ``RuntimeError`` from ``_app_data_by_key`` key lookups, generic
-        ``ValueError`` from header parsing, and ``http_ece.ECEException``
-        from a corrupt encrypted body / failed auth tag) are acknowledged
-        and skipped instead of crashing the worker loop. Credential-material
-        errors (``CredentialDecryptionError``) propagate so ``_listen``
-        records them and the supervisor invalidates the bad key material and
-        prompts re-registration.
+        ``ValueError`` from header parsing, and an ISOLATED
+        ``http_ece.ECEException`` from a corrupt encrypted body / failed auth
+        tag) are acknowledged and skipped instead of crashing the worker loop.
+        Credential-material errors (``CredentialDecryptionError``) propagate so
+        ``_listen`` records them and the supervisor invalidates the bad key
+        material and prompts re-registration.
+
+        Stale-key escalation (Codex follow-up on PR #181): a SUSTAINED run of
+        ``http_ece.ECEException`` -- ``_MAX_CONSECUTIVE_DECRYPT_FAILURES`` in a
+        row with no successful decrypt in between -- is no longer per-message
+        poison but evidence that the stored DH/auth-secret keys are stale
+        (syntactically valid yet no longer matching the server registration).
+        The counter is reset on every successful decrypt
+        (``_handle_data_message``); on reaching the threshold this method raises
+        ``CredentialDecryptionError`` so the run escalates through the same
+        re-registration channel instead of ACKing every push indefinitely.
 
         Returns ``True`` to continue the loop, ``False`` to break (writer
         half-dead during ack).
@@ -906,13 +946,39 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
             #                      (not a subclass), so it must be listed
             #                      explicitly or it bypasses this poison defense
             #                      entirely (Exception-Hierarchie-Audit lesson,
-            #                      CA-CASCADING-FAILURE-001).
+            #                      CA-CASCADING-FAILURE-001). An ISOLATED ECE is
+            #                      ACKed below; a sustained run escalates to
+            #                      re-registration (stale-key branch below).
             # ``CredentialDecryptionError`` is a ValueError subclass but is
             # matched by the more specific arm above and re-raised, so it never
             # reaches here. ACK + skip so the FCM server stops redelivering and
             # the supervisor's short-run crash cap is not tripped by a single
             # bad message.
             persistent_id = getattr(msg, "persistent_id", None)
+            if isinstance(decrypt_err, http_ece.ECEException):
+                # Auth-tag / body-decrypt failure. A single one is a corrupt
+                # individual body (poison, ACK + skip). A sustained run with no
+                # successful decrypt in between means the stored DH/auth-secret
+                # keys no longer match the server registration -- every push
+                # fails the auth tag. Escalate to credential corruption so the
+                # supervisor invalidates the stale tokens and re-registers
+                # (device identity preserved), rather than ACKing every push
+                # forever and silently stalling location updates (Codex
+                # follow-up on PR #181). ``binascii.Error`` (per-message header
+                # decode) and ``RuntimeError`` (``_app_data_by_key`` lookup) are
+                # genuinely per-message and never drive this counter.
+                self._consecutive_decrypt_failures += 1
+                if (
+                    self._consecutive_decrypt_failures
+                    >= _MAX_CONSECUTIVE_DECRYPT_FAILURES
+                ):
+                    self._consecutive_decrypt_failures = 0
+                    raise CredentialDecryptionError(
+                        "FCM auth-tag decrypt failed on "
+                        f"{_MAX_CONSECUTIVE_DECRYPT_FAILURES} consecutive "
+                        "messages; stored key material is stale and requires "
+                        "re-registration"
+                    ) from decrypt_err
             self._log_warn_with_limit(
                 "Skipping FCM message that failed to decrypt (persistent_id=%s): %s",
                 persistent_id,

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
@@ -701,7 +701,11 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
         try:
             await asyncio.wait_for(ctx.event.wait(), timeout=timeout)
         except TimeoutError:
-            _LOGGER.warning(
+            # Expected when no reporter is in range to relay the BLE tag's
+            # location within the window; the RPC delivers data asynchronously
+            # via FCM. Returning an empty result is the healthy idle outcome,
+            # not a fault (INFO, not WARNING).
+            _LOGGER.info(
                 "No location response received for %s (timeout: %ss)", name, timeout
             )
             return []

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/PlaySound/start_sound_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/PlaySound/start_sound_request.py
@@ -36,7 +36,9 @@ from custom_components.googlefindmy.NovaApi.util import generate_random_uuid
 
 
 def start_sound_request(
-    canonic_device_id: str, gcm_registration_id: str
+    canonic_device_id: str,
+    gcm_registration_id: str,
+    request_uuid: str | None = None,
 ) -> tuple[str, str]:
     """Build the hex payload for a 'Play Sound' action (pure builder).
 
@@ -46,12 +48,19 @@ def start_sound_request(
     Args:
         canonic_device_id: The canonical ID of the target device.
         gcm_registration_id: The FCM registration token for push notifications.
+        request_uuid: Optional caller-supplied request UUID (the Stop-Sound
+            correlation/cancel key). When ``None`` a fresh UUID is generated, so
+            existing callers keep their previous behaviour. Passing it lets an
+            upper layer know the cancel key *before* dispatch, so it survives
+            every outcome (success, empty response, exception).
 
     Returns:
         Tuple containing the hex-encoded protobuf payload for Nova transport and
-        the generated request UUID.
+        the request UUID actually used (the injected one, or a freshly
+        generated one when none was supplied).
     """
-    request_uuid = generate_random_uuid()
+    if request_uuid is None:
+        request_uuid = generate_random_uuid()
     return (
         create_sound_request(
             True, canonic_device_id, gcm_registration_id, request_uuid
@@ -74,6 +83,7 @@ async def async_submit_start_sound_request(  # noqa: PLR0913
     cache_get: Callable[[str], Awaitable[Any]] | None = None,
     cache_set: Callable[[str, Any], Awaitable[None]] | None = None,
     refresh_override: Callable[[], Awaitable[str | None]] | None = None,
+    request_uuid: str | None = None,
 ) -> tuple[str, str] | None:  # noqa: PLR0913
     """Submit a 'Play Sound' action using the shared async Nova client.
 
@@ -97,14 +107,24 @@ async def async_submit_start_sound_request(  # noqa: PLR0913
         token: Optional direct ADM token to bypass cache lookups for this call.
         cache_get/cache_set: Optional async cache I/O overrides (flow-local).
         refresh_override: Optional async function to obtain a fresh ADM token.
+        request_uuid: Optional caller-supplied request UUID (the Stop-Sound
+            correlation/cancel key). Forwarded to the builder; when ``None`` the
+            builder generates one as before (backwards compatible). The upper
+            layer (``api.async_play_sound``) supplies it so the cancel key is
+            known before dispatch and is returned only on an accepted command.
 
     Returns:
         Tuple containing the hex response payload (may be empty) and the
-        request UUID on success, or None on handled errors.
+        request UUID on success, or None on handled errors. A returned tuple
+        therefore means the server accepted the command (HTTP 200); every
+        non-acceptance (auth/HTTP/rate-limit/network/pre-dispatch error) is
+        re-raised, never returned, so the caller can treat "a tuple came back"
+        as the single, reliable "command accepted" signal.
     """
-    # Build payload (pure)
+    # Build payload (pure). Forward the caller-supplied cancel key when given,
+    # else the builder generates one (unchanged legacy behaviour).
     hex_payload, request_uuid = start_sound_request(
-        canonic_device_id, gcm_registration_id
+        canonic_device_id, gcm_registration_id, request_uuid
     )
 
     # Prepare optional namespaced TTL cache wrappers if requested and not overridden

--- a/custom_components/googlefindmy/NovaApi/nova_request.py
+++ b/custom_components/googlefindmy/NovaApi/nova_request.py
@@ -184,6 +184,32 @@ HTTP_RETRY_ELIGIBLE = frozenset(
     }
 )
 
+# Status codes after which the server may already have *started executing* the
+# command (and thus a device ring) before answering. The dispatch latch keeps
+# the freshly minted cancel key alive across the rest of the retry sequence for
+# exactly these statuses, so Stop Sound can still target a ring that an earlier
+# attempt may have started.
+#
+# This is deliberately a *subset* of HTTP_RETRY_ELIGIBLE — you only risk a
+# duplicate dispatch on a status you would retry — minus 408 and 429, the two
+# retryable statuses that are refused *before* the backend starts executing:
+#   * 408 Request Timeout: the server gave up waiting for the *inbound* request,
+#     so the command was never fully received.
+#   * 429 Too Many Requests: the request was rate-limited at the gate and
+#     rejected without being processed, so no ring can have started.
+# Latching either would let a never-dispatched failure overwrite the valid
+# cancel key of a parallel, still-ringing play on the same device. Only the
+# transient 5xx codes (500/502/503/504) can be answered *after* the backend
+# began processing the command, so only they are dispatch-ambiguous. Because the
+# latch accumulates monotonically across the retry sequence, an earlier
+# dispatch-ambiguous 5xx still keeps the key alive even if a later attempt only
+# sees a 429. Permanent rejections (4xx) and non-retryable 5xx (501/505/508) are
+# refused before any side effect and are excluded for free by the subset.
+HTTP_DISPATCH_LATCH_ELIGIBLE = HTTP_RETRY_ELIGIBLE - {
+    HTTP_REQUEST_TIMEOUT,
+    HTTP_TOO_MANY_REQUESTS,
+}
+
 RECENT_REFRESH_WINDOW_S = 2.0
 # Maximum number of times the 401 handler will wait for a concurrent refresh
 # deadline before giving up.  This prevents infinite loops when the cache
@@ -330,19 +356,28 @@ class NovaError(Exception):
     """Base exception for Nova API errors.
 
     Attributes:
-        dispatched: True when the failure occurred *at or after* the request
+        dispatched: True when the server may already have processed the request
+            (a side effect such as a device ring could have started), so any
+            client-generated cancel key must be preserved. It is latched True by
+            either of two events: (a) a post-send network failure that provably
             reached the wire (server disconnect, read timeout, payload error),
-            so a side effect (e.g. a device ring) may already have started and
-            any client-generated cancel key must be preserved. False (the
-            default) when the request provably never left the client (DNS,
-            connect refused/timeout, or any pre-dispatch error), so no side
-            effect can have happened. The POST loop latches a wire-reaching
-            attempt across the *whole* retry sequence and stamps that latch onto
-            every error leaving the loop at a single choke point (the
-            `except NovaError` handler), so HTTP-status exits (429/5xx/4xx) carry
-            it just like wrapped network failures: once any attempt reaches the
-            wire it stays True even if a later attempt fails pre-connect or ends
-            on an HTTP status. All other Nova errors keep the safe default.
+            or (b) a dispatch-eligible HTTP status read
+            (HTTP_DISPATCH_LATCH_ELIGIBLE: transient 5xx 500/502/503/504), which
+            means the backend may have begun processing before it ultimately
+            failed. Pre-dispatch rejections (408/429, permanent 4xx,
+            non-retryable 5xx) do not latch.
+            False (the default) when the request provably never left the client
+            (DNS, connect refused/timeout, or any pre-dispatch error) or was
+            refused *before* any side effect — a permanent 4xx (401/403/404), a
+            non-retryable 5xx (501/505/508), or a 408 whose inbound request never
+            fully arrived. The POST loop latches such a wire-reaching attempt
+            across the *whole* retry sequence and stamps that latch onto every
+            error leaving the loop at a single choke point (the `except NovaError`
+            handler), so once any attempt may have been processed it stays True
+            even if a later attempt fails pre-connect or ends on another HTTP
+            status. Permanent client rejections never latch (they only carry an
+            already-set latch through the choke point). All other Nova errors
+            keep the safe default.
     """
 
     dispatched: bool = False
@@ -1477,6 +1512,23 @@ async def async_nova_request(  # noqa: PLR0913,PLR0912,PLR0915
                         "Nova API async request to %s: status=%d", api_scope, status
                     )
 
+                    # Latch dispatch the moment a status is read, but only for
+                    # statuses after which the backend may already have started a
+                    # side effect (a device ring): HTTP_DISPATCH_LATCH_ELIGIBLE
+                    # (transient 5xx 500/502/503/504). For those the cancel key
+                    # must survive the rest of the retry sequence so a later
+                    # pre-connect retry failure cannot clear it. Everything else —
+                    # permanent client rejections (401/403/404), non-retryable 5xx
+                    # (501/505/508), 408 Request Timeout (the inbound request
+                    # never fully arrived) and 429 Too Many Requests (rate-limited
+                    # at the gate, never processed) — is refused *before* any side
+                    # effect, so it must NOT latch: otherwise an undispatched
+                    # failure could overwrite
+                    # the valid cancel key of a still-ringing earlier play on the
+                    # same device.
+                    if status in HTTP_DISPATCH_LATCH_ELIGIBLE:
+                        reached_wire = True
+
                     # Acceptance boundary: the request is treated as "accepted by
                     # the server" — and therefore as a possibly-active ring whose
                     # cancel key must be preserved — ONLY when Google answers 200.
@@ -1743,14 +1795,16 @@ async def async_nova_request(  # noqa: PLR0913,PLR0912,PLR0915
 
     except NovaError as nova_err:
         # Single choke point for the whole retry sequence: stamp the sticky
-        # dispatch latch onto EVERY NovaError leaving the loop — the HTTP-status
-        # exits (429/5xx/4xx after retries) and the wrapped network failure
-        # alike. Dispatch is a property of the *sequence*, not of the final
-        # attempt: once any attempt reaches the wire a side effect (a device
-        # ring) may already have started, so the cancel key must survive
-        # regardless of how the sequence finally ended. The latch only ever
-        # flips False -> True, so a clean rejection sequence (no wire-reaching
-        # attempt) keeps dispatched=False and still drops the key.
+        # dispatch latch onto EVERY NovaError leaving the loop. The latch is set
+        # earlier — on a post-send network failure or on a dispatch-eligible
+        # status read (HTTP_DISPATCH_LATCH_ELIGIBLE: transient 5xx) — so
+        # this point only propagates it. Dispatch is
+        # a property of the *sequence*, not of the final attempt: once any
+        # attempt may have been processed a side effect (a device ring) may
+        # already have started, so the cancel key must survive regardless of how
+        # the sequence finally ended. The latch only ever flips False -> True, so
+        # a sequence of pure permanent rejections (4xx, no wire-reaching attempt)
+        # keeps dispatched=False and still drops the key.
         if reached_wire:
             nova_err.dispatched = True
         raise

--- a/custom_components/googlefindmy/NovaApi/nova_request.py
+++ b/custom_components/googlefindmy/NovaApi/nova_request.py
@@ -327,7 +327,25 @@ def _decode_error_response(content: bytes, http_status: int) -> str:
 
 # --- Custom Exceptions ---
 class NovaError(Exception):
-    """Base exception for Nova API errors."""
+    """Base exception for Nova API errors.
+
+    Attributes:
+        dispatched: True when the failure occurred *at or after* the request
+            reached the wire (server disconnect, read timeout, payload error),
+            so a side effect (e.g. a device ring) may already have started and
+            any client-generated cancel key must be preserved. False (the
+            default) when the request provably never left the client (DNS,
+            connect refused/timeout, or any pre-dispatch error), so no side
+            effect can have happened. The POST loop latches a wire-reaching
+            attempt across the *whole* retry sequence and stamps that latch onto
+            every error leaving the loop at a single choke point (the
+            `except NovaError` handler), so HTTP-status exits (429/5xx/4xx) carry
+            it just like wrapped network failures: once any attempt reaches the
+            wire it stays True even if a later attempt fails pre-connect or ends
+            on an HTTP status. All other Nova errors keep the safe default.
+    """
+
+    dispatched: bool = False
 
 
 class NovaAuthError(NovaError):
@@ -418,6 +436,33 @@ class NovaProtobufDecodeError(NovaError):
         super().__init__(
             f"Failed to decode Google Protobuf response: {detail or 'Unknown error'}"
         )
+
+
+# Network failures that prove the request never reached the wire: a connection
+# was never established (DNS, refused, TLS, proxy) or the *connect* phase timed
+# out. In aiohttp 3.13 these are ClientConnectorError (a ClientOSError subclass)
+# and ConnectionTimeoutError (a ServerTimeoutError subclass). Every other error
+# under (TimeoutError, aiohttp.ClientError) -- ServerDisconnectedError, a
+# read-phase SocketTimeoutError (which shares ServerTimeoutError with the
+# connect-phase ConnectionTimeoutError, hence the *specific* check below),
+# ClientPayloadError, ClientOSError, or a generic total-timeout -- happened at
+# or after dispatch, so the server may have acted on the request.
+_PRE_DISPATCH_NETWORK_ERRORS: tuple[type[BaseException], ...] = (
+    aiohttp.ClientConnectorError,
+    aiohttp.ConnectionTimeoutError,
+)
+
+
+def _network_failure_reached_wire(exc: BaseException) -> bool:
+    """Return True when a network failure may have been acted on by the server.
+
+    A pre-connect failure (DNS, connect refused/timeout, TLS) provably never
+    left the client. Any other aiohttp/timeout failure occurred at or after the
+    request reached the wire, so a side effect may already have started and the
+    caller must preserve its cancel key. See ``NovaError.dispatched``.
+    """
+
+    return not isinstance(exc, _PRE_DISPATCH_NETWORK_ERRORS)
 
 
 # ------------------------ Optional Home Assistant hooks ------------------------
@@ -1405,6 +1450,14 @@ async def async_nova_request(  # noqa: PLR0913,PLR0912,PLR0915
         retries_used = 0
         auth_retries_used = 0  # Counter for 401 retries after token refresh
         deadline_waits = 0  # Circuit breaker for 401 deadline-wait loops
+        # Sticky dispatch latch over the whole retry sequence. Dispatch is a
+        # property of the *sequence*, not of the final attempt: once *any*
+        # attempt reaches the wire, a side effect (a device ring) may already
+        # have started, so the cancel key must be preserved even if a *later*
+        # retry fails before it ever connects. Deriving this from the last
+        # exception alone is wrong (post-send read failure on attempt 1, then a
+        # pre-connect timeout on the last attempt -> still dispatched).
+        reached_wire = False
         while True:
             attempt = retries_used + 1
             try:
@@ -1424,6 +1477,17 @@ async def async_nova_request(  # noqa: PLR0913,PLR0912,PLR0915
                         "Nova API async request to %s: status=%d", api_scope, status
                     )
 
+                    # Acceptance boundary: the request is treated as "accepted by
+                    # the server" — and therefore as a possibly-active ring whose
+                    # cancel key must be preserved — ONLY when Google answers 200.
+                    # This is signalled to upper layers purely via the return
+                    # contract: a non-None return reaches the caller exclusively
+                    # here. Every non-200 status raises below, and every
+                    # connection-setup failure (DNS, connect refused, closed
+                    # connector/session, connect timeout) raises on the `async
+                    # with` entry above. Callers therefore derive "accepted" from
+                    # "this function returned" rather than from an out-of-band
+                    # signal that has to be kept in sync with the real status.
                     if status == HTTP_OK:
                         return cast(bytes, content).hex()
 
@@ -1641,6 +1705,12 @@ async def async_nova_request(  # noqa: PLR0913,PLR0912,PLR0915
             except asyncio.CancelledError:
                 raise
             except (TimeoutError, aiohttp.ClientError) as e:
+                # Latch dispatch the moment *this* attempt reaches the wire. A
+                # later pre-connect retry failure must never clear it: an earlier
+                # post-send attempt may already have started a ring whose cancel
+                # key has to survive. The latch only ever flips False -> True.
+                if _network_failure_reached_wire(e):
+                    reached_wire = True
                 if retries_used < NOVA_MAX_RETRIES:
                     delay = _compute_delay(attempt, None)
                     _LOGGER.warning(
@@ -1661,9 +1731,29 @@ async def async_nova_request(  # noqa: PLR0913,PLR0912,PLR0915
                         retries_used + 1,
                         type(e).__name__,
                     )
+                    # Wrap the final network failure. The sticky dispatch latch
+                    # is stamped onto this — and onto every other NovaError that
+                    # leaves the retry loop — at the single choke point below
+                    # (see the `except NovaError` handler). Deriving dispatch
+                    # per raise-site is exactly the bug this centralization
+                    # removes: HTTP-status exits used to forget the latch.
                     raise NovaError(
                         f"Nova API request failed after retries: {e}"
                     ) from e
+
+    except NovaError as nova_err:
+        # Single choke point for the whole retry sequence: stamp the sticky
+        # dispatch latch onto EVERY NovaError leaving the loop — the HTTP-status
+        # exits (429/5xx/4xx after retries) and the wrapped network failure
+        # alike. Dispatch is a property of the *sequence*, not of the final
+        # attempt: once any attempt reaches the wire a side effect (a device
+        # ring) may already have started, so the cancel key must survive
+        # regardless of how the sequence finally ended. The latch only ever
+        # flips False -> True, so a clean rejection sequence (no wire-reaching
+        # attempt) keeps dispatched=False and still drops the key.
+        if reached_wire:
+            nova_err.dispatched = True
+        raise
 
     finally:
         if ephemeral_session and session:

--- a/custom_components/googlefindmy/NovaApi/nova_request.py
+++ b/custom_components/googlefindmy/NovaApi/nova_request.py
@@ -76,7 +76,11 @@ except ImportError:
         ProtobufDecodeError = Exception  # type: ignore[misc,assignment]
         _RPC_STATUS_AVAILABLE = False
 
-from ..const import DATA_AAS_TOKEN, NOVA_API_USER_AGENT
+from ..const import (
+    DATA_AAS_TOKEN,
+    NOVA_API_USER_AGENT,
+    NOVA_REQUEST_TOTAL_TIMEOUT_S,
+)
 
 if TYPE_CHECKING:
     from bs4 import BeautifulSoup as _BeautifulSoupType
@@ -1404,7 +1408,9 @@ async def async_nova_request(  # noqa: PLR0913,PLR0912,PLR0915
         while True:
             attempt = retries_used + 1
             try:
-                timeout = aiohttp.ClientTimeout(total=30, connect=10, sock_read=30)
+                timeout = aiohttp.ClientTimeout(
+                    total=NOVA_REQUEST_TOTAL_TIMEOUT_S, connect=10, sock_read=30
+                )
                 async with session.post(
                     url,
                     headers=headers,
@@ -1538,7 +1544,9 @@ async def async_nova_request(  # noqa: PLR0913,PLR0912,PLR0915
                                 _SHORT_COOLDOWN_S,
                             )
                             await asyncio.sleep(_SHORT_COOLDOWN_S)
-                            _LOGGER.info("Nova API: refreshing ADM token (AAS retained).")
+                            _LOGGER.info(
+                                "Nova API: refreshing ADM token (AAS retained)."
+                            )
                             try:
                                 await policy.async_on_401()
                             except NovaAuthPermanentError:

--- a/custom_components/googlefindmy/SpotApi/spot_grpc_transport.py
+++ b/custom_components/googlefindmy/SpotApi/spot_grpc_transport.py
@@ -7,7 +7,28 @@ from typing import Final
 from grpclib.client import Channel
 from grpclib.encoding.base import CodecBase
 
-__all__ = ["RawCodec", "SpotGrpcTransport", "SPOT_GRPC_TRANSPORT"]
+__all__ = [
+    "RawCodec",
+    "SpotGrpcTransport",
+    "SPOT_GRPC_TRANSPORT",
+    "is_ssl_transport_teardown_error",
+]
+
+
+def is_ssl_transport_teardown_error(exc: BaseException) -> bool:
+    """Return True for the asyncio SSL-transport teardown race (AP9, finding 6a).
+
+    During a connection teardown there is a narrow window in which asyncio has
+    already detached the SSL transport (``_SSLProtocolTransport._ssl_protocol``
+    is ``None``) but grpclib's ``handler.connection_lost`` flag is not set yet.
+    A write that lands in that window raises
+    ``AttributeError: 'NoneType' object has no attribute '_write_appdata'`` from
+    deep inside ``asyncio.sslproto`` — code we do not own, so we cannot attach a
+    custom exception type at the throw site. Isolating the fragile asyncio
+    signature in this single predicate is the legitimate boundary discriminator:
+    every other ``AttributeError`` is a real bug and must propagate.
+    """
+    return isinstance(exc, AttributeError) and "_write_appdata" in str(exc)
 
 
 class RawCodec(CodecBase):

--- a/custom_components/googlefindmy/SpotApi/spot_request.py
+++ b/custom_components/googlefindmy/SpotApi/spot_request.py
@@ -66,6 +66,7 @@ from custom_components.googlefindmy.exceptions import MissingTokenCacheError
 from custom_components.googlefindmy.SpotApi.spot_grpc_transport import (
     SPOT_GRPC_TRANSPORT,
     SpotGrpcTransport,
+    is_ssl_transport_teardown_error,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -286,6 +287,27 @@ async def async_spot_request(
                 await _async_sleep(_compute_delay(attempt))
                 continue
             raise SpotNetworkError("Fatal transport error after retries.") from err
+
+        except AttributeError as err:
+            # AP9 (finding 6a): asyncio SSL-transport teardown race. grpclib
+            # wrote to an SSL transport whose protocol was already detached
+            # (idle/serverside close, GOAWAY, or a concurrent reset), raising
+            # ``AttributeError: 'NoneType' ... '_write_appdata'`` from inside
+            # asyncio.sslproto. Treat it like the other transient transport
+            # failures: reset the (possibly poisoned) channel and retry within
+            # budget, converting to SpotNetworkError when exhausted. Any other
+            # AttributeError is a genuine bug in our own stream handling and is
+            # re-raised unchanged.
+            if not is_ssl_transport_teardown_error(err):
+                raise
+            await active_transport.reset()
+            if retries_used < _SPOT_MAX_RETRIES:
+                retries_used += 1
+                await _async_sleep(_compute_delay(attempt))
+                continue
+            raise SpotNetworkError(
+                "SSL transport teardown after retries."
+            ) from err
 
         except TimeoutError as err:
             if retries_used < _SPOT_MAX_RETRIES:

--- a/custom_components/googlefindmy/__init__.py
+++ b/custom_components/googlefindmy/__init__.py
@@ -51,7 +51,7 @@ from collections.abc import (
 )
 from contextlib import suppress
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta
 from importlib import import_module
 from types import MappingProxyType, ModuleType, SimpleNamespace
 from typing import (
@@ -113,7 +113,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.helpers.event import async_call_later
+from homeassistant.helpers.event import async_call_later, async_track_time_interval
 from homeassistant.helpers.network import NoURLAvailableError, get_url
 
 if TYPE_CHECKING:
@@ -175,7 +175,9 @@ from .const import (
     DEFAULT_OPTIONS,
     DOMAIN,
     FEATURE_FMDN_FINDER_ENABLED,
+    INTEGRATION_VERSION,
     ISSUE_MULTIPLE_CONFIG_ENTRIES,
+    ISSUE_RESTART_REQUIRED_KEY,
     LEGACY_SERVICE_IDENTIFIER,
     OPT_ALLOW_HISTORY_FALLBACK,
     OPT_CONTRIBUTOR_MODE,
@@ -200,6 +202,7 @@ from .const import (
     TRACKER_SUBENTRY_TRANSLATION_KEY,
     TRANSLATION_KEY_CACHE_PURGED,
     TRANSLATION_KEY_DUPLICATE_ACCOUNT,
+    TRANSLATION_KEY_RESTART_REQUIRED,
     TRANSLATION_KEY_UNIQUE_ID_COLLISION,
     coerce_ignored_mapping,
     map_token_hex_digest,
@@ -2383,6 +2386,9 @@ class GoogleFindMyDomainData(TypedDict, total=False):
     nova_refcount: int
     services_lock: asyncio.Lock
     services_registered: bool
+    restart_check_registered: bool
+    restart_check_unsub: Callable[[], None] | None
+    restart_check_initial_unsub: Callable[[], None] | None
     providers_registered: bool
     views_registered: bool
     _subentry_forward_helper_logs: set[str]
@@ -6046,6 +6052,169 @@ async def _ensure_post_migration_consistency(
     return should_setup, normalized_email
 
 
+# --------------------------------------------------------------------------------------
+# Restart-required watchdog
+#
+# HACS writes freshly downloaded integration code to disk while the running process keeps
+# executing the previously imported module. We surface that mismatch as a global,
+# non-fixable Repairs issue so the user knows a *Home Assistant restart* (not merely an
+# integration reload) is required to activate the installed version.
+# --------------------------------------------------------------------------------------
+_RESTART_CHECK_INITIAL_DELAY: float = 30.0
+_RESTART_CHECK_INTERVAL: timedelta = timedelta(hours=1)
+
+
+def _read_installed_version_sync() -> str | None:
+    """Return manifest.json's version from disk (blocking; run inside an executor)."""
+    try:
+        manifest_path = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "manifest.json"
+        )
+        with open(manifest_path, encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (OSError, ValueError) as err:  # IO failure or malformed JSON
+        _LOGGER.debug("Restart check: could not read installed version: %s", err)
+        return None
+    version = data.get("version") if isinstance(data, dict) else None
+    return version if isinstance(version, str) and version else None
+
+
+async def _async_read_installed_version(hass: HomeAssistant) -> str | None:
+    """Return the on-disk manifest version without blocking the event loop."""
+    version: str | None = await hass.async_add_executor_job(_read_installed_version_sync)
+    return version
+
+
+async def _async_check_restart_required(hass: HomeAssistant) -> None:
+    """Raise or clear the global "restart required" Repairs issue.
+
+    The running module carries ``INTEGRATION_VERSION``; the on-disk manifest reflects what
+    HACS has installed. A mismatch means a restart is pending. On equality or any read
+    error the issue is cleared (self-healing, create/delete symmetric). This coroutine
+    never raises into Home Assistant.
+    """
+    try:
+        installed = await _async_read_installed_version(hass)
+        if installed is not None and installed != INTEGRATION_VERSION:
+            # A last-entry teardown may have run during the executor read above
+            # (the only await in this coroutine). If the watchdog has since been
+            # torn down, do not resurrect the issue: no timer would ever clear it
+            # again. The registration flag lives in the global domain bucket and
+            # is popped by _teardown_restart_required_check (Codex-P1 class:
+            # tick firing after unload).
+            if not _domain_data(hass).get("restart_check_registered"):
+                return
+            issue_severity = getattr(ir, "IssueSeverity", None)
+            if issue_severity is not None:
+                severity = getattr(issue_severity, "WARNING", None)
+                if severity is None:
+                    severity = getattr(issue_severity, "ERROR", "warning")
+            else:
+                severity = getattr(ir, "WARNING", "warning")
+            ir.async_create_issue(
+                hass,
+                DOMAIN,
+                ISSUE_RESTART_REQUIRED_KEY,
+                is_fixable=False,
+                severity=severity,
+                translation_key=TRANSLATION_KEY_RESTART_REQUIRED,
+                translation_placeholders={
+                    "running_version": INTEGRATION_VERSION,
+                    "installed_version": installed,
+                },
+            )
+        else:
+            ir.async_delete_issue(hass, DOMAIN, ISSUE_RESTART_REQUIRED_KEY)
+    except Exception as err:  # noqa: BLE001 - watchdog must never raise into HA
+        _LOGGER.debug("Restart check failed: %s", err)
+
+
+@callback
+def _register_restart_required_check(
+    hass: HomeAssistant, bucket: GoogleFindMyDomainData
+) -> None:
+    """Register the one-shot + hourly restart watchdog exactly once.
+
+    Both unsub handles (initial ``async_call_later`` and periodic
+    ``async_track_time_interval``) are stored so the last-entry teardown can cancel them,
+    preventing a timer leak or a tick firing after unload (Codex-P1 #1/#2). The initial
+    schedule mirrors the existing awaitable-guard precedent for ``async_call_later``.
+    """
+
+    @callback
+    def _scheduled_check(_now: Any) -> None:
+        _async_create_task(
+            hass,
+            _async_check_restart_required(hass),
+            name=f"{DOMAIN}.restart_required_check",
+        )
+
+    initial_handle = async_call_later(
+        hass, _RESTART_CHECK_INITIAL_DELAY, _scheduled_check
+    )
+    if inspect.isawaitable(initial_handle):
+        # Some HA test stubs return an awaitable instead of an unsub callable.
+        _async_create_task(
+            hass,
+            cast(CoroutineType, initial_handle),
+            name=f"{DOMAIN}.restart_required_initial_schedule",
+        )
+        bucket["restart_check_initial_unsub"] = None
+    else:
+        bucket["restart_check_initial_unsub"] = initial_handle
+
+    bucket["restart_check_unsub"] = async_track_time_interval(
+        hass, _scheduled_check, _RESTART_CHECK_INTERVAL
+    )
+
+
+@callback
+def _teardown_restart_required_check(
+    hass: HomeAssistant, bucket: GoogleFindMyDomainData
+) -> None:
+    """Cancel both restart-watchdog timers and clear the issue (last-entry teardown)."""
+    for unsub in (
+        bucket.pop("restart_check_initial_unsub", None),
+        bucket.pop("restart_check_unsub", None),
+    ):
+        if callable(unsub):
+            with suppress(Exception):
+                unsub()
+    bucket.pop("restart_check_registered", None)
+    with suppress(Exception):
+        ir.async_delete_issue(hass, DOMAIN, ISSUE_RESTART_REQUIRED_KEY)
+
+
+async def _async_ensure_restart_required_check(
+    hass: HomeAssistant, bucket: GoogleFindMyDomainData
+) -> None:
+    """Idempotently arm the global restart-required watchdog.
+
+    Called from both ``async_setup`` (component load) and ``async_setup_entry``
+    (each parent entry load). The shared services lock plus the
+    ``restart_check_registered`` idempotent flag keep a single timer pair even
+    across racey startups or multiple config entries (Codex-P1 #6).
+
+    Re-arming from ``async_setup_entry`` is what restores the watchdog after a
+    last-entry reload: ``_teardown_restart_required_check`` cancels the timers and
+    pops the flag on the final unload, but ``async_setup`` does *not* run again on
+    a config-entry reload. Without this re-arm the "updated but not yet restarted"
+    warning would stay hidden until a full Home Assistant restart, defeating the
+    common "reload instead of restart" scenario. This mirrors the EID resolver,
+    the other global singleton that is torn down on last-entry unload and
+    re-created on entry setup.
+    """
+    services_lock: asyncio.Lock = _ensure_services_lock(bucket)
+    async with services_lock:
+        registered = bucket.get("restart_check_registered")
+        if not isinstance(registered, bool):
+            registered = False
+        if not registered:
+            _register_restart_required_check(hass, bucket)
+            bucket["restart_check_registered"] = True
+            _LOGGER.debug("Registered %s restart-required watchdog", DOMAIN)
+
+
 async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
     """Set up the integration namespace and register global services.
 
@@ -6088,6 +6257,10 @@ async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
             await async_register_services(hass, svc_ctx)
             bucket["services_registered"] = True
             _LOGGER.debug("Registered %s services at integration level", DOMAIN)
+
+    # Arm the global restart-required watchdog exactly once. async_setup_entry
+    # re-arms it after a last-entry reload tears it down (see helper docstring).
+    await _async_ensure_restart_required_check(hass, bucket)
 
     return True
 
@@ -7142,6 +7315,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: MyConfigEntry) -> bool:
     entry.runtime_data = runtime_data
     entries_bucket: dict[str, RuntimeData] = _ensure_entries_bucket(domain_bucket)
     entries_bucket[entry.entry_id] = runtime_data
+
+    # Re-arm the global restart-required watchdog now that an entry is active.
+    # async_setup arms it on component load, but a last-entry reload tears it down
+    # and async_setup does not run again; arming here (the exact inverse of the
+    # `not entries_bucket` teardown trigger) keeps the warning alive across reloads.
+    await _async_ensure_restart_required_check(hass, domain_bucket)
 
     _cloud_discovery_runtime(hass, entry)
 
@@ -8234,6 +8413,12 @@ async def _async_unload_parent_entry(hass: HomeAssistant, entry: MyConfigEntry) 
                 bucket.pop(DATA_EID_RESOLVER, None)
             else:
                 hass.async_create_task(resolver.async_refresh())
+
+        if not entries_bucket:
+            # Last entry torn down: cancel the global restart watchdog (both timers)
+            # and clear its issue, mirroring how other global singletons are released
+            # here (Codex-P1 #1/#2).
+            _teardown_restart_required_check(hass, bucket)
 
         try:
             await _maybe_close_spot_transport(entries_bucket)

--- a/custom_components/googlefindmy/__init__.py
+++ b/custom_components/googlefindmy/__init__.py
@@ -8520,6 +8520,20 @@ async def async_remove_entry(hass: HomeAssistant, entry: MyConfigEntry) -> None:
     except Exception as err:
         _LOGGER.debug("FCM release during async_remove_entry raised: %s", err)
 
+    # Retire any entry-scoped FCM Repairs issues now that the entry is actually
+    # being removed. The supervisor success path only deletes them on reload
+    # recovery, and the unload teardown deliberately leaves the fixable reauth
+    # prompt alone; once the entry is gone no supervisor will run again, so the
+    # orphaned repair must be cleaned up here (Codex PR #1104 follow-up).
+    try:
+        from .Auth.fcm_receiver_ha import FcmReceiverHA
+
+        FcmReceiverHA.async_delete_entry_repair_issues(hass, entry.entry_id)
+    except Exception as err:  # pragma: no cover - defensive best-effort cleanup
+        _LOGGER.debug(
+            "Deleting FCM repair issues during async_remove_entry raised: %s", err
+        )
+
     try:
         owner_index = _ensure_device_owner_index(bucket)
         stale = [cid for cid, eid in list(owner_index.items()) if eid == entry.entry_id]

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -1635,9 +1635,10 @@ class GoogleFindMyAPI:
                     _short_err(err),
                 )
             # Non-acceptance (401/403/5xx/other): drop the key UNLESS an earlier
-            # attempt latched dispatch — a post-send failure on a prior retry may
-            # already be ringing. err.dispatched carries that sticky sequence
-            # latch (stamped at the transport's retry-loop choke point).
+            # attempt latched dispatch — a prior attempt that reached the server
+            # (a post-send network failure, or a 5xx/429 status read) may already
+            # be ringing. err.dispatched carries that sticky sequence latch
+            # (stamped at the transport's retry-loop choke point).
             return _cancel_key_after_failure(err, request_uuid)
 
         except NovaRateLimitError as err:
@@ -1653,9 +1654,10 @@ class GoogleFindMyAPI:
             # A network failure wrapped by async_nova_request after its retries,
             # or any other NovaError leaving the transport. The retry-loop choke
             # point stamps the sticky dispatch latch onto it (err.dispatched): if
-            # any attempt reached the wire (server disconnect, read timeout,
-            # payload error), the play may already be ringing, so keep the cancel
-            # key; a provable pre-connect failure never rang, so drop it. Other
+            # any attempt may have been processed by the server (a post-send
+            # network failure, or a 5xx/429 status read), the play may already be
+            # ringing, so keep the cancel key; a provable pre-connect failure
+            # never rang, so drop it. Other
             # subclasses (NovaLogicError, NovaProtobufDecodeError) inherit
             # dispatched=False and keep the conservative drop.
             if err.dispatched:

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -57,11 +57,13 @@ from .NovaApi.ListDevices.nbe_list_devices import async_request_device_list
 from .NovaApi.nova_request import (
     NovaAuthError,
     NovaAuthPermanentError,
+    NovaError,
     NovaHTTPError,
     NovaLogicError,
     NovaProtobufDecodeError,
     NovaRateLimitError,
 )
+from .NovaApi.util import generate_random_uuid
 from .ProtoDecoders.decoder import (
     _select_best_location as _decoder_select_best_location,
 )
@@ -93,6 +95,26 @@ def _short_err(e: Exception | str) -> str:
     if len(msg) > _MAX_ERR_CHARS:
         return msg[: _MAX_ERR_CHARS - 3] + "..."
     return msg
+
+
+def _cancel_key_after_failure(
+    err: NovaError, request_uuid: str
+) -> tuple[bool, str | None]:
+    """Decide the Play-Sound cancel-key fate for a non-accepted command.
+
+    A raised ``NovaError`` is never an acceptance (the submitter returns a tuple
+    only on HTTP 200), so ``success`` is always ``False``. The cancel key is
+    preserved ONLY when the failure latched dispatch (``err.dispatched``): some
+    attempt in the retry sequence reached the wire, so the device may already be
+    ringing and a later Stop needs the key. Pure rejections (401/403/5xx/429
+    with no wire-reaching attempt) and provable pre-dispatch failures inherit
+    ``dispatched is False`` and drop the key, so they can never overwrite a
+    previous, possibly still-ringing play's valid cancel key. Centralizing the
+    decision here keeps every non-acceptance exit on one rule instead of
+    re-deriving it per ``except`` handler. See ``NovaError.dispatched`` and
+    IRR-CA-CANCEL-KEY-ON-SUCCESS-ONLY.
+    """
+    return (False, request_uuid if err.dispatched else None)
 
 
 # Backward-compatible export for tests and legacy call sites.
@@ -1508,13 +1530,46 @@ class GoogleFindMyAPI:
 
         Returns:
             A tuple `(success, request_uuid)` where `success` indicates whether the
-            command was submitted successfully and `request_uuid` captures the
-            backend-generated request identifier when available.
+            command was *accepted* (HTTP 200) and `request_uuid` captures the
+            client-generated cancel key. The UUID is generated locally *before*
+            dispatch. It is returned (non-None) in two cases where the device may
+            be ringing and a later Stop needs the key:
+              1. Acceptance — the server answered 200. `success` is True.
+              2. Post-dispatch ambiguity — a network failure occurred at or after
+                 the request reached the wire (server disconnect, read timeout,
+                 payload error), so the play may have started even though no 200
+                 was read. `success` is False, but the key is preserved.
+            Every failure that provably never reached the wire — no FCM token,
+            missing cache, username/payload/token resolution, connection setup
+            (DNS/connect refused/connect timeout) — and every explicit server
+            rejection (401/403/4xx/5xx/429) returns `(False, None)` so it cannot
+            overwrite a still-valid cancel key of a previous, possibly still-ringing
+            play. The sole exception is a rejection/HTTP-status exit whose retry
+            sequence latched dispatch on an *earlier* wire-reaching attempt: there
+            the key is preserved because that earlier attempt may already be
+            ringing. The pre-/post-dispatch split is classified in-band on the
+            raised NovaError (`NovaError.dispatched`), stamped uniformly at the
+            transport's retry-loop choke point for every exit. See
+            IRR-CA-CANCEL-KEY-ON-SUCCESS-ONLY.
         """
         # Pass cache explicitly for multi-account isolation
         token = self._get_fcm_token_for_action()
         if not token:
+            # PRE-dispatch: nothing was sent, so there is no cancel key to keep.
             return (False, None)
+        # Generate the cancel key locally *before* dispatch so it is in scope on
+        # every path. Acceptance is still derived structurally from the submitter's
+        # return contract: it returns a result tuple exclusively on an HTTP 200 and
+        # re-raises on every non-acceptance. So `success` (the True/False bool) is
+        # driven purely by "did the submitter return a tuple", with no out-of-band
+        # dispatch signal to keep in sync. On the failure branch we additionally
+        # preserve the key when the wrapped NovaError says the request reached the
+        # wire (err.dispatched): the play may be ringing even without a 200, so a
+        # later Stop needs the key. Explicit rejections (401/403/5xx) and provable
+        # pre-dispatch failures keep dropping the key, so they can never overwrite a
+        # previous, possibly still-ringing play's valid cancel key.
+        request_uuid = generate_random_uuid()
+
         try:
             _LOGGER.info("Submitting Play Sound (async) for %s", device_id)
             # Delegate payload build + transport to the submitter; provide HA session.
@@ -1526,6 +1581,7 @@ class GoogleFindMyAPI:
                 session=self._session,
                 namespace=self._namespace(),
                 cache=cast("TokenCache | None", self._cache),
+                request_uuid=request_uuid,
             )
             if result is None:
                 _LOGGER.error(
@@ -1533,9 +1589,13 @@ class GoogleFindMyAPI:
                     "empty response from server (no error details available)",
                     device_id,
                 )
+                # Defensive: the submitter returns a tuple on every accepted (200)
+                # command and re-raises otherwise, so None is not an expected
+                # outcome. Treat the unconfirmed result conservatively — drop the
+                # key rather than risk overwriting a previous play's valid one.
                 return (False, None)
 
-            response_hex, request_uuid = result
+            response_hex, _response_uuid = result
             _LOGGER.info("Play Sound (async) submitted successfully for %s", device_id)
             _LOGGER.debug(
                 "Play Sound Nova response for %s (uuid=%s): %d bytes: %s",
@@ -1552,7 +1612,12 @@ class GoogleFindMyAPI:
                 device_id,
                 _short_err(err),
             )
-            return (False, None)
+            # A raised error is never an acceptance (the submitter returns a tuple
+            # only on a 200). Keep the cancel key only if an earlier attempt
+            # latched dispatch (err.dispatched): a pure 401/403 rejection with no
+            # wire-reaching attempt drops it, so it can never overwrite a
+            # previous, possibly still-ringing play's valid key.
+            return _cancel_key_after_failure(err, request_uuid)
 
         except NovaHTTPError as err:
             if getattr(err, "status", None) in (401, 403):
@@ -1562,24 +1627,59 @@ class GoogleFindMyAPI:
                     device_id,
                     _short_err(err),
                 )
-                return (False, None)
-            _LOGGER.warning(
-                "Server error (%s) while playing sound on %s: %s",
-                err.status,
-                device_id,
-                _short_err(err),
-            )
-            return (False, None)
+            else:
+                _LOGGER.warning(
+                    "Server error (%s) while playing sound on %s: %s",
+                    err.status,
+                    device_id,
+                    _short_err(err),
+                )
+            # Non-acceptance (401/403/5xx/other): drop the key UNLESS an earlier
+            # attempt latched dispatch — a post-send failure on a prior retry may
+            # already be ringing. err.dispatched carries that sticky sequence
+            # latch (stamped at the transport's retry-loop choke point).
+            return _cancel_key_after_failure(err, request_uuid)
 
         except NovaRateLimitError as err:
             _LOGGER.warning(
                 "Play Sound rate-limited for %s: %s", device_id, _short_err(err)
             )
-            return (False, None)
+            # Same rule as the other non-acceptances: a rate-limited final attempt
+            # never rang, but if a *prior* attempt reached the wire the latch
+            # (err.dispatched) preserves the key.
+            return _cancel_key_after_failure(err, request_uuid)
+
+        except NovaError as err:
+            # A network failure wrapped by async_nova_request after its retries,
+            # or any other NovaError leaving the transport. The retry-loop choke
+            # point stamps the sticky dispatch latch onto it (err.dispatched): if
+            # any attempt reached the wire (server disconnect, read timeout,
+            # payload error), the play may already be ringing, so keep the cancel
+            # key; a provable pre-connect failure never rang, so drop it. Other
+            # subclasses (NovaLogicError, NovaProtobufDecodeError) inherit
+            # dispatched=False and keep the conservative drop.
+            if err.dispatched:
+                _LOGGER.warning(
+                    "Play Sound for %s failed after reaching the server (%s); "
+                    "keeping the cancel key in case the device is ringing.",
+                    device_id,
+                    _short_err(err),
+                )
+            else:
+                _LOGGER.error(
+                    "Network error while playing sound on %s before dispatch: %s",
+                    device_id,
+                    _short_err(err),
+                )
+            return _cancel_key_after_failure(err, request_uuid)
 
         except ClientError as err:
+            # Defensive: async_nova_request wraps aiohttp errors into NovaError
+            # (handled above), so a raw ClientError here is a pre-dispatch failure
+            # raised before the POST loop (e.g. token/cache resolution). It never
+            # reached the wire, so the device cannot be ringing: drop the key.
             _LOGGER.error(
-                "Network error while playing sound on %s: %s",
+                "Network error while playing sound on %s before dispatch: %s",
                 device_id,
                 _short_err(err),
             )

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -426,6 +426,26 @@ REBUILD_REGISTRY_MODES: tuple[str, str] = (MODE_REBUILD, MODE_MIGRATE)
 # --------------------------------------------------------------------------------------
 LOCATION_REQUEST_TIMEOUT_S: int = 30
 
+# Total budget for a single Nova HTTP round-trip. Single source of truth for the
+# aiohttp ``ClientTimeout(total=...)`` used in NovaApi/nova_request.py. The outer
+# poll guard below budgets against this value, so the two MUST move together;
+# nova_request.py imports this constant instead of repeating the literal.
+NOVA_REQUEST_TOTAL_TIMEOUT_S: int = 30
+
+# Outer per-device poll guard. A single location request runs two *sequential*
+# phases: first the Nova HTTP round-trip (capped at NOVA_REQUEST_TOTAL_TIMEOUT_S),
+# then the FCM wait (capped at LOCATION_REQUEST_TIMEOUT_S). The outer guard must
+# cover BOTH phases plus a small grace, otherwise a slow-but-successful HTTP call
+# pushes the inner FCM wait past the guard and the outer wait_for raises a
+# spurious TimeoutError before the inner request can return its clean empty
+# result (Nygard: stagger nested timeout budgets, decreasing from outer to
+# inner). The +5s grace absorbs scheduling/setup overhead between the phases.
+# Note: this budgets a single HTTP attempt; a multi-retry backoff sequence inside
+# nova_request can still exceed it, in which case the guard correctly intervenes.
+POLL_DEVICE_OUTER_TIMEOUT_S: int = (
+    NOVA_REQUEST_TOTAL_TIMEOUT_S + LOCATION_REQUEST_TIMEOUT_S + 5
+)
+
 # --------------------------------------------------------------------------------------
 # HTTP headers / User-Agent (Nova API)
 # --------------------------------------------------------------------------------------
@@ -603,6 +623,8 @@ __all__ = [
     "MODE_MIGRATE",
     "REBUILD_REGISTRY_MODES",
     "LOCATION_REQUEST_TIMEOUT_S",
+    "NOVA_REQUEST_TOTAL_TIMEOUT_S",
+    "POLL_DEVICE_OUTER_TIMEOUT_S",
     "NOVA_API_USER_AGENT",
     "FCM_CLIENT_HEARTBEAT_INTERVAL_S",
     "FCM_SERVER_HEARTBEAT_INTERVAL_S",

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -21,7 +21,7 @@ DATA_EID_RESOLVER: Final[Literal["eid_resolver"]] = "eid_resolver"
 # Latest config entry schema version handled by this integration.
 CONFIG_ENTRY_VERSION: int = 2
 # Keep the integration version aligned across the project (match manifest.json)
-INTEGRATION_VERSION: str = "1.7.0-6"
+INTEGRATION_VERSION: str = "1.7.0-7"
 
 # --------------------------------------------------------------------------------------
 # Shared textual constants

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -21,7 +21,7 @@ DATA_EID_RESOLVER: Final[Literal["eid_resolver"]] = "eid_resolver"
 # Latest config entry schema version handled by this integration.
 CONFIG_ENTRY_VERSION: int = 2
 # Keep the integration version aligned across the project (match manifest.json)
-INTEGRATION_VERSION: str = "1.7.0-7"
+INTEGRATION_VERSION: str = "1.7.1"
 
 # --------------------------------------------------------------------------------------
 # Shared textual constants
@@ -494,6 +494,11 @@ TRANSLATION_KEY_CACHE_PURGED: str = "cache_purged"
 TRANSLATION_KEY_UNIQUE_ID_COLLISION: str = "unique_id_collision"
 TRANSLATION_KEY_DUPLICATE_ACCOUNT: str = "duplicate_account_entries"
 
+# Global Repairs issue raised when HACS has written new integration code to disk
+# but the running process still executes the previously loaded version.
+ISSUE_RESTART_REQUIRED_KEY: str = "restart_required"
+TRANSLATION_KEY_RESTART_REQUIRED: str = "restart_required"
+
 
 def issue_id_for(entry_id: str) -> str:
     """Return a stable Repairs issue_id for a given config entry.
@@ -640,6 +645,8 @@ __all__ = [
     "TRANSLATION_KEY_CACHE_PURGED",
     "TRANSLATION_KEY_UNIQUE_ID_COLLISION",
     "TRANSLATION_KEY_DUPLICATE_ACCOUNT",
+    "ISSUE_RESTART_REQUIRED_KEY",
+    "TRANSLATION_KEY_RESTART_REQUIRED",
     "issue_id_for",
     "STORAGE_KEY",
     "STORAGE_VERSION",

--- a/custom_components/googlefindmy/coordinator/helpers/__init__.py
+++ b/custom_components/googlefindmy/coordinator/helpers/__init__.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from .cache import (
     DEFAULT_SNAPSHOT_FIELDS,
     LOCATION_FIELDS,
+    SOUND_UUID_MAX_AGE_S,
     SOURCE_PRIORITY,
     STATUS_AGING,
     STATUS_CURRENT,
@@ -23,6 +24,7 @@ from .cache import (
     epoch_to_datetime_utc,
     fill_missing_coordinates,
     is_presence_expired,
+    is_sound_uuid_expired,
     merge_cache_row,
     normalize_location_fields,
     preserve_metadata_fields,
@@ -139,6 +141,7 @@ __all__ = [
     # cache.py
     "DEFAULT_SNAPSHOT_FIELDS",
     "LOCATION_FIELDS",
+    "SOUND_UUID_MAX_AGE_S",
     "SOURCE_PRIORITY",
     "STATUS_AGING",
     "STATUS_CURRENT",
@@ -150,6 +153,7 @@ __all__ = [
     "epoch_to_datetime_utc",
     "fill_missing_coordinates",
     "is_presence_expired",
+    "is_sound_uuid_expired",
     "merge_cache_row",
     "normalize_location_fields",
     "preserve_metadata_fields",

--- a/custom_components/googlefindmy/coordinator/helpers/cache.py
+++ b/custom_components/googlefindmy/coordinator/helpers/cache.py
@@ -39,6 +39,7 @@ from .subentry import format_epoch_utc, normalize_epoch_seconds
 __all__ = [
     "DEFAULT_SNAPSHOT_FIELDS",
     "LOCATION_FIELDS",
+    "SOUND_UUID_MAX_AGE_S",
     "SOURCE_PRIORITY",
     "STATUS_AGING",
     "STATUS_CURRENT",
@@ -51,6 +52,7 @@ __all__ = [
     "fill_missing_coordinates",
     "get_common_pb2",
     "is_presence_expired",
+    "is_sound_uuid_expired",
     "merge_cache_row",
     "normalize_location_fields",
     "preserve_metadata_fields",
@@ -222,6 +224,40 @@ def is_presence_expired(
     if not last_seen_mono:
         return True
     return (now_mono - float(last_seen_mono)) > ttl_seconds
+
+
+# ---------------------------------------------------------------------------
+# Play Sound UUID Expiry
+# ---------------------------------------------------------------------------
+
+# Stored Play Sound UUIDs older than this are considered stale (#108): a ring
+# auto-stops long before then, so an aged key must not be trusted as a Stop
+# target nor block a fresh cancel key from being cached.
+SOUND_UUID_MAX_AGE_S = 30 * 60  # 30 minutes
+
+
+def is_sound_uuid_expired(
+    ts: float,
+    now: float,
+    max_age_seconds: float,
+) -> bool:
+    """Check if a stored Play Sound UUID has aged out.
+
+    Single source of truth for the sound-UUID expiry so the load path, the
+    store-path overwrite guard, and the Stop read-path all agree on what
+    "stale" means (a divergent inline check caused PR #1106's follow-up bug).
+
+    Args:
+        ts: Epoch timestamp when the UUID was stored (wall-clock seconds).
+            A missing/zero timestamp compares as expired against any positive
+            ``now``, matching the load path's treatment of untimestamped keys.
+        now: Current epoch time (``time.time()``).
+        max_age_seconds: Maximum age before the UUID is considered stale.
+
+    Returns:
+        True if the UUID is older than ``max_age_seconds``, False otherwise.
+    """
+    return (now - float(ts)) > max_age_seconds
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/googlefindmy/coordinator/locate.py
+++ b/custom_components/googlefindmy/coordinator/locate.py
@@ -491,7 +491,13 @@ class LocateOperations(_MixinBase):
                 reauth_started = False
                 if entry is not None:
                     try:
-                        await entry.async_start_reauth(self.hass)
+                        # ``ConfigEntry.async_start_reauth`` is a synchronous
+                        # ``@callback`` returning ``None`` (it schedules the flow
+                        # itself). Awaiting it would raise ``TypeError`` on the
+                        # ``None`` result, which the broad ``except`` below would
+                        # swallow, leaving ``reauth_started`` False and emitting
+                        # the wrong user message. Call it without ``await``.
+                        entry.async_start_reauth(self.hass)
                         reauth_started = True
                     except Exception as reauth_err:  # pragma: no cover - defensive
                         _LOGGER.debug(

--- a/custom_components/googlefindmy/coordinator/locate.py
+++ b/custom_components/googlefindmy/coordinator/locate.py
@@ -600,7 +600,19 @@ class LocateOperations(_MixinBase):
             return False
         try:
             ok, request_uuid = await self.api.async_play_sound(device_id)
-            if ok and request_uuid is not None:
+            # Store the cancel key whenever the device may be ringing:
+            # api.async_play_sound returns a non-None UUID in exactly the two cases
+            # where a ring may be active and Stop needs the key, (1) the server
+            # accepted the command (HTTP 200, ok=True) or (2) post-dispatch
+            # ambiguity, a network failure at/after the request reached the wire
+            # (server disconnect, read timeout; ok=False but the play may have
+            # started). It returns None for every failure that provably never rang
+            # (pre-dispatch/connection-setup failure OR an explicit server rejection
+            # such as 401/403/5xx). That invariant is what makes "store every
+            # non-null UUID" safe: a non-None key may have started a ring that Stop
+            # must cancel, while a None must NOT overwrite a previous, possibly
+            # still-ringing play's key. See IRR-CA-CANCEL-KEY-ON-SUCCESS-ONLY.
+            if request_uuid is not None:
                 self._sound_request_uuids[device_id] = request_uuid
                 # Use getattr for test compatibility (tests may bypass __init__)
                 timestamps = getattr(self, "_sound_request_timestamps", None)

--- a/custom_components/googlefindmy/coordinator/locate.py
+++ b/custom_components/googlefindmy/coordinator/locate.py
@@ -34,6 +34,7 @@ from ..NovaApi.nova_request import (
 )
 from ..SpotApi.spot_request import SpotAuthPermanentError
 from ._mixin_typing import _MixinBase
+from .helpers.cache import SOUND_UUID_MAX_AGE_S, is_sound_uuid_expired
 from .helpers.geo import MIN_PHYSICAL_ACCURACY_M
 
 _LOGGER = logging.getLogger(__name__)
@@ -583,6 +584,24 @@ class LocateOperations(_MixinBase):
                 # Push an update so buttons/entities can refresh availability
                 self.async_set_updated_data(self.data)
 
+    def _cached_sound_uuid_is_stale(self, device_id: str) -> bool:
+        """Return True if the device's cached Play Sound UUID has aged out.
+
+        Mirrors the load-path expiry (#108) so the store-path overwrite guard
+        and the Stop read-path agree with the reload filter on what "stale"
+        means. A key with no tracked timestamp (e.g. tests that bypass
+        ``__init__``, or pre-tracking entries) is treated as fresh here: only a
+        present, genuinely aged timestamp marks the key stale, so a known-good
+        cancel key is never dropped on incomplete state.
+        """
+        timestamps = getattr(self, "_sound_request_timestamps", None)
+        if timestamps is None:
+            return False
+        existing_ts = timestamps.get(device_id)
+        if existing_ts is None:
+            return False
+        return is_sound_uuid_expired(existing_ts, time.time(), SOUND_UUID_MAX_AGE_S)
+
     async def async_play_sound(self, device_id: str) -> bool:
         """Play sound on a device using the native async API (no executor).
 
@@ -606,19 +625,32 @@ class LocateOperations(_MixinBase):
             return False
         try:
             ok, request_uuid = await self.api.async_play_sound(device_id)
-            # Store the cancel key whenever the device may be ringing:
-            # api.async_play_sound returns a non-None UUID in exactly the two cases
-            # where a ring may be active and Stop needs the key, (1) the server
-            # accepted the command (HTTP 200, ok=True) or (2) post-dispatch
-            # ambiguity, a network failure at/after the request reached the wire
-            # (server disconnect, read timeout; ok=False but the play may have
-            # started). It returns None for every failure that provably never rang
-            # (pre-dispatch/connection-setup failure OR an explicit server rejection
-            # such as 401/403/5xx). That invariant is what makes "store every
-            # non-null UUID" safe: a non-None key may have started a ring that Stop
-            # must cancel, while a None must NOT overwrite a previous, possibly
-            # still-ringing play's key. See IRR-CA-CANCEL-KEY-ON-SUCCESS-ONLY.
-            if request_uuid is not None:
+            # Decide whether to (over)write the cached Stop cancel key.
+            # api.async_play_sound returns a non-None UUID in exactly the two
+            # cases where a ring may be active and Stop needs the key: (1) the
+            # server accepted the command (HTTP 200, ok=True) or (2) post-dispatch
+            # ambiguity — a failure at/after the request reached the wire (server
+            # disconnect, read timeout, or a transient 5xx that may have been
+            # generated before Nova accepted the command; ok=False but the play
+            # may have started). It returns None for every failure that provably
+            # never rang (pre-dispatch/connection-setup failure OR an explicit
+            # rejection such as 401/403). Storing rule: overwrite only on an
+            # accepted command (ok=True) or when no key is cached yet. A merely
+            # ambiguous result (ok=False with a fresh UUID) must NOT clobber a
+            # known-good key for an earlier, possibly still-ringing play —
+            # otherwise the default Stop would cancel the wrong request. With no
+            # cached key — or one that has aged past SOUND_UUID_MAX_AGE_S, which
+            # the reload filter would discard — the ambiguous UUID is still
+            # stored, since it may be the only handle on a current ring. See
+            # IRR-CA-CANCEL-KEY-ON-SUCCESS-ONLY.
+            existing_uuid = self._sound_request_uuids.get(device_id)
+            existing_is_stale = (
+                existing_uuid is not None
+                and self._cached_sound_uuid_is_stale(device_id)
+            )
+            if request_uuid is not None and (
+                ok or existing_uuid is None or existing_is_stale
+            ):
                 self._sound_request_uuids[device_id] = request_uuid
                 # Use getattr for test compatibility (tests may bypass __init__)
                 timestamps = getattr(self, "_sound_request_timestamps", None)
@@ -688,7 +720,18 @@ class LocateOperations(_MixinBase):
             return False
         request_uuid_to_use = request_uuid
         if request_uuid_to_use is None:
-            request_uuid_to_use = self._sound_request_uuids.get(device_id)
+            cached_uuid = self._sound_request_uuids.get(device_id)
+            # An aged-out key is no better than no key: the ring it referenced
+            # auto-stopped long ago (the reload filter would discard it), so
+            # targeting it could miss a current ring. Treat it as absent.
+            if cached_uuid is not None and self._cached_sound_uuid_is_stale(
+                device_id
+            ):
+                _LOGGER.debug(
+                    "Ignoring expired cached Play Sound UUID for %s", device_id
+                )
+                cached_uuid = None
+            request_uuid_to_use = cached_uuid
             if request_uuid_to_use is not None:
                 _LOGGER.debug(
                     "Using cached Play Sound UUID for %s: %s",

--- a/custom_components/googlefindmy/coordinator/main.py
+++ b/custom_components/googlefindmy/coordinator/main.py
@@ -69,12 +69,14 @@ from typing import TYPE_CHECKING, Any, Protocol, cast
 # Operations classes - currently empty mixins for future method extraction
 from .cache import CacheOperations
 from .helpers.cache import (
-    build_base_snapshot_entry as _build_base_snapshot_entry_impl,
-)
-from .helpers.cache import (
+    SOUND_UUID_MAX_AGE_S,
     determine_location_status,
     epoch_to_datetime_utc,
     is_presence_expired,
+    is_sound_uuid_expired,
+)
+from .helpers.cache import (
+    build_base_snapshot_entry as _build_base_snapshot_entry_impl,
 )
 from .helpers.cache import (
     sanitize_decoder_row as _sanitize_decoder_row,
@@ -223,9 +225,6 @@ _MAX_TRANSIENT_AUTH_FAILURES = 3
 # Guardrails for owner-driven locate cooldown
 _COOLDOWN_OWNER_MIN_S = 60  # at least 1 minute
 _COOLDOWN_OWNER_MAX_S = 15 * 60  # at most 15 minutes
-
-# Sound UUID expiry after restart (prevents phantom re-triggers)
-_SOUND_UUID_MAX_AGE_S = 30 * 60  # 30 minutes
 
 # Minimum position change (meters) to accept location update without timestamp
 _LOCATION_SIGNIFICANT_CHANGE_M = 50.0
@@ -1547,8 +1546,8 @@ class GoogleFindMyCoordinator(
                 return
 
             # FIX: Filter out stale UUIDs to prevent Play Sound re-trigger after restart (#108)
-            # Sound requests older than _SOUND_UUID_MAX_AGE_S are considered expired
-            max_age_seconds = _SOUND_UUID_MAX_AGE_S
+            # Sound requests older than SOUND_UUID_MAX_AGE_S are considered expired
+            max_age_seconds = SOUND_UUID_MAX_AGE_S
             now = time.time()
             loaded_sound_request_uuids: dict[str, str] = {}
             loaded_sound_request_timestamps: dict[str, float] = {}
@@ -1564,7 +1563,7 @@ class GoogleFindMyCoordinator(
                     if not isinstance(uuid_val, str) or not uuid_val:
                         continue
                     # Discard if older than max_age_seconds
-                    if now - float(ts_val) > max_age_seconds:
+                    if is_sound_uuid_expired(ts_val, now, max_age_seconds):
                         _LOGGER.debug(
                             "Discarding expired Play Sound UUID for %s (age: %.0fs)",
                             device_id,

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -48,7 +48,7 @@ from homeassistant.helpers.update_coordinator import UpdateFailed
 from ..const import (
     DEVICE_LIST_POLL_INTERVAL,
     DOMAIN,
-    LOCATION_REQUEST_TIMEOUT_S,
+    POLL_DEVICE_OUTER_TIMEOUT_S,
 )
 from ..NovaApi.nova_request import NovaAuthError, NovaAuthPermanentError
 from ..SpotApi.GetEidInfoForE2eeDevices.get_eid_info_request import (
@@ -178,6 +178,37 @@ class PollingOperations(_MixinBase):
     def is_fcm_connected(self) -> bool:
         """Convenience boolean for entities relying on push transport availability."""
         return self._fcm_status_state == FcmStatus.CONNECTED
+
+    def _log_idle_poll_diagnostics(
+        self, dev_id: str, dev_name: str, *, source: str
+    ) -> None:
+        """Emit a single DEBUG line per device per cycle to tell an expected
+        idle poll (no reporter in range to relay a BLE tag's location) apart
+        from a possible FCM transport fault.
+
+        Only rendered at DEBUG level, so this stays silent during normal
+        operation and adds no WARNING/INFO noise. ``source`` distinguishes the
+        inner empty result from the outer poll-guard timeout.
+        """
+        if not _LOGGER.isEnabledFor(logging.DEBUG):
+            return
+        now = time.time()
+        cached = self._device_location_data.get(dev_id) or {}
+        last_seen = cached.get("last_seen")
+        try:
+            report_age = f"{now - float(last_seen):.0f}s" if last_seen else "never"
+        except (TypeError, ValueError):
+            report_age = "unknown"
+        changed_at = self._fcm_status_changed_at
+        fcm_age = f"{now - changed_at:.0f}s" if changed_at else "unknown"
+        _LOGGER.debug(
+            "Idle poll for %s (%s): last report %s ago, FCM status %s for %s",
+            dev_name,
+            source,
+            report_age,
+            self._fcm_status_state,
+            fcm_age,
+        )
 
     @property
     def consecutive_timeouts(self) -> int:
@@ -1106,10 +1137,16 @@ class PollingOperations(_MixinBase):
                     )
 
                     try:
-                        # Protect API awaitable with timeout
+                        # Protect API awaitable with an outer guard that is
+                        # strictly larger than the inner FCM wait
+                        # (LOCATION_REQUEST_TIMEOUT_S, see
+                        # NovaApi/.../location_request.py). Equal nested budgets
+                        # make this outer guard win the race and raise a spurious
+                        # TimeoutError before the inner request can return its
+                        # clean empty result (Nygard: stagger nested timeouts).
                         location = await asyncio.wait_for(
                             self.api.async_get_device_location(dev_id, dev_name),
-                            timeout=LOCATION_REQUEST_TIMEOUT_S,
+                            timeout=POLL_DEVICE_OUTER_TIMEOUT_S,
                         )
 
                         # Success path: ensure any previous auth error is cleared
@@ -1124,8 +1161,15 @@ class PollingOperations(_MixinBase):
                             self._last_transient_auth_error = None
 
                         if not location:
-                            _LOGGER.warning(
+                            # Expected for BLE tags with no reporter nearby: the
+                            # inner FCM wait returns an empty result rather than
+                            # raising. This is a healthy idle outcome, not a fault
+                            # (kept at INFO, symmetric with the timeout branch).
+                            _LOGGER.info(
                                 "No location data returned for %s", dev_name
+                            )
+                            self._log_idle_poll_diagnostics(
+                                dev_id, dev_name, source="empty-result"
                             )
                             continue
 
@@ -1336,12 +1380,15 @@ class PollingOperations(_MixinBase):
                                 "Poll timed out for %s (FCM connected); ignoring error to keep status healthy.",
                                 dev_name,
                             )
+                            self._log_idle_poll_diagnostics(
+                                dev_id, dev_name, source="outer-timeout"
+                            )
                             self.increment_stat("timeouts")
                         else:
                             _LOGGER.info(
                                 "Location request timed out for %s after %s seconds",
                                 dev_name,
-                                LOCATION_REQUEST_TIMEOUT_S,
+                                POLL_DEVICE_OUTER_TIMEOUT_S,
                             )
                             self.increment_stat("timeouts")
                             self._consecutive_timeouts += 1

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -45,6 +45,7 @@ from homeassistant.core import Event
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
+from ..Auth.fcm_receiver_ha import CRASH_LOOP_FATAL_PREFIX
 from ..const import (
     DEVICE_LIST_POLL_INTERVAL,
     DOMAIN,
@@ -79,6 +80,43 @@ from .helpers.update import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+# Iter-14 (Codex follow-up): re-auth-escalation classification SSOT.
+# The FCM receiver's ``_fatal_errors`` map is a shared channel: it carries
+# both classic auth fatals (401/404 with credentials issues, raise
+# ``ConfigEntryAuthFailed`` immediately or after _FCM_ERROR_RETRY_THRESHOLD
+# cycles) and supervisor-level "short-run crash loop" fatals (poison
+# message defense; user must reload / regenerate credentials per the
+# repair issue, NOT re-authenticate). Without this classification the
+# crash-loop fatal would be reclassified as an auth fatal after 3 cycles
+# and push users into HA's re-auth flow. Keep this as a free function so
+# branch-coverage tests can pin the classification contract without
+# spinning up the full update coroutine.
+_FCM_FATAL_CLASS_CRASH_LOOP_EXCLUDED = "crash_loop_excluded"
+_FCM_FATAL_CLASS_AUTH_IMMEDIATE = "auth_immediate"
+_FCM_FATAL_CLASS_AUTH_AFTER_THRESHOLD = "auth_after_threshold"
+
+
+def _classify_fcm_fatal(fatal_error: str) -> str:
+    """Classify a non-empty FCM fatal error for the re-auth escalation.
+
+    Returns one of:
+      - ``_FCM_FATAL_CLASS_CRASH_LOOP_EXCLUDED``: supervisor-level
+        short-run cap; excluded from re-auth (repair issue carries the
+        user-visible guidance).
+      - ``_FCM_FATAL_CLASS_AUTH_IMMEDIATE``: classic auth fatal that
+        should raise ``ConfigEntryAuthFailed`` immediately.
+      - ``_FCM_FATAL_CLASS_AUTH_AFTER_THRESHOLD``: unclassified non-cap
+        fatal; count and escalate after _FCM_ERROR_RETRY_THRESHOLD
+        consecutive update cycles.
+    """
+    if fatal_error.startswith(CRASH_LOOP_FATAL_PREFIX):
+        return _FCM_FATAL_CLASS_CRASH_LOOP_EXCLUDED
+    if _is_fatal_fcm_auth_error_impl(fatal_error):
+        return _FCM_FATAL_CLASS_AUTH_IMMEDIATE
+    return _FCM_FATAL_CLASS_AUTH_AFTER_THRESHOLD
+
 
 # Cooldown constants for crowdsourced reports
 _COOLDOWN_MIN_IN_ALL_AREAS_S = 10 * 60  # 10 minutes
@@ -118,6 +156,7 @@ class PollingOperations(_MixinBase):
     _fcm_status_changed_at: float | None
     _force_device_list_reason: str | None
     _short_retry_cancel: Callable[[], None] | None
+    _fcm_error_count: int
     _fcm_last_error: str | None
     _last_transient_auth_error: str | None
     _is_polling: bool
@@ -607,43 +646,65 @@ class PollingOperations(_MixinBase):
                     fatal_error = fatal_by_entry.get(entry_id)
 
             if isinstance(fatal_error, str) and fatal_error:
-                # Check if this is a fatal auth error that should fail immediately
-                # (e.g., 404/401 with credentials issues - no point retrying)
-                is_fatal_auth = _is_fatal_fcm_auth_error_impl(fatal_error)
+                # Iter-14 (Codex follow-up, channel-confusion): the FCM
+                # receiver's supervisor-level "short-run crash loop" cap
+                # publishes its terminal state into the SAME ``_fatal_errors``
+                # map this re-auth escalation consumes. That defense is a
+                # poison-message bulkhead (the user has to reload or
+                # regenerate credentials per the repair issue, NOT
+                # re-authenticate). Classify the fatal first so a cap-fired
+                # listener-lifecycle fatal does not get reclassified as an
+                # auth fatal after _FCM_ERROR_RETRY_THRESHOLD cycles and
+                # push users into Home Assistant's re-auth flow.
+                fatal_class = _classify_fcm_fatal(fatal_error)
 
-                if is_fatal_auth:
-                    # Fatal auth errors - fail immediately, no retry
-                    _LOGGER.error(
-                        "Fatal FCM authentication error: %s. Triggering re-authentication.",
-                        fatal_error,
-                    )
-                    self._set_auth_state(failed=True, reason=fatal_error)
-                    raise ConfigEntryAuthFailed(fatal_error)
-
-                # Track consecutive FCM errors for transient issues
-                if fatal_error != self._fcm_last_error:
-                    # New error type, reset counter
-                    self._fcm_error_count = 1
-                    self._fcm_last_error = fatal_error
+                if fatal_class == _FCM_FATAL_CLASS_CRASH_LOOP_EXCLUDED:
+                    # Reset any partial auth-error count so a later,
+                    # unrelated auth fatal starts from zero rather than
+                    # inheriting a stale count from the crash-loop window.
+                    if self._fcm_error_count > 0:
+                        _LOGGER.debug(
+                            "FCM crash-loop fatal observed; resetting auth-"
+                            "error counter (was %d). Repair issue surfaces "
+                            "guidance, no re-auth.",
+                            self._fcm_error_count,
+                        )
+                        self._fcm_error_count = 0
+                        self._fcm_last_error = None
                 else:
-                    self._fcm_error_count += 1
+                    if fatal_class == _FCM_FATAL_CLASS_AUTH_IMMEDIATE:
+                        # Fatal auth errors - fail immediately, no retry
+                        _LOGGER.error(
+                            "Fatal FCM authentication error: %s. Triggering re-authentication.",
+                            fatal_error,
+                        )
+                        self._set_auth_state(failed=True, reason=fatal_error)
+                        raise ConfigEntryAuthFailed(fatal_error)
 
-                # Only trigger re-auth after _FCM_ERROR_RETRY_THRESHOLD consecutive failures
-                if self._fcm_error_count >= _FCM_ERROR_RETRY_THRESHOLD:
-                    _LOGGER.error(
-                        "FCM error persisted after %d attempts: %s. Triggering re-authentication.",
-                        self._fcm_error_count,
-                        fatal_error,
-                    )
-                    self._set_auth_state(failed=True, reason=fatal_error)
-                    raise ConfigEntryAuthFailed(fatal_error)
-                else:
-                    _LOGGER.warning(
-                        "FCM error detected (%d/%d): %s. Will retry before triggering re-auth.",
-                        self._fcm_error_count,
-                        _FCM_ERROR_RETRY_THRESHOLD,
-                        fatal_error,
-                    )
+                    # Track consecutive FCM errors for transient issues
+                    if fatal_error != self._fcm_last_error:
+                        # New error type, reset counter
+                        self._fcm_error_count = 1
+                        self._fcm_last_error = fatal_error
+                    else:
+                        self._fcm_error_count += 1
+
+                    # Only trigger re-auth after _FCM_ERROR_RETRY_THRESHOLD consecutive failures
+                    if self._fcm_error_count >= _FCM_ERROR_RETRY_THRESHOLD:
+                        _LOGGER.error(
+                            "FCM error persisted after %d attempts: %s. Triggering re-authentication.",
+                            self._fcm_error_count,
+                            fatal_error,
+                        )
+                        self._set_auth_state(failed=True, reason=fatal_error)
+                        raise ConfigEntryAuthFailed(fatal_error)
+                    else:
+                        _LOGGER.warning(
+                            "FCM error detected (%d/%d): %s. Will retry before triggering re-auth.",
+                            self._fcm_error_count,
+                            _FCM_ERROR_RETRY_THRESHOLD,
+                            fatal_error,
+                        )
             # No error - reset counter on successful check
             elif self._fcm_error_count > 0:
                 _LOGGER.debug(

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -1332,7 +1332,7 @@ class PollingOperations(_MixinBase):
 
                     except TimeoutError as terr:
                         if self.is_fcm_connected:
-                            _LOGGER.warning(
+                            _LOGGER.info(
                                 "Poll timed out for %s (FCM connected); ignoring error to keep status healthy.",
                                 dev_name,
                             )

--- a/custom_components/googlefindmy/fmdn_finder/google_uploader.py
+++ b/custom_components/googlefindmy/fmdn_finder/google_uploader.py
@@ -15,7 +15,7 @@ This limitation was confirmed by the GoogleFindMyTools maintainer:
     "uploading finder reports requires a valid DroidGuard report.
      If you want, you can try to trick DroidGuard, but I was not successful doing so."
 
-    — Leon Böttger, https://github.com/leonboe1/GoogleFindMyTools/issues/19
+    — Leon Boettger, https://github.com/leonboe1/GoogleFindMyTools/issues/19
 
 TECHNICAL DETAILS
 ============================================================================

--- a/custom_components/googlefindmy/fmdn_finder/google_uploader.py
+++ b/custom_components/googlefindmy/fmdn_finder/google_uploader.py
@@ -265,7 +265,10 @@ async def _try_grpc_upload(
         RuntimeError: If grpclib not available
         ValueError: If upload fails
     """
-    from ..SpotApi.spot_grpc_transport import SpotGrpcTransport  # noqa: PLC0415
+    from ..SpotApi.spot_grpc_transport import (  # noqa: PLC0415
+        SpotGrpcTransport,
+        is_ssl_transport_teardown_error,
+    )
     from ..SpotApi.spot_request import (  # noqa: PLC0415
         SpotGrpcStatusError,
         _pick_auth_token_async,
@@ -304,6 +307,19 @@ async def _try_grpc_upload(
         # UNIMPLEMENTED likely means missing attestation, not wrong endpoint
         raise SpotGrpcStatusError(
             f"gRPC error: {status_name} (likely missing DroidGuard attestation)"
+        ) from err
+
+    except AttributeError as err:
+        # AP9 (finding 6a): same asyncio SSL-transport teardown race as
+        # async_spot_request. This is a per-call transport with no retry loop
+        # (and the upload path is disabled without DroidGuard attestation), so
+        # classify it like the other connection failures instead of letting the
+        # raw AttributeError escape. Any other AttributeError is a real bug and
+        # is re-raised.
+        if not is_ssl_transport_teardown_error(err):
+            raise
+        raise ValueError(
+            f"Connection to {server} failed (SSL transport teardown): {err}"
         ) from err
 
     except (OSError, ConnectionError, TimeoutError) as err:

--- a/custom_components/googlefindmy/manifest.json
+++ b/custom_components/googlefindmy/manifest.json
@@ -35,5 +35,5 @@
     "selenium>=4.25.0",
     "undetected_chromedriver>=3.5.5"
   ],
-  "version": "1.7.0-6"
+  "version": "1.7.0-7"
 }

--- a/custom_components/googlefindmy/manifest.json
+++ b/custom_components/googlefindmy/manifest.json
@@ -35,5 +35,5 @@
     "selenium>=4.25.0",
     "undetected_chromedriver>=3.5.5"
   ],
-  "version": "1.7.0-7"
+  "version": "1.7.1"
 }

--- a/custom_components/googlefindmy/repairs.py
+++ b/custom_components/googlefindmy/repairs.py
@@ -1,0 +1,141 @@
+# custom_components/googlefindmy/repairs.py
+"""Repair flows for the Google Find My Device integration."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+from homeassistant.components.repairs import RepairsFlow
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResult
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class FcmReauthRepairFlow(RepairsFlow):  # type: ignore[misc]
+    """Guide the user from the fixable ``fcm_reauth_required`` issue into reauth.
+
+    The issue is raised at the FCM supervisor's terminal give-up points
+    (404/401 endpoint exhaustion and the registration backoff). Confirming the
+    repair starts Home Assistant's existing config-entry reauth flow, which
+    renews credentials while preserving the device identity.
+    """
+
+    def __init__(self, entry_id: str | None) -> None:
+        """Store the config entry id forwarded via the issue ``data`` payload."""
+        self._entry_id = entry_id
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Entry point: show the confirmation step."""
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Confirm the repair, launch reauth, and keep the issue open.
+
+        Confirming only *launches* the config-entry reauth flow; the stored
+        credentials are not renewed yet at this point. Returning
+        ``async_create_entry`` would make Home Assistant's repairs manager
+        delete the issue immediately -- only a non-``ABORT`` result triggers the
+        delete (see ``homeassistant.components.repairs.issue_handler``). That is
+        unsafe in the *normal* case: the supervisor reaches this repair at its
+        *terminal* give-up points, and the 401/404 exhaustion paths ``break``
+        out of the loop, so the supervisor will not re-raise the issue on its
+        own. If the user then cancels or fails the reauth flow, both this issue
+        and the core ``config_entry_reauth`` issue (removed by
+        ``async_flow_removed``) would vanish, stranding the account with no
+        guidance.
+
+        Returning ``async_abort`` keeps the issue. Its real resolution is owned
+        by the supervisor's success path, which deletes
+        ``fcm_reauth_required_{entry_id}`` on the next successful FCM
+        (re-)registration once reauth has renewed credentials and reloaded the
+        entry (see ``Auth/fcm_receiver_ha.py``).
+
+        The keep-open contract only holds while a supervisor can still run for
+        this entry. When the repair is *stale* -- the entry id is missing, or
+        the config entry has already been removed -- no supervisor exists to
+        ever clear this entry-scoped issue, and reauth can never start. In that
+        case ``_async_start_reauth`` reports failure and we deliberately return
+        ``async_create_entry`` so the repairs manager dismisses the orphaned
+        issue instead of leaving an unfixable repair pinned in the UI.
+        """
+        if user_input is not None:
+            if self._async_start_reauth():
+                return self.async_abort(reason="reauth_started")
+            return self.async_create_entry(data={})
+
+        return self.async_show_form(
+            step_id="confirm", data_schema=vol.Schema({})
+        )
+
+    def _async_start_reauth(self) -> bool:
+        """Start the config-entry reauth flow, defensively.
+
+        ``ConfigEntry.async_start_reauth`` is a synchronous ``@callback`` that
+        returns ``None``: it schedules the reauth flow itself, or no-ops when a
+        reauth/reconfigure flow is already active for the entry (idempotent).
+        It must therefore be called without ``await`` -- awaiting its ``None``
+        result would raise ``TypeError`` on every confirmation, which the broad
+        guard below would then swallow while the issue is still dismissed.
+
+        ``entry_id`` is used solely as a config-entry registry lookup key; it is
+        never interpreted as a path or executable input.
+
+        Returns ``True`` when the fixable issue must stay open: either reauth
+        was launched, or it failed transiently for an entry that still exists
+        (the user can retry and the supervisor success path can still clear the
+        issue). Returns ``False`` when the repair is *stale* -- a missing entry
+        id or an already removed config entry -- so the caller dismisses the now
+        unfixable issue instead of pinning it open forever.
+        """
+        if not self._entry_id:
+            _LOGGER.warning(
+                "fcm_reauth_required repair confirmed without an entry_id; "
+                "dismissing stale issue"
+            )
+            return False
+
+        entry = self.hass.config_entries.async_get_entry(self._entry_id)
+        if entry is None:
+            _LOGGER.warning(
+                "fcm_reauth_required repair confirmed but config entry %s is "
+                "gone; dismissing stale issue",
+                self._entry_id,
+            )
+            return False
+
+        try:
+            entry.async_start_reauth(self.hass)
+        except Exception as err:  # noqa: BLE001 - defensive: keep the repair UI robust
+            _LOGGER.error(
+                "Failed to start reauth flow from repair for entry %s: %s",
+                self._entry_id,
+                err,
+            )
+            # The entry still exists, so the issue is not stale: keep it open so
+            # the user can retry and the supervisor can still resolve it.
+            return True
+
+        return True
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict[str, str | int | float | None] | None,
+) -> RepairsFlow:
+    """Create the fix flow for a fixable Google Find My Device issue.
+
+    Currently every fixable issue (``fcm_reauth_required_{entry_id}``) maps to
+    the reauth repair. The affected entry id is read from the issue ``data``
+    payload set by ``_async_raise_reauth_issue`` in ``Auth/fcm_receiver_ha.py``.
+    """
+    entry_id_raw = (data or {}).get("entry_id")
+    entry_id = entry_id_raw if isinstance(entry_id_raw, str) else None
+    return FcmReauthRepairFlow(entry_id)

--- a/custom_components/googlefindmy/sensor.py
+++ b/custom_components/googlefindmy/sensor.py
@@ -26,7 +26,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE
+from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE, PERCENTAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
@@ -1043,6 +1043,13 @@ class GoogleFindMyLastSeenSensor(GoogleFindMyDeviceEntity, RestoreSensor):
         - Adds a normalized UTC timestamp mirror (`last_seen_utc`).
         - Uses `accuracy_m` (float meters) rather than `gps_accuracy` for stability.
         - Includes source labeling (`source_label`/`source_rank`) for transparency.
+
+        Map-marker self-heal: `latitude`/`longitude` are stripped here, at the
+        consumer, because the shared helper is also used by the device_tracker,
+        which legitimately carries coordinates. The map marker is a live-state
+        attribute (not a registry entry), so once this property stops emitting the
+        pair, HA drops the spurious marker on the next state write after upgrade.
+        No entity deletion, registry migration, or reconfigure is required.
         """
         dev_id = self._device_id
         if not dev_id:
@@ -1050,7 +1057,18 @@ class GoogleFindMyLastSeenSensor(GoogleFindMyDeviceEntity, RestoreSensor):
         row = self.coordinator.get_device_location_data_for_subentry(
             self.subentry_key, dev_id
         )
-        return _as_ha_attributes(row) if row else None
+        attrs = _as_ha_attributes(row) if row else None
+        if not attrs:
+            return None
+        # Defensive copy: the shared helper output is also consumed by the
+        # device_tracker (which legitimately carries coordinates); never mutate it.
+        attrs = dict(attrs)
+        # A TIMESTAMP sensor must not advertise map coordinates, otherwise HA
+        # plots it as a third, spurious marker. Strip via the HA constants the
+        # device_tracker already uses (not string literals).
+        attrs.pop(ATTR_LATITUDE, None)
+        attrs.pop(ATTR_LONGITUDE, None)
+        return attrs
 
     @property
     def available(self) -> bool:

--- a/custom_components/googlefindmy/strings.json
+++ b/custom_components/googlefindmy/strings.json
@@ -718,6 +718,10 @@
     "fcm_short_run_crash_loop": {
       "title": "FCM Push Crash Loop Detected",
       "description": "The FCM push client repeatedly disconnects within seconds of connecting (short-run crash loop). This is most often caused by a persistent poison notification on the inbound queue that cannot be decoded.\n\n1. Reload the integration to clear the run state.\n2. If the issue returns, regenerate your `secrets.json` (Google may have rotated credentials)."
+    },
+    "restart_required": {
+      "title": "Restart Home Assistant to finish the update",
+      "description": "Google Find My Hub was updated on disk to version {installed_version}, but Home Assistant is still running version {running_version}. Restart Home Assistant to activate the installed version.\n\nReloading the integration is not enough: a full Home Assistant restart is required."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/strings.json
+++ b/custom_components/googlefindmy/strings.json
@@ -699,6 +699,20 @@
       "title": "FCM Push Connection Failed",
       "description": "The background connection to Google is blocked.\n\n1. Is outgoing **TCP Port 5228** allowed in your firewall?\n2. If network is fine, try regenerating your `secrets.json` (credentials might be split/revoked)."
     },
+    "fcm_reauth_required": {
+      "title": "Google Find My Device push needs re-authentication",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Google Find My Device",
+            "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
+          }
+        },
+        "abort": {
+          "reauth_started": "Re-authentication has been started. Finish signing in to restore the background push connection. This repair stays open until the connection recovers, so the prompt is not lost if the sign-in is interrupted."
+        }
+      }
+    },
     "multiple_config_entries": {
       "title": "Multiple configuration entries detected",
       "description": "Google Find My Device now supports multiple configuration entries, one per Google account. If each entry targets a different account, no action is required. When the same account is added twice, Home Assistant creates a **Duplicate account entries** repair issue for the new entry so you can remove or re-enable the correct one."

--- a/custom_components/googlefindmy/strings.json
+++ b/custom_components/googlefindmy/strings.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "FCM Push Crash Loop Detected",
+      "description": "The FCM push client repeatedly disconnects within seconds of connecting (short-run crash loop). This is most often caused by a persistent poison notification on the inbound queue that cannot be decoded.\n\n1. Reload the integration to clear the run state.\n2. If the issue returns, regenerate your `secrets.json` (Google may have rotated credentials)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -699,6 +699,20 @@
       "title": "FCM Push-Verbindung fehlgeschlagen",
       "description": "Die Hintergrundverbindung zu Google ist blockiert.\n\n1. Ist der ausgehende **TCP Port 5228** in Ihrer Firewall freigegeben?\n2. Falls das Netzwerk okay ist: Erneuern Sie bitte Ihre `secrets.json` (Token könnte teilweise ungültig sein)."
     },
+    "fcm_reauth_required": {
+      "title": "Google Find My Device push needs re-authentication",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Google Find My Device",
+            "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
+          }
+        },
+        "abort": {
+          "reauth_started": "Re-authentication has been started. Finish signing in to restore the background push connection. This repair stays open until the connection recovers, so the prompt is not lost if the sign-in is interrupted."
+        }
+      }
+    },
     "multiple_config_entries": {
       "title": "Mehrere Konfigurationseinträge erkannt",
       "description": "Google Find My Device unterstützt jetzt mehrere Konfigurationseinträge – jeweils einen pro Google-Konto. Wenn jede Instanz ein anderes Konto nutzt, ist keine Aktion erforderlich. Wird dasselbe Konto zweimal hinzugefügt, erstellt Home Assistant für den neuen Eintrag die Reparaturmeldung **Doppelte Kontoeinträge**, damit du den richtigen Eintrag entfernen oder wieder aktivieren kannst."

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -718,6 +718,10 @@
     "fcm_short_run_crash_loop": {
       "title": "FCM-Push-Abbruchschleife erkannt",
       "description": "Der FCM-Push-Client trennt die Verbindung wiederholt innerhalb weniger Sekunden nach dem Verbindungsaufbau (Short-Run-Crash-Schleife). Üblicherweise wird das durch eine persistente, nicht dekodierbare Push-Nachricht in der eingehenden Warteschlange ausgelöst.\n\n1. Laden Sie die Integration neu, um den Laufzustand zurückzusetzen.\n2. Falls das Problem erneut auftritt: Erneuern Sie Ihre `secrets.json` (Google könnte Anmeldedaten rotiert haben)."
+    },
+    "restart_required": {
+      "title": "Neustart von Home Assistant zum Abschluss des Updates erforderlich",
+      "description": "Google Find My Hub wurde auf der Festplatte auf Version {installed_version} aktualisiert, aber Home Assistant führt weiterhin Version {running_version} aus. Starten Sie Home Assistant neu, um die installierte Version zu aktivieren.\n\nEin Neuladen der Integration genügt nicht: Ein vollständiger Neustart von Home Assistant ist erforderlich."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "FCM-Push-Abbruchschleife erkannt",
+      "description": "Der FCM-Push-Client trennt die Verbindung wiederholt innerhalb weniger Sekunden nach dem Verbindungsaufbau (Short-Run-Crash-Schleife). Üblicherweise wird das durch eine persistente, nicht dekodierbare Push-Nachricht in der eingehenden Warteschlange ausgelöst.\n\n1. Laden Sie die Integration neu, um den Laufzustand zurückzusetzen.\n2. Falls das Problem erneut auftritt: Erneuern Sie Ihre `secrets.json` (Google könnte Anmeldedaten rotiert haben)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -718,6 +718,10 @@
     "fcm_short_run_crash_loop": {
       "title": "FCM Push Crash Loop Detected",
       "description": "The FCM push client repeatedly disconnects within seconds of connecting (short-run crash loop). This is most often caused by a persistent poison notification on the inbound queue that cannot be decoded.\n\n1. Reload the integration to clear the run state.\n2. If the issue returns, regenerate your `secrets.json` (Google may have rotated credentials)."
+    },
+    "restart_required": {
+      "title": "Restart Home Assistant to finish the update",
+      "description": "Google Find My Hub was updated on disk to version {installed_version}, but Home Assistant is still running version {running_version}. Restart Home Assistant to activate the installed version.\n\nReloading the integration is not enough: a full Home Assistant restart is required."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -699,6 +699,20 @@
       "title": "FCM Push Connection Failed",
       "description": "The background connection to Google is blocked.\n\n1. Is outgoing **TCP Port 5228** allowed in your firewall?\n2. If network is fine, try regenerating your `secrets.json` (credentials might be split/revoked)."
     },
+    "fcm_reauth_required": {
+      "title": "Google Find My Device push needs re-authentication",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Google Find My Device",
+            "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
+          }
+        },
+        "abort": {
+          "reauth_started": "Re-authentication has been started. Finish signing in to restore the background push connection. This repair stays open until the connection recovers, so the prompt is not lost if the sign-in is interrupted."
+        }
+      }
+    },
     "multiple_config_entries": {
       "title": "Multiple configuration entries detected",
       "description": "Google Find My Device now supports multiple configuration entries, one per Google account. If each entry targets a different account, no action is required. When the same account is added twice, Home Assistant creates a **Duplicate account entries** repair issue for the new entry so you can remove or re-enable the correct one."

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "FCM Push Crash Loop Detected",
+      "description": "The FCM push client repeatedly disconnects within seconds of connecting (short-run crash loop). This is most often caused by a persistent poison notification on the inbound queue that cannot be decoded.\n\n1. Reload the integration to clear the run state.\n2. If the issue returns, regenerate your `secrets.json` (Google may have rotated credentials)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -699,6 +699,20 @@
       "title": "Conexión push de FCM fallida",
       "description": "La conexión en segundo plano con Google está bloqueada.\n\n1. ¿El **puerto TCP 5228** saliente está permitido en tu firewall?\n2. Si la red está bien, intenta regenerar tu `secrets.json` (las credenciales podrían estar divididas/revocadas)."
     },
+    "fcm_reauth_required": {
+      "title": "Google Find My Device push needs re-authentication",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Google Find My Device",
+            "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
+          }
+        },
+        "abort": {
+          "reauth_started": "Re-authentication has been started. Finish signing in to restore the background push connection. This repair stays open until the connection recovers, so the prompt is not lost if the sign-in is interrupted."
+        }
+      }
+    },
     "multiple_config_entries": {
       "title": "Se detectaron varias entradas de configuración",
       "description": "Google Find My Device ahora admite varias entradas de configuración, una por cuenta de Google. Si cada entrada usa una cuenta diferente, no es necesario hacer nada. Cuando se añade la misma cuenta dos veces, Home Assistant crea una reparación **Entradas de cuenta duplicadas** para el nuevo registro y que así puedas retirar o reactivar el correcto."

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "Bucle de fallos de FCM Push detectado",
+      "description": "El cliente push de FCM se desconecta repetidamente a los pocos segundos de conectarse (bucle de fallos cortos). Esto suele estar causado por una notificación corrupta persistente en la cola entrante que no se puede decodificar.\n\n1. Recarga la integración para limpiar el estado de ejecución.\n2. Si el problema vuelve, regenera tu `secrets.json` (Google podría haber rotado las credenciales)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -718,6 +718,10 @@
     "fcm_short_run_crash_loop": {
       "title": "Bucle de fallos de FCM Push detectado",
       "description": "El cliente push de FCM se desconecta repetidamente a los pocos segundos de conectarse (bucle de fallos cortos). Esto suele estar causado por una notificación corrupta persistente en la cola entrante que no se puede decodificar.\n\n1. Recarga la integración para limpiar el estado de ejecución.\n2. Si el problema vuelve, regenera tu `secrets.json` (Google podría haber rotado las credenciales)."
+    },
+    "restart_required": {
+      "title": "Reinicia Home Assistant para finalizar la actualización",
+      "description": "Google Find My Hub se actualizó en el disco a la versión {installed_version}, pero Home Assistant sigue ejecutando la versión {running_version}. Reinicia Home Assistant para activar la versión instalada.\n\nRecargar la integración no es suficiente: se requiere un reinicio completo de Home Assistant."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -699,6 +699,20 @@
       "title": "Échec de la connexion push FCM",
       "description": "La connexion en arrière-plan vers Google est bloquée.\n\n1. Le **port TCP sortant 5228** est-il autorisé par votre pare-feu ?\n2. Si le réseau est correct, essayez de régénérer votre `secrets.json` (les identifiants peuvent être partiels/révoqués)."
     },
+    "fcm_reauth_required": {
+      "title": "Google Find My Device push needs re-authentication",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Google Find My Device",
+            "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
+          }
+        },
+        "abort": {
+          "reauth_started": "Re-authentication has been started. Finish signing in to restore the background push connection. This repair stays open until the connection recovers, so the prompt is not lost if the sign-in is interrupted."
+        }
+      }
+    },
     "multiple_config_entries": {
       "title": "Plusieurs entrées de configuration détectées",
       "description": "Google Find My Device prend désormais en charge plusieurs entrées de configuration, une par compte Google. Si chaque entrée cible un compte différent, aucune action n'est nécessaire. Lorsque le même compte est ajouté deux fois, Home Assistant crée une réparation **Entrées de compte en double** pour la nouvelle entrée afin que vous puissiez retirer ou réactiver la bonne."

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -718,6 +718,10 @@
     "fcm_short_run_crash_loop": {
       "title": "Boucle de plantage FCM Push détectée",
       "description": "Le client push FCM se déconnecte à plusieurs reprises quelques secondes après s’être connecté (boucle de plantage court). Cela est généralement causé par une notification persistante corrompue dans la file d’attente entrante qui ne peut pas être décodée.\n\n1. Rechargez l’intégration pour réinitialiser l’état d’exécution.\n2. Si le problème revient, régénérez votre `secrets.json` (Google peut avoir rotaté les identifiants)."
+    },
+    "restart_required": {
+      "title": "Redémarrez Home Assistant pour terminer la mise à jour",
+      "description": "Google Find My Hub a été mis à jour sur le disque vers la version {installed_version}, mais Home Assistant exécute toujours la version {running_version}. Redémarrez Home Assistant pour activer la version installée.\n\nRecharger l'intégration ne suffit pas : un redémarrage complet de Home Assistant est nécessaire."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "Boucle de plantage FCM Push détectée",
+      "description": "Le client push FCM se déconnecte à plusieurs reprises quelques secondes après s’être connecté (boucle de plantage court). Cela est généralement causé par une notification persistante corrompue dans la file d’attente entrante qui ne peut pas être décodée.\n\n1. Rechargez l’intégration pour réinitialiser l’état d’exécution.\n2. Si le problème revient, régénérez votre `secrets.json` (Google peut avoir rotaté les identifiants)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/he.json
+++ b/custom_components/googlefindmy/translations/he.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "לולאת קריסה של FCM Push זוהתה",
+      "description": "לקוח ה-FCM Push מתנתק שוב ושוב תוך שניות לאחר ההתחברות (לולאת קריסה קצרה). הסיבה השכיחה היא הודעה פגומה מתמשכת בתור הנכנס שלא ניתן לפענח.\n\n1. טען מחדש את האינטגרציה כדי לנקות את מצב הריצה.\n2. אם הבעיה חוזרת, חולל מחדש את `secrets.json` (ייתכן ש-Google סובב את האישורים)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/he.json
+++ b/custom_components/googlefindmy/translations/he.json
@@ -699,6 +699,20 @@
       "title": "חיבור Push FCM נכשל",
       "description": "החיבור הרקעי ל-Google חסום.\n\n1. האם **TCP Port 5228** יוצא מותר בחומת האש שלך?\n2. אם הרשת תקינה, יש לנסות ליצור מחדש את `secrets.json` (ייתכן שהאישורים פוצלו/בוטלו)."
     },
+    "fcm_reauth_required": {
+      "title": "Google Find My Device push needs re-authentication",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Google Find My Device",
+            "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
+          }
+        },
+        "abort": {
+          "reauth_started": "Re-authentication has been started. Finish signing in to restore the background push connection. This repair stays open until the connection recovers, so the prompt is not lost if the sign-in is interrupted."
+        }
+      }
+    },
     "multiple_config_entries": {
       "title": "אותרו מספר רשומות תצורה",
       "description": "Google Find My Device תומך כעת במספר רשומות תצורה, אחת לכל חשבון Google. אם כל רשומה מיועדת לחשבון אחר, אין צורך בפעולה. כאשר אותו חשבון נוסף פעמיים, Home Assistant יוצר בעיית תיקון **רשומות חשבון כפולות** עבור הרשומה החדשה כך שניתן להסיר או להפעיל מחדש את הנכונה."

--- a/custom_components/googlefindmy/translations/he.json
+++ b/custom_components/googlefindmy/translations/he.json
@@ -718,6 +718,10 @@
     "fcm_short_run_crash_loop": {
       "title": "לולאת קריסה של FCM Push זוהתה",
       "description": "לקוח ה-FCM Push מתנתק שוב ושוב תוך שניות לאחר ההתחברות (לולאת קריסה קצרה). הסיבה השכיחה היא הודעה פגומה מתמשכת בתור הנכנס שלא ניתן לפענח.\n\n1. טען מחדש את האינטגרציה כדי לנקות את מצב הריצה.\n2. אם הבעיה חוזרת, חולל מחדש את `secrets.json` (ייתכן ש-Google סובב את האישורים)."
+    },
+    "restart_required": {
+      "title": "הפעל מחדש את Home Assistant כדי להשלים את העדכון",
+      "description": "Google Find My Hub עודכן בדיסק לגרסה {installed_version}, אך Home Assistant עדיין מריץ את גרסה {running_version}. הפעל מחדש את Home Assistant כדי להפעיל את הגרסה המותקנת.\n\nטעינה מחדש של האינטגרציה אינה מספיקה: נדרשת הפעלה מחדש מלאה של Home Assistant."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -718,6 +718,10 @@
     "fcm_short_run_crash_loop": {
       "title": "Rilevato ciclo di crash di FCM Push",
       "description": "Il client push FCM si disconnette ripetutamente entro pochi secondi dalla connessione (ciclo di crash brevi). La causa più comune è una notifica persistente corrotta nella coda in arrivo che non può essere decodificata.\n\n1. Ricarica l’integrazione per ripristinare lo stato di esecuzione.\n2. Se il problema si ripresenta, rigenera il tuo `secrets.json` (Google potrebbe aver ruotato le credenziali)."
+    },
+    "restart_required": {
+      "title": "Riavvia Home Assistant per completare l'aggiornamento",
+      "description": "Google Find My Hub è stato aggiornato sul disco alla versione {installed_version}, ma Home Assistant sta ancora eseguendo la versione {running_version}. Riavvia Home Assistant per attivare la versione installata.\n\nRicaricare l'integrazione non è sufficiente: è necessario un riavvio completo di Home Assistant."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "Rilevato ciclo di crash di FCM Push",
+      "description": "Il client push FCM si disconnette ripetutamente entro pochi secondi dalla connessione (ciclo di crash brevi). La causa più comune è una notifica persistente corrotta nella coda in arrivo che non può essere decodificata.\n\n1. Ricarica l’integrazione per ripristinare lo stato di esecuzione.\n2. Se il problema si ripresenta, rigenera il tuo `secrets.json` (Google potrebbe aver ruotato le credenziali)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -699,6 +699,20 @@
       "title": "Connessione push FCM non riuscita",
       "description": "La connessione in background a Google è bloccata.\n\n1. Il **porta TCP 5228** in uscita è consentito dal firewall?\n2. Se la rete è a posto, prova a rigenerare il tuo `secrets.json` (le credenziali potrebbero essere parziali/revocate)."
     },
+    "fcm_reauth_required": {
+      "title": "Google Find My Device push needs re-authentication",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Google Find My Device",
+            "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
+          }
+        },
+        "abort": {
+          "reauth_started": "Re-authentication has been started. Finish signing in to restore the background push connection. This repair stays open until the connection recovers, so the prompt is not lost if the sign-in is interrupted."
+        }
+      }
+    },
     "multiple_config_entries": {
       "title": "Rilevate più voci di configurazione",
       "description": "Google Find My Device ora supporta più voci di configurazione, una per ogni account Google. Se ogni voce utilizza un account diverso, non è necessaria alcuna azione. Quando lo stesso account viene aggiunto due volte, Home Assistant crea una riparazione **Voci di account duplicate** per la nuova voce così da poter rimuovere o riattivare quella corretta."

--- a/custom_components/googlefindmy/translations/nl.json
+++ b/custom_components/googlefindmy/translations/nl.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "FCM Push crash-lus gedetecteerd",
+      "description": "De FCM push-client verbreekt herhaaldelijk binnen enkele seconden na het verbinden de verbinding (short-run crash-lus). Dit wordt meestal veroorzaakt door een aanhoudende beschadigde melding in de inkomende wachtrij die niet kan worden gedecodeerd.\n\n1. Laad de integratie opnieuw om de looptijdstatus te wissen.\n2. Als het probleem terugkeert, regenereer je `secrets.json` (Google kan de inloggegevens hebben gerouleerd)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/nl.json
+++ b/custom_components/googlefindmy/translations/nl.json
@@ -718,6 +718,10 @@
     "fcm_short_run_crash_loop": {
       "title": "FCM Push crash-lus gedetecteerd",
       "description": "De FCM push-client verbreekt herhaaldelijk binnen enkele seconden na het verbinden de verbinding (short-run crash-lus). Dit wordt meestal veroorzaakt door een aanhoudende beschadigde melding in de inkomende wachtrij die niet kan worden gedecodeerd.\n\n1. Laad de integratie opnieuw om de looptijdstatus te wissen.\n2. Als het probleem terugkeert, regenereer je `secrets.json` (Google kan de inloggegevens hebben gerouleerd)."
+    },
+    "restart_required": {
+      "title": "Start Home Assistant opnieuw op om de update te voltooien",
+      "description": "Google Find My Hub is op de schijf bijgewerkt naar versie {installed_version}, maar Home Assistant draait nog versie {running_version}. Start Home Assistant opnieuw op om de geïnstalleerde versie te activeren.\n\nDe integratie opnieuw laden is niet voldoende: een volledige herstart van Home Assistant is vereist."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/nl.json
+++ b/custom_components/googlefindmy/translations/nl.json
@@ -699,6 +699,20 @@
       "title": "FCM push-verbinding mislukt",
       "description": "De achtergrondverbinding met Google is geblokkeerd.\n\n1. Is uitgaande **TCP-poort 5228** toegestaan in je firewall?\n2. Als het netwerk in orde is, probeer dan je `secrets.json` opnieuw te genereren (inloggegevens zijn mogelijk gesplitst/ingetrokken)."
     },
+    "fcm_reauth_required": {
+      "title": "Google Find My Device push needs re-authentication",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Google Find My Device",
+            "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
+          }
+        },
+        "abort": {
+          "reauth_started": "Re-authentication has been started. Finish signing in to restore the background push connection. This repair stays open until the connection recovers, so the prompt is not lost if the sign-in is interrupted."
+        }
+      }
+    },
     "multiple_config_entries": {
       "title": "Meerdere configuratie-items gedetecteerd",
       "description": "Google Find My Device ondersteunt nu meerdere configuratie-items, één per Google-account. Als elk item een ander account target, is geen actie vereist. Wanneer hetzelfde account tweemaal wordt toegevoegd, maakt Home Assistant een reparatieprobleem **Dubbele accountitems** aan voor het nieuwe item, zodat je het juiste kunt verwijderen of opnieuw inschakelen."

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -718,6 +718,10 @@
     "fcm_short_run_crash_loop": {
       "title": "Wykryto pętlę awarii FCM Push",
       "description": "Klient push FCM wielokrotnie rozłącza się w ciągu kilku sekund od połączenia (pętla krótkich awarii). Najczęstszą przyczyną jest trwałe uszkodzone powiadomienie w kolejce przychodzącej, którego nie można zdekodować.\n\n1. Załaduj ponownie integrację, aby wyczyścić stan działania.\n2. Jeśli problem powraca, wygeneruj ponownie plik `secrets.json` (Google mógł zmienić dane uwierzytelniające)."
+    },
+    "restart_required": {
+      "title": "Uruchom ponownie Home Assistant, aby zakończyć aktualizację",
+      "description": "Google Find My Hub został zaktualizowany na dysku do wersji {installed_version}, ale Home Assistant nadal działa w wersji {running_version}. Uruchom ponownie Home Assistant, aby aktywować zainstalowaną wersję.\n\nPrzeładowanie integracji nie wystarczy: wymagane jest pełne ponowne uruchomienie Home Assistant."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "Wykryto pętlę awarii FCM Push",
+      "description": "Klient push FCM wielokrotnie rozłącza się w ciągu kilku sekund od połączenia (pętla krótkich awarii). Najczęstszą przyczyną jest trwałe uszkodzone powiadomienie w kolejce przychodzącej, którego nie można zdekodować.\n\n1. Załaduj ponownie integrację, aby wyczyścić stan działania.\n2. Jeśli problem powraca, wygeneruj ponownie plik `secrets.json` (Google mógł zmienić dane uwierzytelniające)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -699,6 +699,20 @@
       "title": "Połączenie push FCM nie powiodło się",
       "description": "Połączenie w tle z Google jest zablokowane.\n\n1. Czy wychodzący **port TCP 5228** jest dozwolony w zaporze?\n2. Jeśli sieć działa, spróbuj wygenerować ponownie plik `secrets.json` (poświadczenia mogły zostać częściowo cofnięte)."
     },
+    "fcm_reauth_required": {
+      "title": "Google Find My Device push needs re-authentication",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Google Find My Device",
+            "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
+          }
+        },
+        "abort": {
+          "reauth_started": "Re-authentication has been started. Finish signing in to restore the background push connection. This repair stays open until the connection recovers, so the prompt is not lost if the sign-in is interrupted."
+        }
+      }
+    },
     "multiple_config_entries": {
       "title": "Wykryto wiele wpisów konfiguracji",
       "description": "Google Find My Device obsługuje teraz wiele wpisów konfiguracji – po jednym na każde konto Google. Jeśli każdy wpis dotyczy innego konta, nie są wymagane żadne działania. Gdy to samo konto zostanie dodane dwukrotnie, Home Assistant tworzy naprawę **Zduplikowane wpisy kont** dla nowego wpisu, aby można było usunąć lub ponownie włączyć właściwy."

--- a/custom_components/googlefindmy/translations/pt-BR.json
+++ b/custom_components/googlefindmy/translations/pt-BR.json
@@ -699,6 +699,20 @@
       "title": "Falha na conexão push do FCM",
       "description": "A conexão em segundo plano com o Google está bloqueada.\n\n1. A saída pelo **porta TCP 5228** está liberada no firewall?\n2. Se a rede estiver ok, tente gerar novamente o seu `secrets.json` (as credenciais podem estar fragmentadas/revocadas)."
     },
+    "fcm_reauth_required": {
+      "title": "Google Find My Device push needs re-authentication",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Google Find My Device",
+            "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
+          }
+        },
+        "abort": {
+          "reauth_started": "Re-authentication has been started. Finish signing in to restore the background push connection. This repair stays open until the connection recovers, so the prompt is not lost if the sign-in is interrupted."
+        }
+      }
+    },
     "multiple_config_entries": {
       "title": "Várias entradas de configuração detectadas",
       "description": "O Google Find My Device agora oferece suporte a várias entradas de configuração, uma por conta do Google. Se cada entrada tiver como alvo uma conta diferente, nenhuma ação é necessária. Quando a mesma conta é adicionada duas vezes, o Home Assistant cria um problema de reparação **Entradas de conta duplicadas** para a nova entrada, para que você possa remover ou reativar a correta."

--- a/custom_components/googlefindmy/translations/pt-BR.json
+++ b/custom_components/googlefindmy/translations/pt-BR.json
@@ -718,6 +718,10 @@
     "fcm_short_run_crash_loop": {
       "title": "Detectado ciclo de falhas no FCM Push",
       "description": "O cliente push do FCM se desconecta repetidamente segundos após conectar (ciclo de falhas curtas). Geralmente isso é causado por uma notificação persistente corrompida na fila de entrada que não pode ser decodificada.\n\n1. Recarregue a integração para limpar o estado de execução.\n2. Se o problema voltar, regenere seu `secrets.json` (o Google pode ter rotacionado as credenciais)."
+    },
+    "restart_required": {
+      "title": "Reinicie o Home Assistant para concluir a atualização",
+      "description": "O Google Find My Hub foi atualizado no disco para a versão {installed_version}, mas o Home Assistant ainda está executando a versão {running_version}. Reinicie o Home Assistant para ativar a versão instalada.\n\nRecarregar a integração não é suficiente: é necessário reiniciar completamente o Home Assistant."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/pt-BR.json
+++ b/custom_components/googlefindmy/translations/pt-BR.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "Detectado ciclo de falhas no FCM Push",
+      "description": "O cliente push do FCM se desconecta repetidamente segundos após conectar (ciclo de falhas curtas). Geralmente isso é causado por uma notificação persistente corrompida na fila de entrada que não pode ser decodificada.\n\n1. Recarregue a integração para limpar o estado de execução.\n2. Se o problema voltar, regenere seu `secrets.json` (o Google pode ter rotacionado as credenciais)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/pt.json
+++ b/custom_components/googlefindmy/translations/pt.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "Detetado ciclo de falhas do FCM Push",
+      "description": "O cliente push do FCM desliga-se repetidamente segundos após a ligação (ciclo de falhas curtas). Normalmente é causado por uma notificação persistente corrompida na fila de entrada que não pode ser descodificada.\n\n1. Recarregue a integração para limpar o estado de execução.\n2. Se o problema voltar, regenere o seu `secrets.json` (a Google pode ter rodado as credenciais)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/pt.json
+++ b/custom_components/googlefindmy/translations/pt.json
@@ -699,6 +699,20 @@
       "title": "Falha na conexão push do FCM",
       "description": "A conexão em segundo plano com o Google está bloqueada.\n\n1. A saída pelo **porta TCP 5228** está liberada no firewall?\n2. Se a rede estiver ok, tente gerar novamente o seu `secrets.json` (as credenciais podem estar fragmentadas/revocadas)."
     },
+    "fcm_reauth_required": {
+      "title": "Google Find My Device push needs re-authentication",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Google Find My Device",
+            "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
+          }
+        },
+        "abort": {
+          "reauth_started": "Re-authentication has been started. Finish signing in to restore the background push connection. This repair stays open until the connection recovers, so the prompt is not lost if the sign-in is interrupted."
+        }
+      }
+    },
     "multiple_config_entries": {
       "title": "Várias entradas de configuração detectadas",
       "description": "O Google Find My Device agora oferece suporte a várias entradas de configuração, uma por conta do Google. Se cada entrada tiver como alvo uma conta diferente, nenhuma ação é necessária. Quando a mesma conta é adicionada duas vezes, o Home Assistant cria um problema de reparação **Entradas de conta duplicadas** para a nova entrada, para que você possa remover ou reativar a correta."

--- a/custom_components/googlefindmy/translations/pt.json
+++ b/custom_components/googlefindmy/translations/pt.json
@@ -718,6 +718,10 @@
     "fcm_short_run_crash_loop": {
       "title": "Detetado ciclo de falhas do FCM Push",
       "description": "O cliente push do FCM desliga-se repetidamente segundos após a ligação (ciclo de falhas curtas). Normalmente é causado por uma notificação persistente corrompida na fila de entrada que não pode ser descodificada.\n\n1. Recarregue a integração para limpar o estado de execução.\n2. Se o problema voltar, regenere o seu `secrets.json` (a Google pode ter rodado as credenciais)."
+    },
+    "restart_required": {
+      "title": "Reinicie o Home Assistant para concluir a atualização",
+      "description": "O Google Find My Hub foi atualizado no disco para a versão {installed_version}, mas o Home Assistant ainda está a executar a versão {running_version}. Reinicie o Home Assistant para ativar a versão instalada.\n\nRecarregar a integração não é suficiente: é necessário reiniciar completamente o Home Assistant."
     }
   },
   "exceptions": {

--- a/http_ece.pyi
+++ b/http_ece.pyi
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import Any
 
-__all__ = ["decrypt", "encrypt"]
+__all__ = ["ECEException", "decrypt", "encrypt"]
+
+class ECEException(Exception): ...
 
 def decrypt(*args: Any, **kwargs: Any) -> bytes: ...
 def encrypt(*args: Any, **kwargs: Any) -> bytes: ...

--- a/poetry.lock
+++ b/poetry.lock
@@ -2232,7 +2232,7 @@ version = "0.4.9"
 description = "Pure-Python gRPC implementation for asyncio"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "grpclib-0.4.9-py3-none-any.whl", hash = "sha256:7762ec1c8ed94dfad597475152dd35cbd11aecaaca2f243e29702435ca24cf0e"},
     {file = "grpclib-0.4.9.tar.gz", hash = "sha256:cc589c330fa81004c6400a52a566407574498cb5b055fa927013361e21466c46"},
@@ -2263,7 +2263,7 @@ version = "4.3.0"
 description = "Pure-Python HTTP/2 protocol implementation"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd"},
     {file = "h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1"},
@@ -2500,7 +2500,7 @@ version = "4.1.0"
 description = "Pure-Python HPACK header encoding"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496"},
     {file = "hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca"},
@@ -2610,7 +2610,7 @@ version = "6.1.0"
 description = "Pure-Python HTTP/2 framing"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5"},
     {file = "hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08"},
@@ -7639,4 +7639,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13.2"
-content-hash = "e9ce543b98f4f1bdaf4f36c11ec3456490685c0eb95b1d86219f7be5335c14d7"
+content-hash = "d8f65e6488915fd24832aa67dcabb6dfe0197531fafafc289eaa97dcd80d4918"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "googlefindmy-ha"
-version = "1.7.0-6"
+version = "1.7.0-7"
 description = "Home Assistant integration for Google's Find My Device network."
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ beautifulsoup4 = ">=4.12.3"
 cryptography = ">=43.0.3"
 ecdsa = ">=0.19.1"
 gpsoauth = ">=2.0.0"
+grpclib = ">=0.4.7"
 h2 = ">=4.1.0"
 http-ece = ">=1.2.1"
 httpx = { version = ">=0.28.0", extras = ["http2"] }
@@ -49,7 +50,6 @@ pip-audit = ">=2.6"
 
 # Additional dev tools
 pyyaml = ">=6.0.2"
-grpclib = ">=0.4.7"
 pycares = ">=4.4.0"
 certifi = ">=2024.7.4"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -343,7 +343,11 @@ skip_covered = true
 # (was 60 in PR #1071 with 64 % headroom). Target remains >= 95 % per
 # quality-scale rule test-coverage; this floor only prevents regressions
 # while incremental test expansion lands (60 -> 63 -> 70 -> 80 -> 90 -> 95).
-fail_under = 63
+# Recalibrated to 67 after forward-porting the stranded Class-A coverage suite:
+# local full run measured 68.33 % scoped (3696 passed); floor = floor(68) - 1 Pp
+# jitter margin, clamped to [63, CI total]. Three local entity tests error on a
+# root-owned .storage path that CI does not hit, so CI total is >= 68.33 %.
+fail_under = 67
 exclude_lines = [
     "if __name__ == \"__main__\":",
     "pragma: no cover",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "googlefindmy-ha"
-version = "1.7.0-7"
+version = "1.7.1"
 description = "Home Assistant integration for Google's Find My Device network."
 readme = "README.md"
 license = "MIT"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,46 @@ def enable_real_sockets() -> Iterable[None]:
     yield
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _redirect_ha_test_storage(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterable[None]:
+    """Redirect the bundled HA test config dir to a writable tmp location.
+
+    The HA test plugin ships ``testing_config/`` *inside* site-packages. On
+    shutdown (``hass.async_stop``) the entity/device registry performs a final
+    write into ``<testing_config>/.storage``. When site-packages is read-only
+    (e.g. a root-owned venv driven by a non-root test runner), that write raises
+    ``PermissionError`` and surfaces as a teardown error. Pointing
+    ``get_test_config_dir`` at a writable copy makes the suite environment-
+    independent, mirroring the intent of the plugin's own ``mock_storage``.
+
+    ``common`` is imported lazily *inside* the fixture on purpose: importing it
+    at module scope trips the plugin's ``patch_recorder`` assertion.
+    """
+
+    import os
+    import shutil
+
+    import pytest_homeassistant_custom_component.common as _ph
+
+    original = _ph.get_test_config_dir
+    bundled = original()
+    target = str(tmp_path_factory.mktemp("ha_testing_config"))
+    # Preserve the bundled assets (configuration.yaml, etc.) other tests read,
+    # while making the directory — and thus .storage — writable.
+    shutil.copytree(bundled, target, dirs_exist_ok=True)
+
+    def _writable_test_config_dir(*add: str) -> str:
+        return os.path.join(target, *add)
+
+    _ph.get_test_config_dir = _writable_test_config_dir
+    try:
+        yield
+    finally:
+        _ph.get_test_config_dir = original
+
+
 @pytest.hookimpl(trylast=True)
 def pytest_runtest_setup(item: pytest.Item) -> None:
     """Re-enable sockets after other plugins run setup hooks."""

--- a/tests/helpers/api_stub.py
+++ b/tests/helpers/api_stub.py
@@ -1,0 +1,171 @@
+# tests/helpers/api_stub.py
+"""Test fixtures for :class:`GoogleFindMyAPI` (Phase 4 AP-I).
+
+Mirror production attribute names from :mod:`custom_components.googlefindmy.api`
+verbatim. Properties and helpers read these by exact name; semantic-equivalent
+renames cause AttributeError.
+
+Why factories instead of a subclass?
+- ``GoogleFindMyAPI`` is self-contained (no mixin chain like the coordinator),
+  so a subclass would only obscure construction. Factories let tests assemble
+  exactly the surface they need (cache shape, session loop binding, FCM
+  receiver readiness) without inheriting unrelated production wiring.
+- Each test can rebind module-level provider hooks
+  (``_FCM_ReceiverGetter``) through ``monkeypatch.setattr`` on the imported
+  ``api`` module without polluting other tests.
+
+Stub parity (KV-10): the attribute names below mirror the production
+``CacheProtocol`` and ``FcmReceiverProtocol`` 1:1. Anything renamed semantically
+(e.g. ``entry`` instead of ``entry_id``) is a bug, not a refactor.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+
+class StubCache:
+    """Minimal :class:`CacheProtocol`-shaped cache for API tests.
+
+    Mirrors ``TokenCache`` surface used by ``GoogleFindMyAPI``:
+
+    - ``entry_id`` and ``namespace`` attributes (read via ``getattr``)
+    - ``async_get_cached_value`` / ``async_set_cached_value`` coroutines
+    """
+
+    def __init__(
+        self,
+        *,
+        entry_id: str | None = "entry-test",
+        namespace: str | None = None,
+        values: dict[str, Any] | None = None,
+    ) -> None:
+        self.entry_id = entry_id
+        self.namespace = namespace
+        self._values: dict[str, Any] = dict(values or {})
+
+    async def async_get_cached_value(self, key: str) -> Any:
+        return self._values.get(key)
+
+    async def async_set_cached_value(self, key: str, value: Any) -> None:
+        self._values[key] = value
+
+
+class RaisingCache(StubCache):
+    """Cache whose ``entry_id`` attribute raises on access.
+
+    Used to exercise the defensive ``try/except`` paths in
+    :meth:`GoogleFindMyAPI._namespace` and :meth:`_get_fcm_token_for_action`.
+    """
+
+    @property  # type: ignore[override]
+    def entry_id(self) -> str | None:  # noqa: D401 - mimic attribute name
+        raise RuntimeError("entry_id unavailable")
+
+    @entry_id.setter
+    def entry_id(self, _value: str | None) -> None:
+        return None
+
+
+class FakeReceiver:
+    """Minimal :class:`FcmReceiverProtocol`-shaped receiver.
+
+    The production protocol only requires ``get_fcm_token(entry_id=None)``.
+    Optional attributes (``is_ready``/``ready``, ``pc``) are exposed for the
+    push-readiness heuristic in :meth:`GoogleFindMyAPI.is_push_ready`.
+    """
+
+    def __init__(
+        self,
+        *,
+        token: str | None = "token-1234567890",
+        accepts_entry: bool = True,
+        is_ready: bool | None = None,
+        pc: Any | None = None,
+        raise_on_get: BaseException | None = None,
+        raise_on_get_legacy: BaseException | None = None,
+    ) -> None:
+        self._token = token
+        self._accepts_entry = accepts_entry
+        self.is_ready = is_ready
+        self.pc = pc
+        self._raise_on_get = raise_on_get
+        self._raise_on_get_legacy = raise_on_get_legacy
+        self.calls: list[tuple[Any, ...]] = []
+
+    def get_fcm_token(self, *args: Any) -> str | None:
+        self.calls.append(args)
+        if args and not self._accepts_entry:
+            raise TypeError("legacy receiver: entry_id not supported")
+        if args:
+            if self._raise_on_get is not None:
+                raise self._raise_on_get
+        else:
+            if self._raise_on_get_legacy is not None:
+                raise self._raise_on_get_legacy
+            if self._raise_on_get is not None and self._raise_on_get_legacy is None:
+                raise self._raise_on_get
+        return self._token
+
+
+def make_pc(
+    *, run_state_name: str = "STARTED", do_listen: bool = True
+) -> SimpleNamespace:
+    """Build a push-client double for :meth:`GoogleFindMyAPI.is_push_ready`.
+
+    ``run_state`` exposes a ``.name`` attribute, matching the production
+    heuristic that tolerates enum or string values.
+    """
+
+    return SimpleNamespace(
+        run_state=SimpleNamespace(name=run_state_name),
+        do_listen=do_listen,
+    )
+
+
+def install_receiver_provider(
+    monkeypatch: Any,
+    receiver: FakeReceiver | None,
+    *,
+    accepts_entry: bool = True,
+    raise_on_call: BaseException | None = None,
+    raise_on_legacy_call: BaseException | None = None,
+) -> list[tuple[Any, ...]]:
+    """Install a fake ``_FCM_ReceiverGetter`` and return a call-log list.
+
+    The call log captures positional args passed to the provider, so tests can
+    assert entry-scoped vs. legacy invocation.
+    """
+
+    calls: list[tuple[Any, ...]] = []
+
+    def _provider(*args: Any) -> FakeReceiver | None:
+        calls.append(args)
+        if args and not accepts_entry:
+            raise TypeError("legacy provider: entry_id not supported")
+        if args:
+            if raise_on_call is not None:
+                raise raise_on_call
+        else:
+            if raise_on_legacy_call is not None:
+                raise raise_on_legacy_call
+            if raise_on_call is not None and raise_on_legacy_call is None:
+                raise raise_on_call
+        return receiver
+
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.api._FCM_ReceiverGetter", _provider
+    )
+    return calls
+
+
+def run_coro(coro: Any) -> Any:
+    """Drive a coroutine to completion on a fresh loop (no outer loop active)."""
+
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()

--- a/tests/helpers/fcm_handle_stub.py
+++ b/tests/helpers/fcm_handle_stub.py
@@ -1,0 +1,111 @@
+# tests/helpers/fcm_handle_stub.py
+# Mirror production attribute names read by FcmPushClient._handle_data_message
+"""Additive composition stub for ``FcmPushClient._handle_data_message`` tests.
+
+Binds the production unbound ``_handle_data_message`` (plus the two helpers it
+calls, ``_app_data_by_key`` and the static ``_extract_header_param``) to a
+lightweight container that mirrors only the attributes that method reads. This
+exercises the real branch logic without the heavy production constructor --
+the same composition discipline as ``fcm_poison_stub.FcmPushClientSlim``.
+
+Why a *new* builder instead of reusing ``FcmPushClientSlim``: that stub mocks
+``_handle_message`` away (``AsyncMock``) and therefore never runs
+``_handle_data_message``. To cover the 8 branch groups of that method for real
+(plan R2-R8) an additive builder is required; the poison stub is left
+untouched.
+"""
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock
+
+from custom_components.googlefindmy.Auth.firebase_messaging.fcmpushclient import (
+    FcmPushClient,
+)
+
+# Sentinel distinguishing "caller did not pass credentials" (use the valid
+# default) from an explicit ``None``/``{}`` (a real production state the
+# missing-credentials guard must handle).
+_CREDENTIALS_UNSET = object()
+
+
+def make_data_message(
+    *,
+    persistent_id: str = "pid-1",
+    crypto_key: str = "dh=BPK_value",
+    encryption: str = "salt=SALT_value",
+    subtype: str = "APPID",
+    message_type: str | None = None,
+    raw_data: bytes = b"raw-body",
+) -> SimpleNamespace:
+    """Build a ``DataMessageStanza``-shaped namespace.
+
+    ``_app_data_by_key`` reads only ``x.key``/``x.value``; ``_handle_data_message``
+    reads only ``stream_id``/``last_stream_id_received``/``status``/``raw_data``/
+    ``persistent_id``. A ``SimpleNamespace`` is therefore structurally sufficient
+    (duck typing), matching ``fcm_poison_stub.make_poison_data_message`` and the
+    explicit ``SimpleNamespace`` fallback of plan AE4.
+
+    Set ``message_type="deleted_messages"`` to exercise the early-return branch.
+    """
+    app_data = [
+        SimpleNamespace(key="crypto-key", value=crypto_key),
+        SimpleNamespace(key="encryption", value=encryption),
+        SimpleNamespace(key="subtype", value=subtype),
+    ]
+    if message_type is not None:
+        app_data.insert(
+            0, SimpleNamespace(key="message_type", value=message_type)
+        )
+    return SimpleNamespace(
+        app_data=app_data,
+        persistent_id=persistent_id,
+        raw_data=raw_data,
+        stream_id=1,
+        last_stream_id_received=0,
+        status="ok",
+    )
+
+
+class FcmHandleSlim:
+    """Composition stub binding the real ``_handle_data_message``.
+
+    Mirrors the production attributes the method reads:
+    ``logger``, ``credentials``, ``callback``, ``callback_context``,
+    ``_log_warn_with_limit``, ``_log_verbose``, ``_reset_error_count``,
+    ``_try_increment_error_count``. ``_decrypt_raw_data`` is left for the test
+    to set per case (controlled ``bytes`` return), decoupling the JSON/callback
+    branches from real crypto.
+    """
+
+    def __init__(self, *, credentials: Any = _CREDENTIALS_UNSET) -> None:
+        self.logger = logging.getLogger(__name__ + ".FcmHandleSlim")
+        self.logger.propagate = True
+        self.credentials: Any = (
+            {"gcm": {"app_id": "APPID"}, "keys": {}}
+            if credentials is _CREDENTIALS_UNSET
+            else credentials
+        )
+        self.callback = Mock()  # synchronous: production calls it un-awaited (AE7)
+        self.callback_context = object()
+        self._reset_error_count = Mock()
+        self._try_increment_error_count = Mock()
+        # Records every rate-limited warning message the method emits.
+        self.warnings: list[str] = []
+
+    def _log_warn_with_limit(self, msg: str, *args: object) -> None:
+        self.warnings.append(msg)
+        self.logger.warning(msg, *args)
+
+    def _log_verbose(self, msg: str, *args: object) -> None:
+        self.logger.debug(msg, *args)
+
+    # Bind the real production functions. Instance methods bind ``self``
+    # naturally; ``_extract_header_param`` is a @staticmethod and must be
+    # re-wrapped so ``self._extract_header_param(header, param)`` does not bind
+    # ``self`` as a third positional argument.
+    _handle_data_message = FcmPushClient._handle_data_message  # type: ignore[assignment]
+    _app_data_by_key = FcmPushClient._app_data_by_key  # type: ignore[assignment]
+    _extract_header_param = staticmethod(FcmPushClient._extract_header_param)

--- a/tests/helpers/fcm_handle_stub.py
+++ b/tests/helpers/fcm_handle_stub.py
@@ -92,6 +92,9 @@ class FcmHandleSlim:
         self.callback_context = object()
         self._reset_error_count = Mock()
         self._try_increment_error_count = Mock()
+        # Mirror the stale-key escalation counter ``_handle_data_message`` now
+        # resets to 0 on a successful decrypt.
+        self._consecutive_decrypt_failures = 0
         # Records every rate-limited warning message the method emits.
         self.warnings: list[str] = []
 

--- a/tests/helpers/fcm_poison_stub.py
+++ b/tests/helpers/fcm_poison_stub.py
@@ -1,0 +1,111 @@
+# tests/helpers/fcm_poison_stub.py
+# Mirror production attribute names from FcmPushClient.__init__ and DataMessageStanza verbatim
+"""Slim composition stub for FcmPushClient Defense 1 tests (CA-CASCADING-FAILURE-001).
+
+Binds the production ``FcmPushClient._listen`` method to a lightweight container
+that mirrors only the attributes the worker loop touches. This avoids the heavy
+production constructor (``FcmRegisterConfig`` / Firebase wiring) while exercising
+the real Inner-Loop code path, so Defense 1 is verified end-to-end and not
+re-implemented in the stub.
+
+The stub is *not* a subclass of ``FcmPushClient`` (composition only). Production
+attribute names (``logger``, ``do_listen``, ``run_state``, ``config``,
+``log_warn_counters``) are mirrored verbatim from ``FcmPushClient.__init__``;
+test instrumentation fields (``_loop_iteration_count``, ``_last_handled_id``,
+``_after_iter_hook``) are exposed for the Aggregate-Anti-Cascading test.
+"""
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+from custom_components.googlefindmy.Auth.firebase_messaging.fcmpushclient import (
+    FcmPushClient,
+    FcmPushClientConfig,
+    FcmPushClientRunState,
+)
+
+
+def make_poison_data_message(
+    persistent_id: str, kind: str = "padding"
+) -> SimpleNamespace:
+    """Build a DataMessageStanza-shaped namespace for Inner-Loop tests.
+
+    ``kind`` selects the failure class the test will raise on decrypt:
+      - ``padding`` -> ``binascii.Error("Incorrect padding")``
+      - ``value``   -> ``RuntimeError("couldn't find in app_data crypto-key")``
+      - ``valid``   -> message that should pass through without raising
+    """
+    if kind not in {"padding", "value", "valid"}:
+        raise ValueError(f"unknown kind: {kind!r}")
+    return SimpleNamespace(
+        app_data=[],
+        persistent_id=persistent_id,
+        stream_id=1,
+        last_stream_id_received=0,
+        status="ok",
+        _kind=kind,
+    )
+
+
+def make_valid_data_message(persistent_id: str) -> SimpleNamespace:
+    """Convenience wrapper for a pass-through (non-poison) message."""
+    return make_poison_data_message(persistent_id, kind="valid")
+
+
+class FcmPushClientSlim:
+    """Composition stub for Defense 1 tests.
+
+    Binds ``FcmPushClient._listen`` to ``self`` so the production worker loop
+    runs against a controlled set of mocked dependencies. Only the attributes
+    the loop reads or writes are mirrored; everything else is left out.
+    """
+
+    def __init__(self) -> None:
+        # Mirror production attribute names from FcmPushClient.__init__ verbatim
+        self.logger = logging.getLogger(__name__ + ".FcmPushClientSlim")
+        self.logger.propagate = True
+        self.do_listen = True
+        self.run_state: FcmPushClientRunState = FcmPushClientRunState.STARTED
+        # Mirror the production credential-error signal (_listen sets it when
+        # CredentialDecryptionError surfaces; the supervisor reads it).
+        self.credential_error = None
+        self.config = FcmPushClientConfig()  # log_warn_limit default = 5
+        self.log_warn_counters: dict[str, int] = {}
+        self.persistent_ids: list[str] = []
+        self.writer = None  # _do_writer_close short-circuits on None
+
+        # Async-stubbed production methods (overridable per test).
+        self._receive_msg = AsyncMock(return_value=None)
+        self._handle_message = AsyncMock(return_value=None)
+        self._send_selective_ack = AsyncMock(return_value=None)
+        self._connect_with_retry = AsyncMock(return_value=True)
+        self._login = AsyncMock(return_value=None)
+        self._do_writer_close = AsyncMock(return_value=None)
+
+        # Test instrumentation (NOT production attributes).
+        self._loop_iteration_count = 0
+        self._last_handled_id: str | None = None
+        self._after_iter_hook: Callable[[], Any] = lambda: None
+
+    def _log_warn_with_limit(self, msg: str, *args: object) -> None:
+        """Production-verbatim rate-limited WARN helper (KV-H7)."""
+        if msg not in self.log_warn_counters:
+            self.log_warn_counters[msg] = 0
+        if (
+            self.config.log_warn_limit
+            and self.config.log_warn_limit > self.log_warn_counters[msg]
+        ):
+            self.log_warn_counters[msg] += 1
+            self.logger.warning(msg, *args)
+
+    # Bind the real production _listen unbound function to this slim instance.
+    # When invoked via ``self._listen()`` it resolves ``self`` to the stub.
+    # Defense 1 was extracted into two helpers (_process_one_inbound_message,
+    # _ack_or_disconnect); bind both so the unbound _listen can reach them.
+    _listen = FcmPushClient._listen  # type: ignore[assignment]
+    _process_one_inbound_message = FcmPushClient._process_one_inbound_message  # type: ignore[assignment]
+    _ack_or_disconnect = FcmPushClient._ack_or_disconnect  # type: ignore[assignment]

--- a/tests/helpers/fcm_poison_stub.py
+++ b/tests/helpers/fcm_poison_stub.py
@@ -73,6 +73,9 @@ class FcmPushClientSlim:
         # Mirror the production credential-error signal (_listen sets it when
         # CredentialDecryptionError surfaces; the supervisor reads it).
         self.credential_error = None
+        # Mirror the stale-key escalation counter the poison arm reads/writes
+        # (incremented on each ECE, reset on a successful decrypt).
+        self._consecutive_decrypt_failures = 0
         self.config = FcmPushClientConfig()  # log_warn_limit default = 5
         self.log_warn_counters: dict[str, int] = {}
         self.persistent_ids: list[str] = []

--- a/tests/helpers/identity_mixin_stub.py
+++ b/tests/helpers/identity_mixin_stub.py
@@ -1,0 +1,70 @@
+# tests/helpers/identity_mixin_stub.py
+"""Test stub for :class:`IdentityOperations` mixin standalone unit tests.
+
+PR 1.A.2 (Phase 2, AP-A): exercise the simple identity mixin methods
+(``_get_account_email``, ``_create_auth_issue``, ``_dismiss_auth_issue``,
+``_schedule_eid_resolver_refresh``, ``_register_identity_key``,
+``_reset_resolver_offset``) without the full coordinator. ``_MixinBase`` is
+runtime-empty, so a minimal subclass seeds every attribute the mixin reads
+and pre-mocks cross-mixin methods (``_entry_id``) to dodge the
+``NotImplementedError`` traps that come from ``_MixinBase``.
+
+The complex ``get_active_device_identities`` (732 LOC, dozens of
+collaborators) is intentionally out of scope here; it lands in a later AP.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from custom_components.googlefindmy.coordinator.identity import IdentityOperations
+
+
+def make_hass_stub() -> MagicMock:
+    """Return a Home Assistant stub with ``hass.data`` and ``async_create_task``.
+
+    ``hass.data`` is a plain dict so tests can populate it with the
+    ``DOMAIN`` -> ``{DATA_EID_RESOLVER: ...}`` shape that
+    :meth:`IdentityOperations._schedule_eid_resolver_refresh` reads.
+    """
+
+    hass = MagicMock(spec_set=["data", "async_create_task"])
+    hass.data = {}
+    hass.async_create_task = MagicMock(return_value=None)
+    return hass
+
+
+class IdentityStub(IdentityOperations):
+    """Minimal :class:`IdentityOperations` subclass for isolated mixin tests.
+
+    Cross-mixin ``_MixinBase`` stubs (``_entry_id``) are seeded as
+    ``MagicMock`` so methods under test can call them transparently; tests
+    rebind per-case via :func:`setattr`. No ``super().__init__`` chain runs
+    because ``DataUpdateCoordinator.__init__`` would require a full HA
+    runtime.
+    """
+
+    def __init__(
+        self,
+        hass: Any | None = None,
+        config_entry: Any | None = None,
+    ) -> None:
+        self.hass = hass if hass is not None else make_hass_stub()
+        self.config_entry = config_entry
+
+        # Shared-tracker bookkeeping (read+written by ``_register_identity_key``).
+        self._identity_key_to_devices: dict[bytes, set[str]] = {}
+
+        # Cross-mixin methods owned by RegistryOperations: return the entry's
+        # ``entry_id`` (or None) by default so ``_reset_resolver_offset`` works
+        # without extra wiring. Tests override per-case via setattr().
+        entry_id = getattr(config_entry, "entry_id", None) if config_entry else None
+        self._entry_id = MagicMock(return_value=entry_id)
+
+        # Diagnostics buffer (``get_active_device_identities`` reads it; kept
+        # here as None so its absence is well-defined for future tests).
+        self._diag = None
+
+
+__all__ = ["IdentityStub", "make_hass_stub"]

--- a/tests/helpers/locate_mixin_stub.py
+++ b/tests/helpers/locate_mixin_stub.py
@@ -1,0 +1,104 @@
+# tests/helpers/locate_mixin_stub.py
+"""Test stub for :class:`LocateOperations` mixin standalone unit tests.
+
+Phase 3 AP-C: exercise the locate mixin methods (``_normalize_coords``,
+``can_play_sound``, ``_get_device_lock``, ``can_request_location``) and
+gating branches of the async helpers (``async_locate_device``,
+``async_play_sound``, ``async_stop_sound``) without the full coordinator.
+``_MixinBase`` is runtime-empty, so a minimal subclass seeds every
+attribute the mixin reads and pre-mocks cross-mixin methods to dodge the
+``NotImplementedError`` traps that come from ``_MixinBase``.
+
+The deep success-path branches of ``async_locate_device`` (Nova roundtrip,
+Google Home filter, weighted fusion, cache commit) are intentionally out
+of scope here; they land in Phase 4.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.googlefindmy.coordinator.locate import LocateOperations
+
+
+def make_hass_stub(*, loop: Any | None = None) -> MagicMock:
+    """Return a Home Assistant stub with ``data``, ``loop`` and task helpers."""
+
+    hass = MagicMock(spec_set=["data", "loop", "async_create_task"])
+    hass.data = {}
+    hass.loop = loop if loop is not None else MagicMock()
+    hass.async_create_task = MagicMock(return_value=None)
+    return hass
+
+
+class LocateStub(LocateOperations):
+    """Minimal :class:`LocateOperations` subclass for isolated mixin tests.
+
+    Cross-mixin ``_MixinBase`` stubs are seeded as ``MagicMock`` so methods
+    under test can call them transparently; tests rebind per-case via
+    :func:`setattr`. No ``super().__init__`` chain runs because
+    ``DataUpdateCoordinator.__init__`` would require a full HA runtime.
+    """
+
+    def __init__(
+        self,
+        hass: Any | None = None,
+        config_entry: Any | None = None,
+        *,
+        api: Any | None = None,
+        location_poll_interval: int = 120,
+        min_poll_interval: int = 60,
+    ) -> None:
+        self.hass = hass if hass is not None else make_hass_stub()
+        self.config_entry = config_entry
+        self.data: list[dict[str, Any]] = []
+
+        # Locate-state attributes the mixin reads or mutates.
+        self._device_caps: dict[str, dict[str, Any]] = {}
+        self._device_action_locks: dict[str, Any] = {}
+        self._locate_inflight: set[str] = set()
+        self._locate_cooldown_until: dict[str, float] = {}
+        self._device_poll_cooldown_until: dict[str, float] = {}
+        self._push_cooldown_until: float = 0.0
+        self._device_location_data: dict[str, dict[str, Any]] = {}
+        self._sound_request_uuids: dict[str, str] = {}
+        self._sound_request_timestamps: dict[str, float] = {}
+        self._last_poll_mono: float = 0.0
+        self._present_last_seen: dict[str, float] = {}
+        self._is_polling: bool = False
+
+        # Cross-mixin scalars used by helpers.
+        self.location_poll_interval = location_poll_interval
+        self.min_poll_interval = min_poll_interval
+        self.api = api if api is not None else MagicMock()
+        self.api.async_get_device_location = AsyncMock(return_value={})
+        self.api.async_play_sound = AsyncMock(return_value=(True, "uuid-stub"))
+        self.api.async_stop_sound = AsyncMock(return_value=True)
+
+        # Cross-mixin methods owned by other mixins or DataUpdateCoordinator:
+        # mock them so default behavior is a no-op. Tests override per-case.
+        entry_id = getattr(config_entry, "entry_id", None) if config_entry else None
+        self._entry_id = MagicMock(return_value=entry_id)
+        self.increment_stat = MagicMock(return_value=None)
+        self.is_ignored = MagicMock(return_value=False)
+        self.get_device_display_name = MagicMock(return_value=None)
+        self._api_push_ready = MagicMock(return_value=True)
+        self._ensure_device_name_cache = MagicMock(return_value={})
+        self._set_auth_state = MagicMock(return_value=None)
+        self._record_semantic_label = MagicMock(return_value=None)
+        self._apply_semantic_mapping = MagicMock(return_value=False)
+        self._get_google_home_filter = MagicMock(return_value=None)
+        self._should_preserve_precise_home_coordinates = MagicMock(return_value=False)
+        self.update_device_cache = MagicMock(return_value=None)
+        self._apply_weighted_location_fusion = MagicMock(return_value=True)
+        self.note_error = MagicMock(return_value=None)
+        self.push_updated = MagicMock(return_value=None)
+        self._short_error_message = MagicMock(return_value="short-err")
+        self._async_save_sound_uuids = AsyncMock(return_value=None)
+        self.async_set_updated_data = MagicMock(return_value=None)
+        self.async_request_refresh = AsyncMock(return_value=None)
+        self._note_push_transport_problem = MagicMock(return_value=None)
+
+
+__all__ = ["LocateStub", "make_hass_stub"]

--- a/tests/helpers/main_coordinator_stub.py
+++ b/tests/helpers/main_coordinator_stub.py
@@ -1,0 +1,111 @@
+# tests/helpers/main_coordinator_stub.py
+"""Test stub for :class:`GoogleFindMyCoordinator` standalone unit tests.
+
+Phase 3 AP-F: exercise the coordinator's pure helpers, static methods and
+attribute-driven branches (``_get_ignored_set``, ``is_ignored``,
+``safe_update_metric``, ``mark_recent_reconfigure``, ``recent_reconfigure_at``,
+``cache`` property, ``_apply_semantic_mapping``, ``_find_semantic_match``,
+``_record_semantic_label``, ``get_observed_semantic_labels``,
+``_should_preserve_precise_home_coordinates``, ``auth_error_active``) without
+the full HA runtime. ``MainCoordinatorStub`` bypasses
+``GoogleFindMyCoordinator.__init__`` (which would pull in
+``aiohttp_get_clientsession``, ``DataUpdateCoordinator.__init__`` and
+``_get_api_class``) and seeds the minimum attribute set the targeted methods
+read or mutate.
+
+Deep async branches (``async_setup``, ``async_shutdown``, ``async_update_data``
+and the Nova-roundtrip locate paths) are intentionally out of scope here; they
+land in Phase 4 alongside ``__init__.py`` and ``config_flow.py``.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.googlefindmy.coordinator.main import GoogleFindMyCoordinator
+
+
+def make_hass_stub(*, loop: Any | None = None) -> MagicMock:
+    """Return a Home Assistant stub with ``data``, ``loop`` and task helpers."""
+
+    hass = MagicMock(spec_set=["data", "loop", "async_create_task", "bus"])
+    hass.data = {}
+    hass.loop = loop if loop is not None else MagicMock()
+    hass.async_create_task = MagicMock(return_value=None)
+    hass.bus = MagicMock()
+    return hass
+
+
+class MainCoordinatorStub(GoogleFindMyCoordinator):
+    """Minimal :class:`GoogleFindMyCoordinator` subclass for isolated unit tests.
+
+    Cross-mixin ``_MixinBase`` stubs (``_entry_id``, ``_is_on_hass_loop``,
+    ``_run_on_hass_loop``, ``_dispatch_async_request_refresh`` and friends)
+    are seeded as ``MagicMock`` so methods under test can call them
+    transparently; tests rebind per-case via :func:`setattr`. No
+    ``super().__init__`` chain runs because
+    ``DataUpdateCoordinator.__init__`` would require a full HA runtime.
+    """
+
+    def __init__(
+        self,
+        hass: Any | None = None,
+        config_entry: Any | None = None,
+        *,
+        cache: Any | None = None,
+    ) -> None:
+        self.hass = hass if hass is not None else make_hass_stub()
+        self.config_entry = config_entry
+        self.data: list[dict[str, Any]] = []
+
+        # Cache (private + property-backed)
+        self._cache = cache if cache is not None else MagicMock()
+        self._cache.async_get_cached_value = AsyncMock(return_value=None)
+        self._cache.async_set_cached_value = AsyncMock(return_value=None)
+
+        # Reconfigure marker
+        self._recent_reconfigure_at: float | None = None
+
+        # Performance metrics / errors
+        self.performance_metrics: dict[str, float] = {}
+        self.recent_errors: deque[tuple[float, str, str]] = deque(maxlen=20)
+        self._setup_started_at: float | None = None
+        self._setup_completed_at: float | None = None
+
+        # Auth state (mirror production attribute names from
+        # ``GoogleFindMyCoordinator.__init__`` so the ``auth_error_active``
+        # property and any helper that reads ``_auth_error_message`` work).
+        self._auth_error_active: bool = False
+        self._auth_error_message: str | None = None
+
+        # Force-refresh state
+        self._force_device_list_refresh: bool = False
+        self._force_device_list_reason: str | None = None
+
+        # Semantic-label cache (lazy in production, pre-seeded here for clarity)
+        self._semantic_label_cache: dict[str, Any] = {}
+
+        # Ignored devices fallback attribute (used when entry.options is empty)
+        self.ignored_devices: list[str] | None = None
+
+        # Stats / device caches consumed by the public reporting helpers
+        self._device_location_data: dict[str, dict[str, Any]] = {}
+        self._device_names: dict[str, str] = {}
+        self._device_names_by_user: dict[str, str] = {}
+        self._present_device_ids: set[str] = set()
+
+        # Cross-mixin methods that the coordinator helpers may invoke transparently.
+        entry_id = getattr(config_entry, "entry_id", None) if config_entry else None
+        self._entry_id = MagicMock(return_value=entry_id)
+        self._is_on_hass_loop = MagicMock(return_value=True)
+        self._run_on_hass_loop = MagicMock(return_value=None)
+        self._dispatch_async_request_refresh = MagicMock(return_value=None)
+        self._haversine_distance = MagicMock(return_value=0.0)
+        self._ensure_service_device_exists = MagicMock(return_value=None)
+        self._reindex_poll_targets_from_device_registry = MagicMock(return_value=None)
+        self._cancel_pending_subentry_repair = MagicMock(return_value=None)
+
+
+__all__ = ["MainCoordinatorStub", "make_hass_stub"]

--- a/tests/helpers/polling_branches_stub.py
+++ b/tests/helpers/polling_branches_stub.py
@@ -1,0 +1,64 @@
+# tests/helpers/polling_branches_stub.py
+"""Branch-coverage test stub for :class:`PollingOperations`.
+
+Mirror production attribute names from PollingOperations / _MixinBase verbatim.
+Properties read these by exact name; semantic-equivalent renames cause AttributeError.
+
+Extends :class:`tests.helpers.polling_mixin_stub.PollingStub` (Phase 2) with the
+extra cross-mixin hook ``async_request_refresh`` that the branch APIs under test
+in Phase 4 AP-J exercise:
+
+- ``_dispatch_async_request_refresh`` (loop detection + awaitable scheduling
+  + exception swallowing)
+- ``_schedule_short_retry`` (coalesce, delay clamping, callback dispatch)
+- ``_handle_dr_event`` (reindex + dispatch fan-out)
+- ``_is_fcm_ready_soft`` (3-tier priority: API / receiver / push-client)
+- ``_note_fcm_deferral`` (escalation timeline at 0/120/300s)
+
+The Phase 2 ``PollingStub`` deliberately omitted ``async_request_refresh``
+because the simple mixin methods do not touch it. CA-F6 (no in-place edit of a
+gemerged stub) requires the addition to live in a new helper module.
+
+Why subclass instead of monkeypatching?
+- Tests can rebind ``async_request_refresh`` per-case (sync ``MagicMock``, async
+  coroutine, raising ``MagicMock``) without leaking state across test methods.
+- A subclass keeps the production isinstance/mro structure of ``PollingStub``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from tests.helpers.polling_mixin_stub import PollingStub
+
+
+class PollingBranchesStub(PollingStub):
+    """Phase 4 AP-J branch-coverage stub for :class:`PollingOperations`."""
+
+    def __init__(
+        self,
+        hass: Any | None = None,
+        config_entry: Any | None = None,
+        *,
+        api: Any | None = None,
+        location_poll_interval: int = 120,
+        min_poll_interval: int = 60,
+    ) -> None:
+        super().__init__(
+            hass,
+            config_entry,
+            api=api,
+            location_poll_interval=location_poll_interval,
+            min_poll_interval=min_poll_interval,
+        )
+
+        # Cross-mixin hook exercised by ``_dispatch_async_request_refresh``
+        # and indirectly by ``_schedule_short_retry`` and ``_handle_dr_event``.
+        # Default is a no-op ``MagicMock`` so tests that only need the
+        # callable-check branch can ignore it. Tests override per-case to a
+        # coroutine factory or a raising MagicMock.
+        self.async_request_refresh = MagicMock(return_value=None)
+
+
+__all__ = ["PollingBranchesStub"]

--- a/tests/helpers/polling_mixin_stub.py
+++ b/tests/helpers/polling_mixin_stub.py
@@ -1,0 +1,118 @@
+# tests/helpers/polling_mixin_stub.py
+"""Test stub for :class:`PollingOperations` mixin standalone unit tests.
+
+PR 1.A.3 (Phase 2, AP-B): exercise the simple polling mixin methods
+(``_set_api_status``, ``_set_fcm_status``, ``api_status``, ``fcm_status``,
+``is_fcm_connected``, ``consecutive_timeouts``, ``last_poll_result``,
+``_is_on_hass_loop``, ``_run_on_hass_loop``, ``_compute_type_cooldown_seconds``,
+``_apply_report_type_cooldown``, ``is_polling``,
+``get_fcm_acquire_duration_seconds``, ``get_last_poll_duration_seconds``,
+``_clear_fcm_deferral``, ``_nudge_fcm_supervisor``,
+``_get_predicted_poll_time``, ``_note_push_transport_problem``,
+``force_poll_due``) without the full coordinator. ``_MixinBase`` is
+runtime-empty, so a minimal subclass seeds every attribute the mixin reads
+and pre-mocks cross-mixin methods (``_entry_id``, ``get_metric``,
+``_get_duration``, ``async_set_updated_data``,
+``_reindex_poll_targets_from_device_registry``) to dodge the
+``NotImplementedError`` traps that come from ``_MixinBase``.
+
+The complex async methods (``_async_update_data``,
+``_async_start_poll_cycle``, ``_handle_dr_event``,
+``_dispatch_async_request_refresh``, ``_schedule_short_retry``,
+``_is_fcm_ready_soft``, ``_note_fcm_deferral``) are intentionally out of
+scope here; they land in a later AP.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Any
+from unittest.mock import MagicMock
+
+from custom_components.googlefindmy.coordinator.helpers.stats import (
+    ApiStatus,
+    FcmStatus,
+)
+from custom_components.googlefindmy.coordinator.polling import PollingOperations
+
+
+def make_hass_stub(*, loop: Any | None = None) -> MagicMock:
+    """Return a Home Assistant stub with ``data``, ``loop`` and task helpers.
+
+    ``loop`` defaults to a fresh :class:`MagicMock` so equality checks against
+    the running loop default to ``False``. Tests that want the "on-loop"
+    branch can pass ``asyncio.get_event_loop()`` (or the running loop).
+    """
+
+    hass = MagicMock(spec_set=["data", "loop", "async_create_task"])
+    hass.data = {}
+    hass.loop = loop if loop is not None else MagicMock()
+    hass.async_create_task = MagicMock(return_value=None)
+    return hass
+
+
+class PollingStub(PollingOperations):
+    """Minimal :class:`PollingOperations` subclass for isolated mixin tests.
+
+    Cross-mixin ``_MixinBase`` stubs (``_entry_id``, ``get_metric``,
+    ``_get_duration``, ``async_set_updated_data``,
+    ``_reindex_poll_targets_from_device_registry``) are seeded as
+    ``MagicMock`` so methods under test can call them transparently; tests
+    rebind per-case via :func:`setattr`. No ``super().__init__`` chain runs
+    because ``DataUpdateCoordinator.__init__`` would require a full HA
+    runtime.
+    """
+
+    def __init__(
+        self,
+        hass: Any | None = None,
+        config_entry: Any | None = None,
+        *,
+        api: Any | None = None,
+        location_poll_interval: int = 120,
+        min_poll_interval: int = 60,
+    ) -> None:
+        self.hass = hass if hass is not None else make_hass_stub()
+        self.config_entry = config_entry
+        self.data: list[dict[str, Any]] = []
+
+        # Polling-state attributes (declared on _MixinBase, populated here).
+        self._api_status_state: str = ApiStatus.UNKNOWN
+        self._api_status_reason: str | None = None
+        self._api_status_changed_at: float | None = None
+        self._fcm_status_state: str = FcmStatus.UNKNOWN
+        self._fcm_status_reason: str | None = None
+        self._fcm_status_changed_at: float | None = None
+
+        self._consecutive_timeouts: int = 0
+        self._last_poll_result: str | None = None
+        self._is_polling: bool = False
+
+        self._fcm_defer_started_mono: float = 0.0
+        self._fcm_last_stage: int = 0
+        self._degraded_mode_warned: bool = False
+
+        self._device_poll_cooldown_until: dict[str, float] = {}
+        self._short_retry_cancel = None
+        self._push_cooldown_until: float = 0.0
+        self._push_ready_memo: bool | None = None
+
+        self._last_poll_mono: float = 0.0
+        self._device_update_history: dict[str, deque[float]] = {}
+
+        # Cross-mixin scalars used by helpers.
+        self.location_poll_interval = location_poll_interval
+        self.min_poll_interval = min_poll_interval
+        self.api = api if api is not None else MagicMock()
+
+        # Cross-mixin methods owned by other mixins or DataUpdateCoordinator:
+        # mock them so default behavior is a no-op. Tests override per-case.
+        entry_id = getattr(config_entry, "entry_id", None) if config_entry else None
+        self._entry_id = MagicMock(return_value=entry_id)
+        self.get_metric = MagicMock(return_value=None)
+        self._get_duration = MagicMock(return_value=None)
+        self.async_set_updated_data = MagicMock(return_value=None)
+        self._reindex_poll_targets_from_device_registry = MagicMock(return_value=None)
+
+
+__all__ = ["PollingStub", "make_hass_stub"]

--- a/tests/helpers/registry_mixin_stub.py
+++ b/tests/helpers/registry_mixin_stub.py
@@ -1,0 +1,174 @@
+# tests/helpers/registry_mixin_stub.py
+"""Test stub for :class:`RegistryOperations` mixin standalone unit tests.
+
+PR 1.A.1b (AP-1.1a-β): exercise mixin methods M1-M14 + M17 without the
+full coordinator. ``_MixinBase`` is runtime-empty, so a minimal subclass
+seeds every attribute the mixin reads, and cross-mixin methods owned by
+``SubentryOperations``/``IdentityOperations`` are pre-mocked to dodge the
+``NotImplementedError`` traps (risk R-NEU-3 in the notes sidecar).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+from custom_components.googlefindmy.const import DOMAIN, TRACKER_SUBENTRY_KEY
+from custom_components.googlefindmy.coordinator.registry import RegistryOperations
+
+
+class _DevRegStub:
+    """In-memory device registry; replaces ``dr.async_get(hass)`` results.
+
+    Holds devices as ``SimpleNamespace`` so tests can mutate ``.identifiers``,
+    ``.disabled_by`` etc. without touching real Home Assistant classes.
+    """
+
+    def __init__(self) -> None:
+        self.devices: list[SimpleNamespace] = []
+        self.update_calls: list[dict[str, Any]] = []
+        self._next_id = 0
+
+    def add_device(
+        self,
+        *,
+        identifiers: set[tuple[str, str]] | None = None,
+        name: str | None = None,
+        name_by_user: str | None = None,
+        disabled_by: Any | None = None,
+        config_entries: set[str] | None = None,
+    ) -> SimpleNamespace:
+        """Insert a synthetic device entry and return it."""
+
+        self._next_id += 1
+        device = SimpleNamespace(
+            id=f"dev-{self._next_id}",
+            identifiers=set(identifiers or set()),
+            name=name,
+            name_by_user=name_by_user,
+            disabled_by=disabled_by,
+            config_entries=set(config_entries or set()),
+        )
+        self.devices.append(device)
+        return device
+
+    def async_update_device(self, device_id: str, **kwargs: Any) -> SimpleNamespace | None:
+        """Stub used by ``_device_registry_allows_translation_update`` (signature only)."""
+
+        self.update_calls.append({"device_id": device_id, **kwargs})
+        for device in self.devices:
+            if device.id == device_id:
+                for key, value in kwargs.items():
+                    setattr(device, key, value)
+                return device
+        return None
+
+
+class _EntRegStub:
+    """In-memory entity registry; replaces ``er.async_get(hass)`` results."""
+
+    def __init__(self) -> None:
+        self.entries: list[SimpleNamespace] = []
+        self._next_id = 0
+
+    def add_entry(
+        self,
+        *,
+        platform: str = DOMAIN,
+        domain: str = "device_tracker",
+        device_id: str | None = None,
+        disabled_by: Any | None = None,
+    ) -> SimpleNamespace:
+        """Insert a synthetic entity registry entry."""
+
+        self._next_id += 1
+        entry = SimpleNamespace(
+            entity_id=f"{domain}.entity_{self._next_id}",
+            platform=platform,
+            domain=domain,
+            device_id=device_id,
+            disabled_by=disabled_by,
+        )
+        self.entries.append(entry)
+        return entry
+
+
+def make_hass_stub(*, with_setdefault_error: bool = False) -> MagicMock:
+    """Return a Home Assistant stub with ``hass.data`` and ``hass.config_entries``.
+
+    ``with_setdefault_error`` triggers the defensive branch in
+    :meth:`RegistryOperations._sync_owner_index` (B3) where
+    ``hass.data.setdefault`` raises.
+    """
+
+    # spec_set whitelists the two attributes the mixin actually reads on hass.
+    # An empty list would have blocked every assignment below (AttributeError).
+    hass = MagicMock(spec_set=["data", "config_entries"])
+    hass.data = {} if not with_setdefault_error else _RaisingDict()
+    hass.config_entries = MagicMock()
+    hass.config_entries.async_get_entry = MagicMock(return_value=None)
+    return hass
+
+
+class _RaisingDict(dict[str, Any]):
+    """``hass.data`` variant whose ``setdefault`` raises (defensive-guard test)."""
+
+    def setdefault(self, *args: Any, **kwargs: Any) -> Any:  # type: ignore[override]
+        raise RuntimeError("simulated hass.data corruption")
+
+
+class RegistryStub(RegistryOperations):
+    """Minimal :class:`RegistryOperations` subclass for isolated mixin tests.
+
+    Cross-mixin ``_MixinBase`` stubs are seeded as ``MagicMock`` so methods
+    under test can call them transparently; tests rebind per-case via
+    :func:`setattr`. No ``super().__init__`` chain runs because
+    ``DataUpdateCoordinator.__init__`` would require a full HA runtime.
+    """
+
+    def __init__(
+        self,
+        hass: Any | None = None,
+        config_entry: Any | None = None,
+        *,
+        data: list[dict[str, Any]] | None = None,
+    ) -> None:
+        # _MixinBase declares these as plain annotations; assign at runtime.
+        self.hass = hass if hass is not None else make_hass_stub()
+        self.config_entry = config_entry
+        self.data = data if data is not None else []
+
+        # Caches populated lazily by the mixin.
+        self._device_registry_config_subentry_kwarg_cache = None
+        self._device_registry_supports_translation_update = None
+        self._device_names: dict[str, str] | None = None
+
+        # Owner-index / poll-target sets the mixin reads and writes.
+        self._devices_with_entry: set[str] = set()
+        self._enabled_poll_device_ids: set[str] = set()
+        self._identity_key_to_devices: dict[bytes, set[str]] = {}
+
+        # Service-device bookkeeping (read by M15 in PR 1.A.2).
+        self._service_device_ready = False
+        self._service_device_id = None
+
+        # Subentry metadata mapping (typed on _MixinBase; runtime-empty here).
+        self._subentry_metadata = {}
+
+        # Cross-mixin methods (R-NEU-3): mock them so default behavior is a no-op.
+        # Tests can override per-case via setattr().
+        self._refresh_subentry_index = MagicMock(return_value=None)
+        self._schedule_eid_resolver_refresh = MagicMock(return_value=None)
+        self.get_subentry_metadata = MagicMock(return_value=None)
+        self.stable_subentry_identifier = MagicMock(return_value=TRACKER_SUBENTRY_KEY)
+        self.get_device_display_name = MagicMock(return_value=None)
+        self.increment_stat = MagicMock(return_value=None)
+
+
+__all__ = [
+    "RegistryStub",
+    "_DevRegStub",
+    "_EntRegStub",
+    "make_hass_stub",
+]

--- a/tests/test_api_basics.py
+++ b/tests/test_api_basics.py
@@ -1,0 +1,1229 @@
+# tests/test_api_basics.py
+"""Basics coverage for :mod:`custom_components.googlefindmy.api` (Phase 4 AP-I).
+
+Risk-priority follows Aniche RV-G3: methods whose failure mode silently corrupts
+user-facing data (token retrieval, error mapping, sync-wrappers) are covered
+first. End-to-end Auth round-trips and HTTP transport remain Phase-5 scope.
+
+Class naming uses the ``Basics`` suffix (CA-F6: disjoint from existing
+``_StubCache`` / ``_SyncHarness`` classes in :mod:`tests.test_api_location_selection`).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import ClientError
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+from custom_components.googlefindmy import api as api_module
+from custom_components.googlefindmy.api import (
+    GoogleFindMyAPI,
+    _build_can_ring_index,
+    _EphemeralCache,
+    _infer_can_ring_slot,
+    _is_multi_entry_guard_message,
+    _maybe_log_guard_once,
+    _short_err,
+    register_fcm_receiver_provider,
+    unregister_fcm_receiver_provider,
+)
+from custom_components.googlefindmy.const import (
+    CONTRIBUTOR_MODE_HIGH_TRAFFIC,
+    CONTRIBUTOR_MODE_IN_ALL_AREAS,
+    DEFAULT_CONTRIBUTOR_MODE,
+)
+from custom_components.googlefindmy.NovaApi.nova_request import (
+    NovaAuthError,
+    NovaHTTPError,
+    NovaLogicError,
+    NovaProtobufDecodeError,
+    NovaRateLimitError,
+)
+from tests.helpers.api_stub import (
+    FakeReceiver,
+    RaisingCache,
+    StubCache,
+    install_receiver_provider,
+    make_pc,
+    run_coro,
+)
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_fcm_provider() -> Any:
+    """Snapshot/restore the module-level FCM receiver getter."""
+
+    saved = api_module._FCM_ReceiverGetter
+    yield
+    api_module._FCM_ReceiverGetter = saved
+
+
+@pytest.fixture(autouse=True)
+def _reset_guard_log_flag() -> Any:
+    """Reset the module-level multi-entry guard log flag between tests."""
+
+    api_module._GUARD_LOGGED_ONCE = False
+    yield
+    api_module._GUARD_LOGGED_ONCE = False
+
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+
+
+class TestShortErrBasics:
+    """:func:`_short_err` truncation and pass-through."""
+
+    def test_short_message_is_returned_verbatim(self) -> None:
+        assert _short_err("kurz") == "kurz"
+
+    def test_long_message_is_truncated_with_ellipsis(self) -> None:
+        long = "x" * (api_module._MAX_ERR_CHARS + 50)
+        result = _short_err(long)
+        assert len(result) == api_module._MAX_ERR_CHARS
+        assert result.endswith("...")
+
+    def test_exception_input_is_stringified(self) -> None:
+        assert _short_err(RuntimeError("boom")) == "boom"
+
+
+class TestMultiEntryGuardDetection:
+    """Both markers of the multi-entry guard message."""
+
+    @pytest.mark.parametrize(
+        "msg",
+        [
+            "Multiple config entries active for googlefindmy",
+            "entry.runtime_data missing for this entry",
+        ],
+    )
+    def test_detects_known_markers(self, msg: str) -> None:
+        assert _is_multi_entry_guard_message(msg) is True
+
+    @pytest.mark.parametrize("msg", ["", "unrelated error"])
+    def test_rejects_unrelated_messages(self, msg: str) -> None:
+        assert _is_multi_entry_guard_message(msg) is False
+
+
+class TestMaybeLogGuardOnce:
+    """Initial INFO log, subsequent DEBUG suppression, optional context."""
+
+    def test_first_call_logs_info_then_suppressed(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.DEBUG, logger=api_module._LOGGER.name)
+        _maybe_log_guard_once("device_list")
+        _maybe_log_guard_once("device_list")
+        info_records = [r for r in caplog.records if r.levelno == logging.INFO]
+        debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
+        assert len(info_records) == 1
+        assert len(debug_records) == 1
+        assert "device_list" in debug_records[0].getMessage()
+
+    def test_extras_are_appended(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level(logging.INFO, logger=api_module._LOGGER.name)
+        _maybe_log_guard_once(
+            "device_list", email="user@example.com", entry_id="entry-1"
+        )
+        info = [r for r in caplog.records if r.levelno == logging.INFO]
+        message = info[0].getMessage()
+        assert "email=user@example.com" in message
+        assert "entry_id=entry-1" in message
+
+
+class TestFcmProviderRegistration:
+    """Register/unregister keeps the module-global provider in sync."""
+
+    def test_register_and_unregister_round_trip(self) -> None:
+        def _getter(_entry_id: str | None = None) -> FakeReceiver:
+            return FakeReceiver()
+
+        register_fcm_receiver_provider(_getter)
+        assert api_module._FCM_ReceiverGetter is _getter
+        unregister_fcm_receiver_provider()
+        assert api_module._FCM_ReceiverGetter is None
+
+
+# ---------------------------------------------------------------------------
+# Capability helpers
+# ---------------------------------------------------------------------------
+
+
+class TestInferCanRingSlotBasics:
+    """Slot inference across the documented input shapes."""
+
+    @pytest.mark.parametrize(
+        "device, expected",
+        [
+            ({"can_ring": True}, True),
+            ({"can_ring": False}, False),
+            ({"canRing": True}, True),
+            ({"capabilities": ["ring", "vibrate"]}, True),
+            ({"capabilities": {"PLAY_SOUND": True}}, True),
+            ({"capabilities": {"ring": False, "play_sound": False}}, False),
+            ({"capabilities": "scalar-not-iterable"}, None),
+            ({}, None),
+        ],
+    )
+    def test_returns_expected_verdict(
+        self, device: dict[str, Any], expected: bool | None
+    ) -> None:
+        assert _infer_can_ring_slot(device) is expected
+
+    def test_returns_none_on_internal_error(self) -> None:
+        class _Boom(dict):  # type: ignore[type-arg]
+            def __contains__(self, key: object) -> bool:
+                raise RuntimeError("boom")
+
+        assert _infer_can_ring_slot(_Boom()) is None
+
+
+class TestBuildCanRingIndexBasics:
+    """Index respects identifier fallbacks and ignores undecidable rows."""
+
+    def test_uses_canonical_id_and_skips_unknown(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Empirie: api.py:Z290-Z315 (_infer_can_ring_slot) — returns None ONLY when
+        # neither `can_ring`/`canRing` nor a `capabilities` key is present. An empty
+        # list/dict for `capabilities` still triggers the membership check, yielding
+        # False (a valid bool), so such a row IS recorded in the index. To test the
+        # skip-unknown path we must omit the `capabilities` key entirely.
+        rows = [
+            {"canonicalId": "A", "can_ring": True},
+            {"id": "B", "can_ring": False},
+            {"device_id": "C"},  # no can_ring / canRing / capabilities → verdict None
+            {"id": "", "can_ring": True},
+        ]
+        monkeypatch.setattr(
+            api_module, "get_devices_with_location", lambda *_a, **_k: rows
+        )
+        index = _build_can_ring_index(object(), cache=None)
+        assert index == {"A": True, "B": False}
+
+    def test_decoder_error_yields_empty_index(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _raise(*_a: Any, **_k: Any) -> list[dict[str, Any]]:
+            raise RuntimeError("decoder boom")
+
+        monkeypatch.setattr(api_module, "get_devices_with_location", _raise)
+        assert _build_can_ring_index(object(), cache=None) == {}
+
+
+# ---------------------------------------------------------------------------
+# Constructor / EphemeralCache / contributor mode / namespace
+# ---------------------------------------------------------------------------
+
+
+class TestApiInitBasics:
+    """``__init__`` paths: cache, ephemeral, missing credentials, epoch."""
+
+    def test_requires_cache_or_credentials(self) -> None:
+        with pytest.raises(TypeError, match="GoogleFindMyAPI requires"):
+            GoogleFindMyAPI()
+
+    def test_ephemeral_cache_built_from_token_or_email(self) -> None:
+        api = GoogleFindMyAPI(oauth_token="tok", google_email="x@example.com")
+        assert isinstance(api._cache, _EphemeralCache)
+
+    def test_invalid_switch_epoch_falls_back_to_now(self) -> None:
+        api = GoogleFindMyAPI(
+            cache=StubCache(),
+            contributor_mode_switch_epoch=0,
+        )
+        assert api._contributor_mode_switch_epoch > 0
+
+    def test_contributor_mode_normalized_at_init(self) -> None:
+        api = GoogleFindMyAPI(
+            cache=StubCache(),
+            contributor_mode="  HIGH_TRAFFIC  ",
+        )
+        assert api._contributor_mode == CONTRIBUTOR_MODE_HIGH_TRAFFIC
+
+    def test_unknown_contributor_mode_uses_default(self) -> None:
+        api = GoogleFindMyAPI(cache=StubCache(), contributor_mode="bogus")
+        assert api._contributor_mode == DEFAULT_CONTRIBUTOR_MODE
+
+
+class TestEphemeralCacheBasics:
+    """Public TokenCache-protocol surface of :class:`_EphemeralCache`."""
+
+    def test_get_set_delete_round_trip(self) -> None:
+        cache = _EphemeralCache(oauth_token="tok", email="x@example.com")
+        run_coro(cache.set("k", "v"))
+        assert run_coro(cache.get("k")) == "v"
+        run_coro(cache.set("k", None))
+        assert run_coro(cache.get("k")) is None
+
+    def test_all_returns_snapshot_copy(self) -> None:
+        cache = _EphemeralCache(oauth_token="tok", email="x@example.com")
+        snap = run_coro(cache.all())
+        snap["mutated"] = True
+        assert "mutated" not in run_coro(cache.all())
+
+    def test_get_or_set_with_sync_generator(self) -> None:
+        cache = _EphemeralCache(oauth_token="tok", email="x@example.com")
+        value = run_coro(cache.get_or_set("new", lambda: "computed"))
+        assert value == "computed"
+        assert run_coro(cache.get("new")) == "computed"
+
+    def test_get_or_set_with_async_generator(self) -> None:
+        cache = _EphemeralCache(oauth_token="tok", email="x@example.com")
+
+        async def _gen() -> str:
+            return "async-value"
+
+        assert run_coro(cache.get_or_set("k", _gen)) == "async-value"
+
+    def test_get_or_set_returns_existing(self) -> None:
+        cache = _EphemeralCache(oauth_token="tok", email="x@example.com")
+        run_coro(cache.set("k", "pre"))
+        assert run_coro(cache.get_or_set("k", lambda: "new")) == "pre"
+
+    def test_protocol_aliases_forward_to_base(self) -> None:
+        cache = _EphemeralCache(oauth_token="tok", email="x@example.com")
+        run_coro(cache.async_set_cached_value("k", "v"))
+        assert run_coro(cache.async_get_cached_value("k")) == "v"
+
+    def test_secrets_bundle_injects_fcm_credentials(self) -> None:
+        cache = _EphemeralCache(
+            oauth_token=None,
+            email=None,
+            secrets_bundle={"fcm_credentials": {"android_id": "42"}},
+        )
+        assert run_coro(cache.get("fcm_credentials")) == {"android_id": "42"}
+
+    def test_secrets_bundle_without_fcm_creds_is_logged(self) -> None:
+        cache = _EphemeralCache(
+            oauth_token=None,
+            email=None,
+            secrets_bundle={"other": "value"},
+        )
+        assert run_coro(cache.get("fcm_credentials")) is None
+
+
+class TestApiCloseAndContributorMode:
+    """``close`` unrefs the shared session; ``set_contributor_mode`` validates."""
+
+    def test_close_clears_session_reference(self) -> None:
+        api = GoogleFindMyAPI(cache=StubCache(), session=MagicMock())
+        run_coro(api.close())
+        assert api._session is None
+
+    def test_normalize_contributor_mode_known_value(self) -> None:
+        assert (
+            GoogleFindMyAPI._normalize_contributor_mode("  in_all_areas  ")
+            == CONTRIBUTOR_MODE_IN_ALL_AREAS
+        )
+
+    def test_normalize_contributor_mode_non_string(self) -> None:
+        assert (
+            GoogleFindMyAPI._normalize_contributor_mode(None)
+            == DEFAULT_CONTRIBUTOR_MODE
+        )
+        assert (
+            GoogleFindMyAPI._normalize_contributor_mode(123)  # type: ignore[arg-type]
+            == DEFAULT_CONTRIBUTOR_MODE
+        )
+
+    def test_set_contributor_mode_invalid_epoch_uses_now(self) -> None:
+        api = GoogleFindMyAPI(cache=StubCache())
+        api._contributor_mode_switch_epoch = 0
+        api.set_contributor_mode("high_traffic", switch_epoch=-5)
+        assert api._contributor_mode == CONTRIBUTOR_MODE_HIGH_TRAFFIC
+        assert api._contributor_mode_switch_epoch > 0
+
+
+class TestNamespaceBasics:
+    """``_namespace`` reads ``entry_id`` then ``namespace`` then returns None."""
+
+    def test_prefers_entry_id(self) -> None:
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="  entry-x  "))
+        assert api._namespace() == "entry-x"
+
+    def test_falls_back_to_namespace(self) -> None:
+        api = GoogleFindMyAPI(cache=StubCache(entry_id=None, namespace="ns-1"))
+        assert api._namespace() == "ns-1"
+
+    def test_returns_none_when_absent(self) -> None:
+        api = GoogleFindMyAPI(cache=StubCache(entry_id=None, namespace=None))
+        assert api._namespace() is None
+
+    def test_returns_none_on_exception(self) -> None:
+        api = GoogleFindMyAPI(cache=RaisingCache())
+        assert api._namespace() is None
+
+    def test_decoder_token_cache_returns_none_for_stub(self) -> None:
+        api = GoogleFindMyAPI(cache=StubCache())
+        assert api._decoder_token_cache() is None
+
+
+# ---------------------------------------------------------------------------
+# Sync-call guard / loop resolution / helper
+# ---------------------------------------------------------------------------
+
+
+class TestSyncCallGuardBasics:
+    """Detect a running loop and log the guard message."""
+
+    def test_returns_false_without_running_loop(self) -> None:
+        api = GoogleFindMyAPI(cache=StubCache())
+        assert api._sync_call_guard("should not log") is False
+
+    def test_returns_true_when_loop_running(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        api = GoogleFindMyAPI(cache=StubCache())
+        caplog.set_level(logging.ERROR, logger=api_module._LOGGER.name)
+
+        async def _probe() -> bool:
+            return api._sync_call_guard("guard:active loop")
+
+        loop = asyncio.new_event_loop()
+        try:
+            assert loop.run_until_complete(_probe()) is True
+        finally:
+            loop.close()
+        assert any("guard:active loop" in r.getMessage() for r in caplog.records)
+
+
+class TestResolveSyncLoopBasics:
+    """Session-bound vs. fresh-loop resolution paths."""
+
+    def test_session_without_loop_raises(self) -> None:
+        api = GoogleFindMyAPI(
+            cache=StubCache(),
+            session=SimpleNamespace(loop=None),
+        )
+        with pytest.raises(RuntimeError, match="determine the event loop"):
+            api._resolve_sync_loop()
+
+    def test_session_with_closed_loop_raises(self) -> None:
+        closed = asyncio.new_event_loop()
+        closed.close()
+        api = GoogleFindMyAPI(
+            cache=StubCache(),
+            session=SimpleNamespace(loop=closed),
+        )
+        with pytest.raises(RuntimeError, match="closed"):
+            api._resolve_sync_loop()
+
+    def test_session_with_open_loop_returns_it(self) -> None:
+        open_loop = asyncio.new_event_loop()
+        try:
+            api = GoogleFindMyAPI(
+                cache=StubCache(),
+                session=SimpleNamespace(loop=open_loop),
+            )
+            assert api._resolve_sync_loop() is open_loop
+        finally:
+            open_loop.close()
+
+    def test_no_session_creates_and_caches_loop(self) -> None:
+        api = GoogleFindMyAPI(cache=StubCache())
+        try:
+            loop_a = api._resolve_sync_loop()
+            loop_b = api._resolve_sync_loop()
+            assert loop_a is loop_b
+        finally:
+            if api._sync_loop is not None:
+                api._sync_loop.close()
+
+    def test_closed_cached_loop_is_replaced(self) -> None:
+        api = GoogleFindMyAPI(cache=StubCache())
+        old = asyncio.new_event_loop()
+        old.close()
+        api._sync_loop = old
+        try:
+            new_loop = api._resolve_sync_loop()
+            assert new_loop is not old
+            assert not new_loop.is_closed()
+        finally:
+            if api._sync_loop is not None:
+                api._sync_loop.close()
+
+
+class TestRunSyncHelperBasics:
+    """Guard short-circuit / resolve failure / running loop / coroutine errors."""
+
+    def test_returns_default_when_guard_active(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        api = GoogleFindMyAPI(cache=StubCache())
+        caplog.set_level(logging.ERROR, logger=api_module._LOGGER.name)
+
+        async def _probe() -> Any:
+            async def _factory() -> str:
+                return "ok"
+
+            return api._run_sync_helper(
+                _factory,
+                guard_message="guard:short",
+                context="ctx",
+                default="default",
+            )
+
+        loop = asyncio.new_event_loop()
+        try:
+            assert loop.run_until_complete(_probe()) == "default"
+        finally:
+            loop.close()
+
+    def test_returns_default_when_resolve_fails(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        api = GoogleFindMyAPI(
+            cache=StubCache(),
+            session=SimpleNamespace(loop=None),
+        )
+        caplog.set_level(logging.ERROR, logger=api_module._LOGGER.name)
+
+        async def _factory() -> str:
+            return "unused"
+
+        assert (
+            api._run_sync_helper(
+                _factory,
+                guard_message="g",
+                context="ctx",
+                default="def",
+            )
+            == "def"
+        )
+        assert any("sync setup" in r.getMessage() for r in caplog.records)
+
+    def test_returns_default_when_target_loop_already_running(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        running = MagicMock(spec=asyncio.AbstractEventLoop)
+        running.is_running.return_value = True
+        running.is_closed.return_value = False
+        api = GoogleFindMyAPI(cache=StubCache())
+        monkeypatch.setattr(api, "_resolve_sync_loop", lambda: running)
+        caplog.set_level(logging.ERROR, logger=api_module._LOGGER.name)
+
+        async def _factory() -> str:
+            return "unused"
+
+        assert (
+            api._run_sync_helper(
+                _factory, guard_message="g", context="ctx", default="def"
+            )
+            == "def"
+        )
+
+    def test_coroutine_exception_returns_default(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        api = GoogleFindMyAPI(cache=StubCache())
+        caplog.set_level(logging.ERROR, logger=api_module._LOGGER.name)
+
+        async def _factory() -> str:
+            raise RuntimeError("inner boom")
+
+        try:
+            result = api._run_sync_helper(
+                _factory, guard_message="g", context="ctx", default="def"
+            )
+        finally:
+            if api._sync_loop is not None:
+                api._sync_loop.close()
+        assert result == "def"
+        assert any("inner boom" in r.getMessage() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# FCM token retrieval (action / quiet)
+# ---------------------------------------------------------------------------
+
+
+class TestFcmTokenForActionBasics:
+    """All branches of :meth:`_get_fcm_token_for_action`."""
+
+    def test_no_provider_returns_none(self) -> None:
+        api_module._FCM_ReceiverGetter = None
+        api = GoogleFindMyAPI(cache=StubCache())
+        assert api._get_fcm_token_for_action() is None
+
+    def test_entry_scoped_token_returned(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        receiver = FakeReceiver(token="entry-token-1234")
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="entry-x"))
+        assert api._get_fcm_token_for_action() == "entry-token-1234"
+
+    def test_provider_typeerror_falls_back_to_legacy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receiver = FakeReceiver(token="legacy-token-12345")
+        install_receiver_provider(monkeypatch, receiver, accepts_entry=False)
+        api = GoogleFindMyAPI(cache=StubCache())
+        assert api._get_fcm_token_for_action() == "legacy-token-12345"
+
+    def test_provider_legacy_failure_returns_none(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        install_receiver_provider(
+            monkeypatch,
+            None,
+            accepts_entry=False,
+            raise_on_legacy_call=RuntimeError("legacy boom"),
+        )
+        api = GoogleFindMyAPI(cache=StubCache())
+        caplog.set_level(logging.ERROR, logger=api_module._LOGGER.name)
+        assert api._get_fcm_token_for_action() is None
+        assert any("legacy path" in r.getMessage() for r in caplog.records)
+
+    def test_provider_general_exception_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        install_receiver_provider(
+            monkeypatch,
+            None,
+            raise_on_call=RuntimeError("provider boom"),
+        )
+        api = GoogleFindMyAPI(cache=StubCache())
+        assert api._get_fcm_token_for_action() is None
+
+    def test_receiver_none_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        install_receiver_provider(monkeypatch, None)
+        api = GoogleFindMyAPI(cache=StubCache())
+        assert api._get_fcm_token_for_action() is None
+
+    def test_receiver_typeerror_falls_back_to_legacy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receiver = FakeReceiver(
+            token="receiver-legacy-1234",
+            accepts_entry=False,
+        )
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api._get_fcm_token_for_action() == "receiver-legacy-1234"
+
+    def test_receiver_legacy_failure_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receiver = FakeReceiver(
+            accepts_entry=False,
+            raise_on_get_legacy=RuntimeError("legacy receiver boom"),
+        )
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api._get_fcm_token_for_action() is None
+
+    def test_receiver_general_exception_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receiver = FakeReceiver(raise_on_get=RuntimeError("receiver boom"))
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api._get_fcm_token_for_action() is None
+
+    def test_short_token_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        receiver = FakeReceiver(token="abc")
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api._get_fcm_token_for_action() is None
+
+    def test_cache_entry_id_exception_falls_back_to_legacy_call(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Empirie: api.py:Z624-Z638 (_namespace) wraps BOTH getattr calls in a single
+        # try/except Exception. When entry_id raises, the whole function returns None
+        # — the namespace attribute is NEVER reached. _get_fcm_token_for_action then
+        # passes None to the provider, which falls through to the legacy receiver
+        # call (no args). Author's mental model (entry_id raises → namespace used) is
+        # wrong; the defensive wrapper short-circuits BOTH attribute reads.
+        receiver = FakeReceiver(token="legacy-token-1234567")
+        calls = install_receiver_provider(monkeypatch, receiver)
+        cache = RaisingCache()
+        cache.namespace = "never-reached-because-entry_id-raises"  # type: ignore[attr-defined]
+        api = GoogleFindMyAPI(cache=cache)
+        assert api._get_fcm_token_for_action() == "legacy-token-1234567"
+        assert calls and calls[0] == (None,)
+
+    def test_namespace_fallback_used_when_entry_id_is_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Empirie: api.py:Z624-Z638 (_namespace) — when getattr(cache, "entry_id")
+        # returns None WITHOUT raising, the `or getattr(cache, "namespace", None)`
+        # branch is reached and resolves to "ns-via-fallback". The provider is then
+        # called entry-scoped with that resolved namespace.
+        receiver = FakeReceiver(token="ns-token-1234567")
+        calls = install_receiver_provider(monkeypatch, receiver)
+        cache = StubCache(entry_id=None, namespace="ns-via-fallback")
+        api = GoogleFindMyAPI(cache=cache)
+        assert api._get_fcm_token_for_action() == "ns-token-1234567"
+        assert calls and calls[0] == ("ns-via-fallback",)
+
+
+class TestPeekFcmTokenQuietlyBasics:
+    """Quiet probe mirrors action-token paths but logs at DEBUG only."""
+
+    def test_no_provider_returns_none(self) -> None:
+        api_module._FCM_ReceiverGetter = None
+        api = GoogleFindMyAPI(cache=StubCache())
+        assert api._peek_fcm_token_quietly() is None
+
+    def test_happy_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        receiver = FakeReceiver(token="peek-token-12345")
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api._peek_fcm_token_quietly() == "peek-token-12345"
+
+    def test_provider_typeerror_falls_back_to_legacy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receiver = FakeReceiver(token="peek-legacy-12345")
+        install_receiver_provider(monkeypatch, receiver, accepts_entry=False)
+        api = GoogleFindMyAPI(cache=StubCache())
+        assert api._peek_fcm_token_quietly() == "peek-legacy-12345"
+
+    def test_provider_legacy_failure_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        install_receiver_provider(
+            monkeypatch,
+            None,
+            accepts_entry=False,
+            raise_on_legacy_call=RuntimeError("peek legacy boom"),
+        )
+        api = GoogleFindMyAPI(cache=StubCache())
+        assert api._peek_fcm_token_quietly() is None
+
+    def test_provider_general_exception_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        install_receiver_provider(
+            monkeypatch,
+            None,
+            raise_on_call=RuntimeError("peek provider boom"),
+        )
+        api = GoogleFindMyAPI(cache=StubCache())
+        assert api._peek_fcm_token_quietly() is None
+
+    def test_receiver_none_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        install_receiver_provider(monkeypatch, None)
+        api = GoogleFindMyAPI(cache=StubCache())
+        assert api._peek_fcm_token_quietly() is None
+
+    def test_receiver_typeerror_falls_back_to_legacy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receiver = FakeReceiver(
+            token="receiver-peek-12345",
+            accepts_entry=False,
+        )
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api._peek_fcm_token_quietly() == "receiver-peek-12345"
+
+    def test_receiver_legacy_failure_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receiver = FakeReceiver(
+            accepts_entry=False,
+            raise_on_get_legacy=RuntimeError("peek receiver legacy"),
+        )
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api._peek_fcm_token_quietly() is None
+
+    def test_receiver_general_exception_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receiver = FakeReceiver(raise_on_get=RuntimeError("peek receiver boom"))
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api._peek_fcm_token_quietly() is None
+
+    def test_short_token_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        receiver = FakeReceiver(token="ab")
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api._peek_fcm_token_quietly() is None
+
+
+# ---------------------------------------------------------------------------
+# Push readiness / can_play_sound
+# ---------------------------------------------------------------------------
+
+
+class TestIsPushReadyBasics:
+    """All decision branches of :meth:`is_push_ready`."""
+
+    def test_returns_false_without_provider(self) -> None:
+        api_module._FCM_ReceiverGetter = None
+        api = GoogleFindMyAPI(cache=StubCache())
+        assert api.is_push_ready() is False
+
+    def test_returns_false_when_receiver_is_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        install_receiver_provider(monkeypatch, None)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api.is_push_ready() is False
+
+    def test_returns_value_of_is_ready_boolean(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receiver = FakeReceiver(is_ready=True)
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api.is_push_ready() is True
+
+    def test_returns_true_when_push_client_started(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receiver = FakeReceiver(is_ready=None, pc=make_pc(do_listen=True))
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api.is_push_ready() is True
+
+    def test_returns_false_when_push_client_not_listening(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receiver = FakeReceiver(is_ready=None, pc=make_pc(do_listen=False))
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api.is_push_ready() is False
+
+    def test_returns_false_when_no_signals_available(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receiver = FakeReceiver(is_ready=None, pc=None)
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api.is_push_ready() is False
+
+    def test_provider_typeerror_falls_back_to_legacy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receiver = FakeReceiver(is_ready=True)
+        install_receiver_provider(monkeypatch, receiver, accepts_entry=False)
+        api = GoogleFindMyAPI(cache=StubCache())
+        assert api.is_push_ready() is True
+
+    def test_provider_general_exception_returns_false(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        install_receiver_provider(
+            monkeypatch, None, raise_on_call=RuntimeError("push provider boom")
+        )
+        api = GoogleFindMyAPI(cache=StubCache())
+        assert api.is_push_ready() is False
+
+    def test_provider_legacy_failure_returns_false(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        install_receiver_provider(
+            monkeypatch,
+            None,
+            accepts_entry=False,
+            raise_on_legacy_call=RuntimeError("push legacy boom"),
+        )
+        api = GoogleFindMyAPI(cache=StubCache())
+        assert api.is_push_ready() is False
+
+    def test_push_ready_property_alias(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        receiver = FakeReceiver(is_ready=True)
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api.push_ready is True
+
+
+class TestCanPlaySoundBasics:
+    """Capability cache + push-ready gate decide the verdict."""
+
+    def test_returns_false_when_push_not_ready(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        install_receiver_provider(monkeypatch, None)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        api._device_capabilities["dev"] = True
+        assert api.can_play_sound("dev") is False
+
+    def test_returns_cached_value_when_known(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receiver = FakeReceiver(is_ready=True)
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        api._device_capabilities["dev"] = False
+        assert api.can_play_sound("dev") is False
+
+    def test_returns_none_when_capability_unknown(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receiver = FakeReceiver(is_ready=True)
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api.can_play_sound("unknown") is None
+
+
+# ---------------------------------------------------------------------------
+# Async error mapping: device list / location / play / stop
+# ---------------------------------------------------------------------------
+
+
+def _make_api_with_session() -> GoogleFindMyAPI:
+    return GoogleFindMyAPI(cache=StubCache(entry_id="entry-1"), session=None)
+
+
+class TestAsyncBasicDeviceListErrorMapping:
+    """Each documented exception class is mapped to UpdateFailed/AuthFailed."""
+
+    def _patch_request(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        exc: BaseException,
+    ) -> None:
+        async def _raise(*_a: Any, **_k: Any) -> str:
+            raise exc
+
+        monkeypatch.setattr(api_module, "async_request_device_list", _raise)
+
+    def test_rate_limit_maps_to_update_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, NovaRateLimitError("rate"))
+        api = _make_api_with_session()
+        with pytest.raises(UpdateFailed):
+            run_coro(api.async_get_basic_device_list())
+
+    @pytest.mark.parametrize("status", [401, 403])
+    def test_http_401_403_maps_to_auth_failed(
+        self, monkeypatch: pytest.MonkeyPatch, status: int
+    ) -> None:
+        self._patch_request(monkeypatch, NovaHTTPError(status, "http"))
+        api = _make_api_with_session()
+        with pytest.raises(ConfigEntryAuthFailed):
+            run_coro(api.async_get_basic_device_list())
+
+    def test_http_500_maps_to_update_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, NovaHTTPError(500, "server"))
+        api = _make_api_with_session()
+        with pytest.raises(UpdateFailed):
+            run_coro(api.async_get_basic_device_list())
+
+    def test_nova_auth_error_maps_to_auth_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, NovaAuthError(401, "auth"))
+        api = _make_api_with_session()
+        with pytest.raises(ConfigEntryAuthFailed):
+            run_coro(api.async_get_basic_device_list())
+
+    def test_protobuf_decode_maps_to_update_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, NovaProtobufDecodeError("decode"))
+        api = _make_api_with_session()
+        with pytest.raises(UpdateFailed):
+            run_coro(api.async_get_basic_device_list())
+
+    def test_logic_error_maps_to_update_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, NovaLogicError(message="logic", code=1))
+        api = _make_api_with_session()
+        with pytest.raises(UpdateFailed):
+            run_coro(api.async_get_basic_device_list())
+
+    @pytest.mark.parametrize(
+        "marker",
+        ["BadAuthentication", "Missing 'Token' in gpsoauth", "Bad Authentication"],
+    )
+    def test_bad_auth_runtime_maps_to_auth_failed(
+        self, monkeypatch: pytest.MonkeyPatch, marker: str
+    ) -> None:
+        self._patch_request(monkeypatch, RuntimeError(marker))
+        api = _make_api_with_session()
+        with pytest.raises(ConfigEntryAuthFailed):
+            run_coro(api.async_get_basic_device_list())
+
+    def test_token_cache_closed_maps_to_auth_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, RuntimeError("TokenCache is closed"))
+        api = _make_api_with_session()
+        with pytest.raises(ConfigEntryAuthFailed):
+            run_coro(api.async_get_basic_device_list())
+
+    def test_multi_entry_guard_message_maps_to_update_failed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        self._patch_request(
+            monkeypatch, RuntimeError("Multiple config entries active here")
+        )
+        api = _make_api_with_session()
+        caplog.set_level(logging.INFO, logger=api_module._LOGGER.name)
+        with pytest.raises(UpdateFailed):
+            run_coro(api.async_get_basic_device_list())
+        assert any(
+            "multiple config entries" in r.getMessage().lower() for r in caplog.records
+        )
+
+    def test_generic_runtime_maps_to_update_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, RuntimeError("other transient"))
+        api = _make_api_with_session()
+        with pytest.raises(UpdateFailed):
+            run_coro(api.async_get_basic_device_list())
+
+    def test_client_error_maps_to_update_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, ClientError("net"))
+        api = _make_api_with_session()
+        with pytest.raises(UpdateFailed):
+            run_coro(api.async_get_basic_device_list())
+
+    def test_unexpected_exception_maps_to_update_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, Exception("boom"))
+        api = _make_api_with_session()
+        with pytest.raises(UpdateFailed):
+            run_coro(api.async_get_basic_device_list())
+
+
+class TestAsyncDeviceLocationErrorMapping:
+    """Each documented exception class for the location request branch."""
+
+    def _patch_request(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        exc: BaseException,
+    ) -> None:
+        async def _raise(*_a: Any, **_k: Any) -> list[Any]:
+            raise exc
+
+        monkeypatch.setattr(api_module, "get_location_data_for_device", _raise)
+
+    def test_nova_auth_permanent_maps_to_auth_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(
+            monkeypatch, api_module.NovaAuthPermanentError(401, "perm-auth")
+        )
+        api = _make_api_with_session()
+        with pytest.raises(ConfigEntryAuthFailed):
+            run_coro(api.async_get_device_location("d", "name"))
+
+    def test_nova_auth_transient_reraised(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, NovaAuthError(401, "transient"))
+        api = _make_api_with_session()
+        with pytest.raises(NovaAuthError):
+            run_coro(api.async_get_device_location("d", "name"))
+
+    def test_nova_auth_permanent_via_flag_maps_to_auth_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(
+            monkeypatch,
+            NovaAuthError(401, "perm-flag", is_permanent=True),
+        )
+        api = _make_api_with_session()
+        with pytest.raises(ConfigEntryAuthFailed):
+            run_coro(api.async_get_device_location("d", "name"))
+
+    @pytest.mark.parametrize("status", [401, 403])
+    def test_http_401_403_maps_to_auth_failed(
+        self, monkeypatch: pytest.MonkeyPatch, status: int
+    ) -> None:
+        self._patch_request(monkeypatch, NovaHTTPError(status, "http"))
+        api = _make_api_with_session()
+        with pytest.raises(ConfigEntryAuthFailed):
+            run_coro(api.async_get_device_location("d", "name"))
+
+    def test_http_500_returns_empty_dict(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._patch_request(monkeypatch, NovaHTTPError(500, "server"))
+        api = _make_api_with_session()
+        assert run_coro(api.async_get_device_location("d", "name")) == {}
+
+    def test_rate_limit_returns_empty_dict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, NovaRateLimitError("rate"))
+        api = _make_api_with_session()
+        assert run_coro(api.async_get_device_location("d", "name")) == {}
+
+    def test_protobuf_decode_returns_empty_dict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, NovaProtobufDecodeError("decode"))
+        api = _make_api_with_session()
+        assert run_coro(api.async_get_device_location("d", "name")) == {}
+
+    def test_logic_error_returns_empty_dict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, NovaLogicError(message="logic", code=2))
+        api = _make_api_with_session()
+        assert run_coro(api.async_get_device_location("d", "name")) == {}
+
+    def test_client_error_returns_empty_dict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, ClientError("net"))
+        api = _make_api_with_session()
+        assert run_coro(api.async_get_device_location("d", "name")) == {}
+
+    def test_fcm_startup_runtime_returns_empty_dict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(
+            monkeypatch,
+            RuntimeError("FCM receiver provider has not been registered yet"),
+        )
+        api = _make_api_with_session()
+        assert run_coro(api.async_get_device_location("d", "name")) == {}
+
+    def test_generic_runtime_returns_empty_dict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, RuntimeError("other"))
+        api = _make_api_with_session()
+        assert run_coro(api.async_get_device_location("d", "name")) == {}
+
+    def test_unexpected_exception_returns_empty_dict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, ValueError("boom"))
+        api = _make_api_with_session()
+        assert run_coro(api.async_get_device_location("d", "name")) == {}
+
+
+class TestAsyncPlaySoundErrorMapping:
+    """Each documented exception class for the play-sound branch."""
+
+    def _api_with_token(self, monkeypatch: pytest.MonkeyPatch) -> GoogleFindMyAPI:
+        receiver = FakeReceiver(token="play-token-1234567")
+        install_receiver_provider(monkeypatch, receiver)
+        return GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+
+    def _patch_submit(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        result: Any,
+        *,
+        raises: BaseException | None = None,
+    ) -> None:
+        async def _submit(*_a: Any, **_k: Any) -> Any:
+            if raises is not None:
+                raise raises
+            return result
+
+        monkeypatch.setattr(api_module, "async_submit_start_sound_request", _submit)
+
+    def test_missing_token_short_circuits(self) -> None:
+        api_module._FCM_ReceiverGetter = None
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert run_coro(api.async_play_sound("d")) == (False, None)
+
+    def test_empty_submission_response(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        api = self._api_with_token(monkeypatch)
+        self._patch_submit(monkeypatch, None)
+        assert run_coro(api.async_play_sound("d")) == (False, None)
+
+    def test_success_returns_uuid_tuple(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        api = self._api_with_token(monkeypatch)
+        self._patch_submit(monkeypatch, ("AB", "uuid-1234"))
+        assert run_coro(api.async_play_sound("d")) == (True, "uuid-1234")
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            NovaAuthError(401, "auth"),
+            NovaHTTPError(401, "http"),
+            NovaHTTPError(503, "http"),
+            NovaRateLimitError("rate"),
+            ClientError("net"),
+            Exception("boom"),
+        ],
+    )
+    def test_documented_exceptions_return_false_none(
+        self, monkeypatch: pytest.MonkeyPatch, exc: BaseException
+    ) -> None:
+        api = self._api_with_token(monkeypatch)
+        self._patch_submit(monkeypatch, None, raises=exc)
+        assert run_coro(api.async_play_sound("d")) == (False, None)
+
+
+class TestAsyncStopSoundErrorMapping:
+    """Each documented exception class for the stop-sound branch."""
+
+    def _api_with_token(self, monkeypatch: pytest.MonkeyPatch) -> GoogleFindMyAPI:
+        receiver = FakeReceiver(token="stop-token-1234567")
+        install_receiver_provider(monkeypatch, receiver)
+        return GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+
+    def _patch_submit(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        result: Any,
+        *,
+        raises: BaseException | None = None,
+    ) -> None:
+        async def _submit(*_a: Any, **_k: Any) -> Any:
+            if raises is not None:
+                raise raises
+            return result
+
+        monkeypatch.setattr(api_module, "async_submit_stop_sound_request", _submit)
+
+    def test_missing_token_short_circuits(self) -> None:
+        api_module._FCM_ReceiverGetter = None
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert run_coro(api.async_stop_sound("d")) is False
+
+    def test_none_response_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        api = self._api_with_token(monkeypatch)
+        self._patch_submit(monkeypatch, None)
+        assert run_coro(api.async_stop_sound("d", "uuid-1234")) is False
+
+    def test_success_returns_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        api = self._api_with_token(monkeypatch)
+        self._patch_submit(monkeypatch, "CDEF")
+        assert run_coro(api.async_stop_sound("d", "uuid-5678")) is True
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            NovaAuthError(401, "auth"),
+            NovaHTTPError(403, "http"),
+            NovaHTTPError(500, "http"),
+            NovaRateLimitError("rate"),
+            ClientError("net"),
+            Exception("boom"),
+        ],
+    )
+    def test_documented_exceptions_return_false(
+        self, monkeypatch: pytest.MonkeyPatch, exc: BaseException
+    ) -> None:
+        api = self._api_with_token(monkeypatch)
+        self._patch_submit(monkeypatch, None, raises=exc)
+        assert run_coro(api.async_stop_sound("d")) is False

--- a/tests/test_api_basics.py
+++ b/tests/test_api_basics.py
@@ -39,8 +39,10 @@ from custom_components.googlefindmy.const import (
     CONTRIBUTOR_MODE_IN_ALL_AREAS,
     DEFAULT_CONTRIBUTOR_MODE,
 )
+from custom_components.googlefindmy.exceptions import MissingTokenCacheError
 from custom_components.googlefindmy.NovaApi.nova_request import (
     NovaAuthError,
+    NovaError,
     NovaHTTPError,
     NovaLogicError,
     NovaProtobufDecodeError,
@@ -1132,6 +1134,17 @@ class TestAsyncPlaySoundErrorMapping:
         *,
         raises: BaseException | None = None,
     ) -> None:
+        """Install a fake submitter that models the acceptance contract.
+
+        The real submitter returns a result tuple *only* when the server accepted
+        the command (HTTP 200) and re-raises on every other outcome. The fake
+        mirrors that single contract: it returns ``result`` to model an accepted
+        command, or raises ``raises`` to model any non-acceptance — a pre-dispatch
+        failure (nothing sent), a connection-setup error, or a server rejection
+        (401/403/5xx, reached the wire but refused). There is no out-of-band
+        dispatch signal to model anymore.
+        """
+
         async def _submit(*_a: Any, **_k: Any) -> Any:
             if raises is not None:
                 raise raises
@@ -1139,37 +1152,113 @@ class TestAsyncPlaySoundErrorMapping:
 
         monkeypatch.setattr(api_module, "async_submit_start_sound_request", _submit)
 
+    def _patch_generate_uuid(
+        self, monkeypatch: pytest.MonkeyPatch, value: str = "uuid-injected"
+    ) -> None:
+        """Pin the client-generated cancel key so acceptance paths are testable."""
+        monkeypatch.setattr(api_module, "generate_random_uuid", lambda: value)
+
     def test_missing_token_short_circuits(self) -> None:
+        # PRE-dispatch guard: nothing was sent, so there is no cancel key to keep.
         api_module._FCM_ReceiverGetter = None
         api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
         assert run_coro(api.async_play_sound("d")) == (False, None)
 
-    def test_empty_submission_response(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_empty_submission_drops_cancel_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The submitter returns a tuple on every accepted (200) command and
+        # re-raises otherwise, so a None result is not an expected outcome. Treat
+        # it conservatively: drop the key rather than risk overwriting a previous
+        # play's still-valid cancel key. See IRR-CA-CANCEL-KEY-ON-SUCCESS-ONLY.
         api = self._api_with_token(monkeypatch)
+        self._patch_generate_uuid(monkeypatch)
         self._patch_submit(monkeypatch, None)
         assert run_coro(api.async_play_sound("d")) == (False, None)
 
-    def test_success_returns_uuid_tuple(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_success_returns_injected_uuid(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Success returns the client-generated (injected) cancel key. The real
+        # submitter echoes the injected UUID back through the builder; the mock
+        # mirrors that contract.
         api = self._api_with_token(monkeypatch)
-        self._patch_submit(monkeypatch, ("AB", "uuid-1234"))
-        assert run_coro(api.async_play_sound("d")) == (True, "uuid-1234")
+        self._patch_generate_uuid(monkeypatch)
+
+        async def _echo_submit(*_a: Any, **_k: Any) -> Any:
+            return ("AB", _k.get("request_uuid"))
+
+        monkeypatch.setattr(
+            api_module, "async_submit_start_sound_request", _echo_submit
+        )
+        assert run_coro(api.async_play_sound("d")) == (True, "uuid-injected")
 
     @pytest.mark.parametrize(
         "exc",
         [
+            # Server rejections (reached the wire, then refused) — Codex PR #1100
+            # iter-4: a 401/403/5xx is NOT an accepted command, so it must drop the
+            # cancel key, never keep it.
             NovaAuthError(401, "auth"),
             NovaHTTPError(401, "http"),
             NovaHTTPError(503, "http"),
             NovaRateLimitError("rate"),
             ClientError("net"),
             Exception("boom"),
+            # Pre-dispatch failures (nothing sent) — Codex PR #1100 earlier iters,
+            # incl. NovaAuthPermanentError from token refresh (a NovaAuthError
+            # subclass) raised before the wire.
+            MissingTokenCacheError(),
+            api_module.NovaAuthPermanentError(401, "token refresh failed"),
+            NovaAuthError(401, "auth resolution"),
+            ValueError("Username is not available for async_nova_request."),
+            Exception("boom before post"),
         ],
     )
-    def test_documented_exceptions_return_false_none(
+    def test_any_submitter_exception_drops_cancel_key(
         self, monkeypatch: pytest.MonkeyPatch, exc: BaseException
     ) -> None:
+        # Architectural invariant (IRR-CA-CANCEL-KEY-ON-SUCCESS-ONLY): the submitter
+        # returns a tuple only for an accepted command (HTTP 200) and re-raises for
+        # every non-acceptance — whether a pre-dispatch failure (nothing sent) or a
+        # server rejection (401/403/5xx, reached the wire but refused). In ALL these
+        # cases the play never started a ring, so async_play_sound must return
+        # (False, None); returning a non-null UUID would let the coordinator
+        # overwrite a still-valid cancel key of an earlier, possibly still-ringing
+        # play, breaking a later Stop. This collapses the former
+        # post-dispatch-keeps / pre-dispatch-drops split into one contract.
         api = self._api_with_token(monkeypatch)
+        self._patch_generate_uuid(monkeypatch)
         self._patch_submit(monkeypatch, None, raises=exc)
+        assert run_coro(api.async_play_sound("d")) == (False, None)
+
+    def test_post_dispatch_network_failure_keeps_cancel_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Codex PR #1100 iter-5: a network failure at/after the request reached
+        # the wire (server disconnect, read timeout) may have started a ring even
+        # without a 200. async_nova_request flags the wrapped NovaError as
+        # dispatched=True; async_play_sound then KEEPS the client-generated cancel
+        # key (success stays False) so a later Stop can target the possibly-active
+        # ring. This is the one failure path that preserves the key.
+        api = self._api_with_token(monkeypatch)
+        self._patch_generate_uuid(monkeypatch)
+        err = NovaError("network failed after retries")
+        err.dispatched = True
+        self._patch_submit(monkeypatch, None, raises=err)
+        assert run_coro(api.async_play_sound("d")) == (False, "uuid-injected")
+
+    def test_pre_dispatch_network_failure_drops_cancel_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A NovaError flagged dispatched=False (a pre-connect failure: DNS,
+        # refused, connect timeout) provably never rang, so the key must be
+        # dropped, exactly like every other non-acceptance.
+        api = self._api_with_token(monkeypatch)
+        self._patch_generate_uuid(monkeypatch)
+        err = NovaError("connect failed before the wire")
+        err.dispatched = False
+        self._patch_submit(monkeypatch, None, raises=err)
         assert run_coro(api.async_play_sound("d")) == (False, None)
 
 

--- a/tests/test_api_fcm_token_scoping.py
+++ b/tests/test_api_fcm_token_scoping.py
@@ -87,11 +87,14 @@ def test_actions_use_scoped_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
         session: Any,
         namespace: str | None,
         cache: DummyCache,
-    ) -> tuple[str, str]:
+        request_uuid: str | None = None,
+    ) -> tuple[str, str | None]:
         submissions.append(
             ("start", device_id, token, namespace, getattr(cache, "entry_id", None))
         )
-        return "ok", f"uuid-{device_id}"
+        # Production-faithful: an accepted command returns a result tuple and the
+        # builder echoes the injected cancel key back.
+        return "ok", request_uuid
 
     async def fake_submit_stop(
         device_id: str,
@@ -137,8 +140,9 @@ def test_actions_use_scoped_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
         ok1, uuid1 = await api_entry_1.async_play_sound("device-1")
         ok2, uuid2 = await api_entry_2.async_play_sound("device-2")
         assert ok1 and ok2
-        assert uuid1 == "uuid-device-1"
-        assert uuid2 == "uuid-device-2"
+        # Each play generates its own client-side cancel key (non-None, distinct).
+        assert uuid1 and uuid2
+        assert uuid1 != uuid2
         assert await api_entry_1.async_stop_sound("device-1")
         assert await api_entry_2.async_stop_sound("device-2")
 
@@ -173,7 +177,8 @@ def test_play_sound_returns_uuid_and_passes_to_stop(
         session: Any,
         namespace: str | None,
         cache: DummyCache,
-    ) -> tuple[str, str]:
+        request_uuid: str | None = None,
+    ) -> tuple[str, str | None]:
         submissions.append(
             (
                 "start",
@@ -183,7 +188,9 @@ def test_play_sound_returns_uuid_and_passes_to_stop(
                 getattr(cache, "entry_id", ""),
             )
         )
-        return "deadbeef", f"uuid-{device_id}"
+        # Production-faithful: an accepted command returns a result tuple and
+        # echoes the injected cancel key back to the caller.
+        return "deadbeef", request_uuid
 
     async def fake_submit_stop(
         device_id: str,
@@ -204,6 +211,12 @@ def test_play_sound_returns_uuid_and_passes_to_stop(
     monkeypatch.setattr(
         "custom_components.googlefindmy.api.async_submit_stop_sound_request",
         fake_submit_stop,
+    )
+
+    # Pin the client-generated cancel key so the play->stop round-trip is exact.
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.api.generate_random_uuid",
+        lambda: "uuid-device-uuid",
     )
 
     api = GoogleFindMyAPI(cache=DummyCache(entry_id="entry-uuid"))

--- a/tests/test_cloud_key_decryptor.py
+++ b/tests/test_cloud_key_decryptor.py
@@ -1,0 +1,410 @@
+# tests/test_cloud_key_decryptor.py
+"""Coverage + regression lock for ``KeyBackup/cloud_key_decryptor.py``.
+
+This module exercises the E2EE cryptographic primitives of the key-backup chain
+using the **real** ``cryptography`` library (no mocks). Fixtures are constructed
+with the module's own encrypt/derive helpers so every decrypt is verified as a
+true roundtrip oracle.
+
+Highlights:
+- ``RL-1`` is a *discriminating* regression lock for the historically fixed
+  operator-precedence / bit-vs-byte bug in ``decrypt_aes_cbc_no_padding``
+  (oracle commit ``0c2798ab``): a 16-byte block-aligned ciphertext must NOT be
+  rejected as "not block-size aligned". Under the buggy variant
+  ``(len % algorithms.AES.block_size) // 8`` this would raise; under the fixed
+  ``len % (algorithms.AES.block_size // 8)`` it passes.
+- ``CT-1 … CT-29`` freeze the contract of every public (and one private)
+  primitive as a safety net for future refactors.
+"""
+
+from __future__ import annotations
+
+import pytest
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+from custom_components.googlefindmy.KeyBackup.cloud_key_decryptor import (
+    ACCOUNT_KEY_CBC_TOTAL_LEN,
+    ACCOUNT_KEY_GCM_TOTAL_LEN,
+    EIK_CBC_TOTAL_LEN,
+    EIK_GCM_TOTAL_LEN,
+    P256_HKDF_AES_GCM,
+    SECUREBOX,
+    SHARED_HKDF_AES_GCM,
+    VERSION,
+    _split_iv_and_ciphertext,
+    decrypt_account_key,
+    decrypt_aes_cbc_no_padding,
+    decrypt_aes_gcm,
+    decrypt_aes_gcm_with_derived_key,
+    decrypt_application_key,
+    decrypt_eik,
+    decrypt_owner_key,
+    decrypt_recovery_key,
+    decrypt_security_domain_key,
+    decrypt_shared_key,
+    derive_key_using_hkdf_sha256,
+    derive_shared_secret,
+    encrypt_aes_gcm,
+)
+from custom_components.googlefindmy.KeyBackup.lskf_hasher import ascii_to_bytes
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers (no mocks — real cryptography lib)
+# ---------------------------------------------------------------------------
+KEY16 = bytes(range(16))
+KEY24 = bytes(range(24))
+KEY32 = bytes(range(32))
+KEY_BAD = bytes(64)  # 64 bytes -> invalid AES-GCM key length
+
+
+def _cbc_encrypt(key: bytes, iv: bytes, plaintext: bytes) -> bytes:
+    """Encrypt with raw AES-CBC (no padding); plaintext must be block-aligned."""
+    cipher = Cipher(algorithms.AES(key), modes.CBC(iv))
+    encryptor = cipher.encryptor()
+    return encryptor.update(plaintext) + encryptor.finalize()
+
+
+def _raw_p256_scalar() -> bytes:
+    """Return a valid 32-byte raw P-256 private scalar."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    return key.private_numbers().private_value.to_bytes(32, "big")
+
+
+def _uncompressed_pub() -> bytes:
+    """Return a fresh 65-byte uncompressed SEC1 P-256 public key."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    return key.public_key().public_bytes(
+        Encoding.X962, PublicFormat.UncompressedPoint
+    )
+
+
+def _build_shared_blob(ikm: bytes, plaintext: bytes, aad: bytes) -> bytes:
+    """Build a VERSION || IV||CT||TAG blob for shared-secret (non-ECDH) mode."""
+    derived = derive_key_using_hkdf_sha256(
+        ikm, SECUREBOX + VERSION, SHARED_HKDF_AES_GCM
+    )
+    return VERSION + encrypt_aes_gcm(derived, plaintext, additional_data=aad)
+
+
+def _build_ecdh_blob(priv_raw: bytes, plaintext: bytes, aad: bytes) -> bytes:
+    """Build a VERSION || PUBKEY(65) || IV||CT||TAG blob for ECDH mode.
+
+    The embedded public key comes from an ephemeral keypair; the shared secret
+    is computed via the SUT's own ``derive_shared_secret`` so the decrypt path
+    reconstructs the identical key.
+    """
+    embedded_pub = _uncompressed_pub()
+    shared_secret = derive_shared_secret(priv_raw, embedded_pub)
+    derived = derive_key_using_hkdf_sha256(
+        shared_secret, SECUREBOX + VERSION, P256_HKDF_AES_GCM
+    )
+    ct_and_iv = encrypt_aes_gcm(derived, plaintext, additional_data=aad)
+    return VERSION + embedded_pub + ct_and_iv
+
+
+# ===========================================================================
+# RL-1 — discriminating regression lock for BF-1 (oracle 0c2798ab)
+# ===========================================================================
+def test_rl1a_block_aligned_ciphertext_is_not_rejected() -> None:
+    """RL-1a: a single 16-byte block must decrypt, not raise an alignment error.
+
+    Discriminating: the buggy ``(len % 128) // 8`` would compute ``2`` for a
+    16-byte ciphertext and wrongly raise; the fixed ``len % (128 // 8)`` is 0.
+    """
+    plaintext = bytes(range(16))  # exactly one AES block
+    iv = bytes(16)
+    ciphertext = _cbc_encrypt(KEY16, iv, plaintext)
+    assert len(ciphertext) == 16
+
+    result = decrypt_aes_cbc_no_padding(KEY16, iv + ciphertext, iv_length=16)
+
+    assert result == plaintext
+
+
+def test_rl1b_non_aligned_ciphertext_raises() -> None:
+    """RL-1b: a 20-byte (non block-aligned) ciphertext must raise."""
+    iv = bytes(16)
+    ciphertext = bytes(20)  # 20 % 16 != 0
+    with pytest.raises(ValueError, match="AES-CBC ciphertext is not block-size aligned"):
+        decrypt_aes_cbc_no_padding(KEY16, iv + ciphertext, iv_length=16)
+
+
+# ===========================================================================
+# CT-1 … CT-29 — contract / coverage tests (refactor safety net)
+# ===========================================================================
+def test_ct1_hkdf_length_determinism_and_domain_separation() -> None:
+    """CT-1: HKDF yields 16 deterministic bytes; different info => different key."""
+    ikm = bytes(32)
+    salt = SECUREBOX + VERSION
+    key_a = derive_key_using_hkdf_sha256(ikm, salt, SHARED_HKDF_AES_GCM)
+    key_a2 = derive_key_using_hkdf_sha256(ikm, salt, SHARED_HKDF_AES_GCM)
+    key_b = derive_key_using_hkdf_sha256(ikm, salt, P256_HKDF_AES_GCM)
+
+    assert len(key_a) == 16
+    assert key_a == key_a2  # deterministic
+    assert key_a != key_b  # domain separation via info
+
+
+def test_ct2_split_non_positive_iv_length_raises() -> None:
+    """CT-2: iv_length <= 0 raises."""
+    with pytest.raises(ValueError, match="IV length must be positive"):
+        _split_iv_and_ciphertext(bytes(16), 0)
+
+
+def test_ct3_split_buffer_shorter_than_iv_raises() -> None:
+    """CT-3: buffer shorter than IV raises."""
+    with pytest.raises(ValueError, match="Encrypted buffer shorter than IV length"):
+        _split_iv_and_ciphertext(bytes(4), 8)
+
+
+def test_ct4_split_empty_payload_raises() -> None:
+    """CT-4: no payload after the IV raises."""
+    with pytest.raises(ValueError, match="Ciphertext is empty"):
+        _split_iv_and_ciphertext(bytes(8), 8)
+
+
+def test_ct5_split_happy_path() -> None:
+    """CT-5: split returns (iv, ciphertext) correctly."""
+    iv = bytes(range(12))
+    ciphertext = bytes(range(12, 28))
+    out_iv, out_ct = _split_iv_and_ciphertext(iv + ciphertext, 12)
+
+    assert out_iv == iv
+    assert out_ct == ciphertext
+
+
+def test_ct6_gcm_decrypt_invalid_key_length_raises() -> None:
+    """CT-6: AES-GCM decrypt rejects invalid key length."""
+    with pytest.raises(ValueError, match="AESGCM key must be 16, 24, or 32 bytes"):
+        decrypt_aes_gcm(KEY_BAD, bytes(32))
+
+
+def test_ct7_gcm_roundtrip() -> None:
+    """CT-7: encrypt_aes_gcm -> decrypt_aes_gcm roundtrip (with and without AAD)."""
+    plaintext = b"the quick brown fox"
+    blob = encrypt_aes_gcm(KEY32, plaintext)
+    assert decrypt_aes_gcm(KEY32, blob) == plaintext
+
+    aad = b"context"
+    blob_aad = encrypt_aes_gcm(KEY16, plaintext, additional_data=aad)
+    assert decrypt_aes_gcm(KEY16, blob_aad, additional_data=aad) == plaintext
+
+
+def test_ct8_gcm_encrypt_invalid_key_length_raises() -> None:
+    """CT-8: AES-GCM encrypt rejects invalid key length."""
+    with pytest.raises(ValueError, match="AESGCM key must be 16, 24, or 32 bytes"):
+        encrypt_aes_gcm(KEY_BAD, b"data")
+
+
+def test_ct9_gcm_encrypt_non_positive_iv_length_raises() -> None:
+    """CT-9: AES-GCM encrypt rejects non-positive IV length."""
+    with pytest.raises(ValueError, match="IV length must be positive"):
+        encrypt_aes_gcm(KEY16, b"data", iv_length=0)
+
+
+def test_ct10_gcm_encrypt_frames_iv_then_ciphertext_tag() -> None:
+    """CT-10: encrypt returns IV || CIPHERTEXT||TAG of expected length."""
+    plaintext = b"1234567890"
+    iv_length = 12
+    blob = encrypt_aes_gcm(KEY24, plaintext, iv_length=iv_length)
+
+    # IV (12) + ciphertext (len plaintext) + GCM tag (16)
+    assert len(blob) == iv_length + len(plaintext) + 16
+    assert decrypt_aes_gcm(KEY24, blob, iv_length=iv_length) == plaintext
+
+
+def test_ct11_gcm_wrong_aad_raises_invalid_tag() -> None:
+    """CT-11: a wrong additional_data fails authentication with InvalidTag."""
+    blob = encrypt_aes_gcm(KEY16, b"secret", additional_data=b"aad-A")
+    with pytest.raises(InvalidTag):
+        decrypt_aes_gcm(KEY16, blob, additional_data=b"aad-B")
+
+
+def test_ct12_cbc_block_aligned_roundtrip() -> None:
+    """CT-12: AES-CBC (no padding) roundtrip over two aligned blocks."""
+    plaintext = bytes(range(32))  # 2 blocks
+    iv = bytes(16)
+    ciphertext = _cbc_encrypt(KEY16, iv, plaintext)
+
+    result = decrypt_aes_cbc_no_padding(KEY16, iv + ciphertext, iv_length=16)
+
+    assert result == plaintext
+
+
+def test_ct13_derived_key_invalid_version_raises() -> None:
+    """CT-13: a wrong VERSION header raises."""
+    bad = b"\x00\x00" + bytes(32)  # wrong version prefix
+    with pytest.raises(ValueError, match="Invalid version or data length"):
+        decrypt_aes_gcm_with_derived_key(bad, bytes(32), b"aad")
+
+
+def test_ct14_derived_key_shared_mode_roundtrip() -> None:
+    """CT-14: shared-secret (non-ECDH) derived-key roundtrip."""
+    ikm = bytes(range(32))
+    aad = b"V1 shared-mode"
+    plaintext = b"shared-mode-secret"
+    blob = _build_shared_blob(ikm, plaintext, aad)
+
+    result = decrypt_aes_gcm_with_derived_key(
+        blob, ikm, aad, derive_with_public_key=False
+    )
+
+    assert result == plaintext
+
+
+def test_ct15_derived_key_ecdh_mode_roundtrip() -> None:
+    """CT-15: ECDH derived-key roundtrip with an embedded 65-byte public key."""
+    priv_raw = _raw_p256_scalar()
+    aad = b"V1 ecdh-mode"
+    plaintext = b"ecdh-mode-secret"
+    blob = _build_ecdh_blob(priv_raw, plaintext, aad)
+
+    result = decrypt_aes_gcm_with_derived_key(
+        blob, priv_raw, aad, derive_with_public_key=True
+    )
+
+    assert result == plaintext
+
+
+def test_ct16_derive_shared_secret_short_private_key_raises() -> None:
+    """CT-16: a private key buffer shorter than 32 bytes raises."""
+    with pytest.raises(
+        ValueError, match="Private key buffer too short"
+    ):
+        derive_shared_secret(bytes(31), _uncompressed_pub())
+
+
+def test_ct17_derive_shared_secret_bad_public_key_length_raises() -> None:
+    """CT-17: a public key that is not 65 bytes raises."""
+    with pytest.raises(
+        ValueError, match="Public key must be 65 bytes"
+    ):
+        derive_shared_secret(_raw_p256_scalar(), bytes(64))
+
+
+def test_ct18_derive_shared_secret_ecdh_symmetry() -> None:
+    """CT-18: ECDH is symmetric — both parties derive the same secret."""
+    alice = ec.generate_private_key(ec.SECP256R1())
+    bob = ec.generate_private_key(ec.SECP256R1())
+    alice_raw = alice.private_numbers().private_value.to_bytes(32, "big")
+    bob_raw = bob.private_numbers().private_value.to_bytes(32, "big")
+    alice_pub = alice.public_key().public_bytes(
+        Encoding.X962, PublicFormat.UncompressedPoint
+    )
+    bob_pub = bob.public_key().public_bytes(
+        Encoding.X962, PublicFormat.UncompressedPoint
+    )
+
+    secret_ab = derive_shared_secret(alice_raw, bob_pub)
+    secret_ba = derive_shared_secret(bob_raw, alice_pub)
+
+    assert secret_ab == secret_ba
+
+
+def test_ct19_decrypt_recovery_key_roundtrip() -> None:
+    """CT-19: decrypt_recovery_key wrapper roundtrip."""
+    lskf_hash = bytes(range(32))
+    plaintext = b"recovery-key-bytes"
+    aad = ascii_to_bytes("V1 locally_encrypted_recovery_key")
+    blob = _build_shared_blob(lskf_hash, plaintext, aad)
+
+    assert decrypt_recovery_key(lskf_hash, blob) == plaintext
+
+
+def test_ct20_decrypt_application_key_roundtrip() -> None:
+    """CT-20: decrypt_application_key wrapper roundtrip."""
+    recovery_key = bytes(range(1, 33))
+    plaintext = b"application-key-bytes"
+    aad = ascii_to_bytes("V1 encrypted_application_key")
+    blob = _build_shared_blob(recovery_key, plaintext, aad)
+
+    assert decrypt_application_key(recovery_key, blob) == plaintext
+
+
+def test_ct21_decrypt_security_domain_key_roundtrip() -> None:
+    """CT-21: decrypt_security_domain_key is plain AES-GCM (no derived key)."""
+    application_key = KEY32
+    plaintext = b"security-domain-key"
+    blob = encrypt_aes_gcm(application_key, plaintext)
+
+    assert decrypt_security_domain_key(application_key, blob) == plaintext
+
+
+def test_ct22_decrypt_shared_key_ecdh_roundtrip() -> None:
+    """CT-22: decrypt_shared_key wrapper (ECDH mode) roundtrip."""
+    security_domain_key = _raw_p256_scalar()
+    plaintext = b"shared-key-bytes"
+    aad = ascii_to_bytes("V1 shared_key")
+    blob = _build_ecdh_blob(security_domain_key, plaintext, aad)
+
+    assert decrypt_shared_key(security_domain_key, blob) == plaintext
+
+
+def test_ct23_decrypt_owner_key_roundtrip() -> None:
+    """CT-23: decrypt_owner_key is plain AES-GCM (no derived key)."""
+    shared_key = KEY16
+    plaintext = b"owner-key-bytes"
+    blob = encrypt_aes_gcm(shared_key, plaintext)
+
+    assert decrypt_owner_key(shared_key, blob) == plaintext
+
+
+def test_ct24_decrypt_eik_cbc_path() -> None:
+    """CT-24: a 48-byte EIK blob takes the CBC path (16 IV + 32 CT)."""
+    owner_key = KEY16
+    plaintext = bytes(range(32))  # 2 blocks (CBC, no padding)
+    iv = bytes(16)
+    ciphertext = _cbc_encrypt(owner_key, iv, plaintext)
+    blob = iv + ciphertext
+    assert len(blob) == EIK_CBC_TOTAL_LEN
+
+    assert decrypt_eik(owner_key, blob) == plaintext
+
+
+def test_ct25_decrypt_eik_gcm_path() -> None:
+    """CT-25: a 60-byte EIK blob takes the GCM path (12 IV + 32 CT + 16 TAG)."""
+    owner_key = KEY16
+    plaintext = bytes(range(32))
+    blob = encrypt_aes_gcm(owner_key, plaintext, iv_length=12)
+    assert len(blob) == EIK_GCM_TOTAL_LEN
+
+    assert decrypt_eik(owner_key, blob) == plaintext
+
+
+def test_ct26_decrypt_eik_invalid_length_raises() -> None:
+    """CT-26: an EIK blob of unexpected length raises."""
+    with pytest.raises(ValueError, match="The encrypted EIK has invalid length"):
+        decrypt_eik(KEY16, bytes(50))
+
+
+def test_ct27_decrypt_account_key_cbc_path() -> None:
+    """CT-27: a 32-byte account-key blob takes the CBC path (16 IV + 16 CT)."""
+    owner_key = KEY16
+    plaintext = bytes(range(16))  # one block
+    iv = bytes(16)
+    ciphertext = _cbc_encrypt(owner_key, iv, plaintext)
+    blob = iv + ciphertext
+    assert len(blob) == ACCOUNT_KEY_CBC_TOTAL_LEN
+
+    assert decrypt_account_key(owner_key, blob) == plaintext
+
+
+def test_ct28_decrypt_account_key_gcm_path() -> None:
+    """CT-28: a 44-byte account-key blob takes the GCM path (12 IV + 16 CT + 16 TAG)."""
+    owner_key = KEY16
+    plaintext = bytes(range(16))
+    blob = encrypt_aes_gcm(owner_key, plaintext, iv_length=12)
+    assert len(blob) == ACCOUNT_KEY_GCM_TOTAL_LEN
+
+    assert decrypt_account_key(owner_key, blob) == plaintext
+
+
+def test_ct29_decrypt_account_key_invalid_length_raises() -> None:
+    """CT-29: an account-key blob of unexpected length raises."""
+    with pytest.raises(
+        ValueError, match="The encrypted Account Key has invalid length"
+    ):
+        decrypt_account_key(KEY16, bytes(40))

--- a/tests/test_config_flow_basics.py
+++ b/tests/test_config_flow_basics.py
@@ -1,0 +1,1241 @@
+# tests/test_config_flow_basics.py
+"""Basics coverage for :mod:`custom_components.googlefindmy.config_flow` (Phase 4 AP-L).
+
+Targets pure-function helpers that are reachable without instantiating a
+full Home Assistant flow manager: validators, normalizers, payload builders,
+error mapping, credential interpreters, discovery helpers and the lightweight
+dataclass surface. The 25 helpers tested here are all reachable from the flow
+steps, so every test exercises a code path that real onboarding traverses
+(Aniche RV-G3: user-setup path, every branch is onboarding critical).
+
+Empiricism trace (CA-MOCK-001 / CA-ASSERTION-EMPIRIE-001):
+- All assertions are grounded against the production implementation in
+  ``custom_components/googlefindmy/config_flow.py`` (read at commit
+  a2edc23d). Line anchors are noted on the test classes.
+- No mocks of pure-function behaviour; only thin shims for the
+  ``HomeAssistant``/``ConfigEntry`` boundary where the helpers touch HA APIs
+  (``_find_entry_by_email``, ``_resolve_entry_email_for_lookup``,
+  ``_ensure_optional_entry_attributes``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from custom_components.googlefindmy import config_flow as cf
+
+# ---------------------------------------------------------------------------
+# Block A: validators (cf.py lines 944-956)
+# ---------------------------------------------------------------------------
+
+
+class TestEmailValid:
+    """Empiricism: ``_email_valid`` returns ``bool(_EMAIL_RE.match(value or ""))``."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "user@example.com",
+            "first.last@sub.example.co.uk",
+            "user+tag@example.com",
+            "U_S_E_R@example.io",
+        ],
+    )
+    def test_accepts_well_formed_addresses(self, value: str) -> None:
+        assert cf._email_valid(value) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",  # empty
+            "not-an-email",  # no @
+            "@example.com",  # missing local part
+            "user@",  # missing domain
+            "user@nope",  # missing TLD
+            "user@.com",  # empty subdomain label
+            "a@b.c",  # TLD too short
+            " user@example.com",  # leading whitespace blocks regex
+        ],
+    )
+    def test_rejects_malformed_addresses(self, value: str) -> None:
+        assert cf._email_valid(value) is False
+
+    def test_handles_none_via_value_or_empty(self) -> None:
+        # The implementation defends against ``None`` via ``value or ""``.
+        assert cf._email_valid(None) is False  # type: ignore[arg-type]
+
+
+class TestTokenPlausible:
+    """Empiricism: ``_TOKEN_RE`` requires ``\\S{16,}`` (no whitespace, len>=16)."""
+
+    def test_accepts_long_token_without_whitespace(self) -> None:
+        assert cf._token_plausible("a" * 16) is True
+        assert cf._token_plausible("aas_et/" + "x" * 64) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            "short",  # too short
+            "a" * 15,  # one shy of minimum length
+            "with whitespace1234567890",  # contains space
+            "with\ttab12345678",  # contains tab
+        ],
+    )
+    def test_rejects_short_or_whitespace_tokens(self, value: str) -> None:
+        assert cf._token_plausible(value) is False
+
+    def test_handles_none(self) -> None:
+        assert cf._token_plausible(None) is False  # type: ignore[arg-type]
+
+
+class TestLooksLikeJwt:
+    """Empiricism: ``count(".") >= 2 and value[:3] == 'eyJ'``."""
+
+    def test_classic_jwt_shape_accepted(self) -> None:
+        assert cf._looks_like_jwt("eyJabc.eyJdef.signature") is True
+
+    def test_two_dots_but_wrong_prefix_rejected(self) -> None:
+        assert cf._looks_like_jwt("aaa.bbb.ccc") is False
+
+    def test_correct_prefix_but_no_dots_rejected(self) -> None:
+        assert cf._looks_like_jwt("eyJabcdefghijklmnop") is False
+
+    def test_empty_string_rejected(self) -> None:
+        # Slicing ``""[:3]`` yields ``""`` which is not ``"eyJ"`` — no IndexError.
+        assert cf._looks_like_jwt("") is False
+
+
+# ---------------------------------------------------------------------------
+# Block B: normalizers (cf.py lines 964-988)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeFeatureList:
+    """Empiricism: dedupes, strips, lowercases, sorts; skips non-str."""
+
+    def test_strips_lowercases_dedupes_and_sorts(self) -> None:
+        result = cf._normalize_feature_list(
+            ["  Maps ", "device_tracker", "MAPS", "Sensor"]
+        )
+        assert result == ["device_tracker", "maps", "sensor"]
+
+    def test_skips_non_string_entries(self) -> None:
+        # Non-str entries are silently dropped (no exception, no insertion).
+        result = cf._normalize_feature_list(["sensor", 42, None, "button"])  # type: ignore[list-item]
+        assert result == ["button", "sensor"]
+
+    def test_drops_empty_after_strip(self) -> None:
+        result = cf._normalize_feature_list(["", "  ", "sensor"])
+        assert result == ["sensor"]
+
+    def test_empty_input_returns_empty_list(self) -> None:
+        assert cf._normalize_feature_list([]) == []
+
+
+class TestNormalizeVisibleIds:
+    """Empiricism: strips and dedupes (no case-folding!), sorts."""
+
+    def test_strips_and_dedupes(self) -> None:
+        result = cf._normalize_visible_ids(["  abc ", "abc", "def"])
+        assert result == ["abc", "def"]
+
+    def test_preserves_case(self) -> None:
+        # Visible IDs are case-sensitive device identifiers.
+        result = cf._normalize_visible_ids(["ABC", "abc"])
+        assert result == ["ABC", "abc"]
+
+    def test_skips_non_strings_and_blanks(self) -> None:
+        result = cf._normalize_visible_ids(["abc", 0, None, "", " "])  # type: ignore[list-item]
+        assert result == ["abc"]
+
+    def test_empty_input(self) -> None:
+        assert cf._normalize_visible_ids([]) == []
+
+
+# ---------------------------------------------------------------------------
+# Block C: feature settings and payload builder (cf.py lines 991-1063)
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveFeatureSettings:
+    """Empiricism: per-key precedence options_payload > defaults > module DEFAULT."""
+
+    def test_explicit_options_override_defaults(self) -> None:
+        opt_key = cf.OPT_GOOGLE_HOME_FILTER_ENABLED
+        if opt_key is None:
+            pytest.skip("OPT_GOOGLE_HOME_FILTER_ENABLED not available in this build")
+
+        opt_stats = cf.OPT_ENABLE_STATS_ENTITIES
+        opt_map = cf.OPT_MAP_VIEW_TOKEN_EXPIRATION
+
+        has_filter, flags = cf._derive_feature_settings(
+            options_payload={
+                opt_key: True,
+                opt_stats: False,
+                opt_map: True,
+            },
+            defaults={opt_stats: True},
+        )
+        assert has_filter is True
+        assert flags[opt_stats] is False  # options wins over defaults
+        assert flags[opt_map] is True
+        assert flags[opt_key] is True
+
+    def test_defaults_apply_when_options_silent(self) -> None:
+        opt_key = cf.OPT_GOOGLE_HOME_FILTER_ENABLED
+        if opt_key is None:
+            pytest.skip("OPT_GOOGLE_HOME_FILTER_ENABLED not available in this build")
+        opt_stats = cf.OPT_ENABLE_STATS_ENTITIES
+
+        has_filter, flags = cf._derive_feature_settings(
+            options_payload={},
+            defaults={opt_key: True, opt_stats: True},
+        )
+        assert has_filter is True
+        assert flags[opt_stats] is True
+
+    def test_module_default_used_when_options_and_defaults_silent(self) -> None:
+        opt_key = cf.OPT_GOOGLE_HOME_FILTER_ENABLED
+        if opt_key is None or cf.DEFAULT_GOOGLE_HOME_FILTER_ENABLED is None:
+            pytest.skip("Module default not configured in this build")
+
+        has_filter, _flags = cf._derive_feature_settings(
+            options_payload={}, defaults={}
+        )
+        assert has_filter is bool(cf.DEFAULT_GOOGLE_HOME_FILTER_ENABLED)
+
+    def test_contributor_mode_passthrough(self) -> None:
+        has_filter, flags = cf._derive_feature_settings(
+            options_payload={cf.OPT_CONTRIBUTOR_MODE: "high_traffic"},
+            defaults={},
+        )
+        assert flags[cf.OPT_CONTRIBUTOR_MODE] == "high_traffic"
+        # contributor_mode does not affect the filter flag itself.
+        assert isinstance(has_filter, bool)
+
+
+class TestBuildSubentryPayload:
+    """Empiricism: lines 1040-1063 — composes group_key/features/flags dict."""
+
+    def test_basic_payload_without_visible_ids(self) -> None:
+        payload = cf._build_subentry_payload(
+            group_key="trackers",
+            features=["device_tracker", "Sensor"],
+            entry_title="Acme",
+            has_google_home_filter=True,
+            feature_flags={"enable_stats": True},
+        )
+        assert payload["group_key"] == "trackers"
+        assert payload["features"] == ["device_tracker", "sensor"]
+        assert payload["fcm_push_enabled"] is False
+        assert payload["has_google_home_filter"] is True
+        assert payload["feature_flags"] == {"enable_stats": True}
+        assert payload["entry_title"] == "Acme"
+        # Without visible_device_ids, key must NOT be present.
+        assert "visible_device_ids" not in payload
+
+    def test_visible_device_ids_included_when_provided(self) -> None:
+        payload = cf._build_subentry_payload(
+            group_key="trackers",
+            features=[],
+            entry_title="T",
+            has_google_home_filter=False,
+            feature_flags={},
+            visible_device_ids=["dev_b", "dev_a", "dev_a"],
+        )
+        assert payload["visible_device_ids"] == ["dev_a", "dev_b"]
+
+    def test_empty_visible_ids_after_normalization_drops_key(self) -> None:
+        # All-empty visible_device_ids list becomes [] after normalization → dropped.
+        payload = cf._build_subentry_payload(
+            group_key="g",
+            features=[],
+            entry_title="t",
+            has_google_home_filter=False,
+            feature_flags={},
+            visible_device_ids=["", "   "],
+        )
+        assert "visible_device_ids" not in payload
+
+    def test_feature_flags_is_copied_not_referenced(self) -> None:
+        flags = {"a": True}
+        payload = cf._build_subentry_payload(
+            group_key="g",
+            features=[],
+            entry_title="t",
+            has_google_home_filter=False,
+            feature_flags=flags,
+        )
+        flags["b"] = False  # mutate source after build
+        assert payload["feature_flags"] == {"a": True}
+
+
+# ---------------------------------------------------------------------------
+# Block D: token persistence guard + multi-entry guard (cf.py lines 1072-1088)
+# ---------------------------------------------------------------------------
+
+
+class TestDisqualifiesForPersistence:
+    """Empiricism: rejects JWT-shaped tokens, accepts everything else."""
+
+    def test_jwt_rejected(self) -> None:
+        reason = cf._disqualifies_for_persistence("eyJabc.eyJdef.signature")
+        assert isinstance(reason, str)
+        assert "JWT" in reason or "installation" in reason
+
+    def test_aas_token_accepted(self) -> None:
+        assert cf._disqualifies_for_persistence("aas_et/" + "x" * 64) is None
+
+    def test_generic_token_accepted(self) -> None:
+        assert cf._disqualifies_for_persistence("a" * 32) is None
+
+
+class TestIsMultiEntryGuardError:
+    """Empiricism: returns True only for substring match of two guard phrases."""
+
+    def test_recognizes_multi_entry_phrase(self) -> None:
+        assert cf._is_multi_entry_guard_error(
+            Exception("Multiple config entries active here")
+        )
+
+    def test_recognizes_runtime_data_phrase(self) -> None:
+        assert cf._is_multi_entry_guard_error(Exception("pass entry.runtime_data"))
+
+    def test_unrelated_error_not_recognized(self) -> None:
+        assert cf._is_multi_entry_guard_error(Exception("not found")) is False
+
+    def test_works_with_non_exception_repr(self) -> None:
+        # _is_multi_entry_guard_error stringifies with f"{err}".
+        class _Custom(Exception):
+            def __str__(self) -> str:
+                return "Multiple config entries active"
+
+        assert cf._is_multi_entry_guard_error(_Custom()) is True
+
+
+# ---------------------------------------------------------------------------
+# Block E: API exception mapping (cf.py lines 1094-1127)
+# ---------------------------------------------------------------------------
+
+
+class TestMapApiExcToErrorKey:
+    """Empiricism: 5-branch dispatcher — DependencyNotReady > name > status > aiohttp > guard > unknown."""
+
+    def test_dependency_not_ready_wins(self) -> None:
+        err = cf.DependencyNotReady("deps missing")
+        assert cf._map_api_exc_to_error_key(err) == "dependency_not_ready"
+
+    @pytest.mark.parametrize(
+        "exc_cls_name",
+        ["AuthError", "UnauthorizedAccess", "ForbiddenRequest", "CredentialFailure"],
+    )
+    def test_auth_keywords_in_name(self, exc_cls_name: str) -> None:
+        cls = type(exc_cls_name, (Exception,), {})
+        assert cf._map_api_exc_to_error_key(cls("x")) == "invalid_auth"
+
+    def test_status_401_maps_to_invalid_auth(self) -> None:
+        err = type("HttpError", (Exception,), {})("nope")
+        err.status = 401  # type: ignore[attr-defined]
+        assert cf._map_api_exc_to_error_key(err) == "invalid_auth"
+
+    def test_status_code_attribute_403(self) -> None:
+        err = type("HttpError", (Exception,), {})("nope")
+        err.status_code = 403  # type: ignore[attr-defined]
+        assert cf._map_api_exc_to_error_key(err) == "invalid_auth"
+
+    def test_status_as_string_digit(self) -> None:
+        err = type("HttpError", (Exception,), {})("nope")
+        err.status = "401"  # type: ignore[attr-defined]
+        assert cf._map_api_exc_to_error_key(err) == "invalid_auth"
+
+    def test_status_as_bool_true_is_one(self) -> None:
+        # Empiricism (lines 1108-1109): bool is checked BEFORE int — True -> 1, not 401.
+        err = type("HttpError", (Exception,), {})("nope")
+        err.status = True  # type: ignore[attr-defined]
+        result = cf._map_api_exc_to_error_key(err)
+        # 1 is not in (401, 403) → falls through to network heuristic → name has no
+        # timeout/connect → ends in "unknown".
+        assert result == "unknown"
+
+    def test_non_digit_status_string_falls_through(self) -> None:
+        err = type("HttpError", (Exception,), {})("nope")
+        err.status = "Service Unavailable"  # type: ignore[attr-defined]
+        # Not digit → status_int stays None → falls through.
+        assert cf._map_api_exc_to_error_key(err) == "unknown"
+
+    def test_timeout_in_class_name_maps_to_cannot_connect(self) -> None:
+        cls = type("ReadTimeoutError", (Exception,), {})
+        assert cf._map_api_exc_to_error_key(cls("x")) == "cannot_connect"
+
+    def test_connection_in_class_name(self) -> None:
+        cls = type("ConnectionRefusedError", (Exception,), {})
+        assert cf._map_api_exc_to_error_key(cls("x")) == "cannot_connect"
+
+    def test_multi_entry_guard_returns_unknown(self) -> None:
+        # Even though the guard is recognized, the mapping is still "unknown".
+        assert (
+            cf._map_api_exc_to_error_key(Exception("Multiple config entries active"))
+            == "unknown"
+        )
+
+    def test_plain_runtime_error_unknown(self) -> None:
+        assert cf._map_api_exc_to_error_key(RuntimeError("boom")) == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Block F: secrets extractors (cf.py lines 1167-1251)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractEmailFromSecrets:
+    """Empiricism: flat key priority list, then nested ``account.email`` fallback."""
+
+    def test_prefers_google_home_username(self) -> None:
+        data: dict[str, Any] = {
+            "googleHomeUsername": "primary@example.com",
+            cf.CONF_GOOGLE_EMAIL: "other@example.com",
+            "email": "third@example.com",
+        }
+        assert cf._extract_email_from_secrets(data) == "primary@example.com"
+
+    def test_falls_through_to_conf_google_email(self) -> None:
+        data = {cf.CONF_GOOGLE_EMAIL: "via_conf@example.com"}
+        assert cf._extract_email_from_secrets(data) == "via_conf@example.com"
+
+    def test_nested_account_email_fallback(self) -> None:
+        data: dict[str, Any] = {"account": {"email": "nested@example.com"}}
+        assert cf._extract_email_from_secrets(data) == "nested@example.com"
+
+    def test_nested_lookup_swallows_exceptions(self) -> None:
+        # account is a string → indexing raises → swallowed → None.
+        assert cf._extract_email_from_secrets({"account": "not-a-dict"}) is None
+
+    def test_non_email_values_are_rejected(self) -> None:
+        data = {"email": "no_at_sign"}
+        assert cf._extract_email_from_secrets(data) is None
+
+    def test_returns_none_when_no_candidates(self) -> None:
+        assert cf._extract_email_from_secrets({}) is None
+
+
+class TestExtractOauthCandidatesFromSecrets:
+    """Empiricism: aas_token first, then flat keys, then fcm fallbacks; de-dup."""
+
+    def test_aas_token_listed_first(self) -> None:
+        data: dict[str, Any] = {
+            cf.CONF_OAUTH_TOKEN: "oauth_token_value_with_padding_xxxx",
+            "aas_token": "aas_token_value_with_padding_xxxx",
+        }
+        cands = cf._extract_oauth_candidates_from_secrets(data)
+        labels = [label for label, _token in cands]
+        assert labels[0] == "aas_token"
+        assert cf.CONF_OAUTH_TOKEN in labels
+
+    def test_deduplicates_repeated_token_value(self) -> None:
+        token = "shared_token_value_padding_xxxx"
+        data = {
+            "aas_token": token,
+            "oauth_token": token,
+            "access_token": token,
+        }
+        cands = cf._extract_oauth_candidates_from_secrets(data)
+        # All three keys point to the same token → only first survives dedup.
+        assert len(cands) == 1
+        assert cands[0][0] == "aas_token"
+
+    def test_skips_implausible_tokens(self) -> None:
+        data: dict[str, Any] = {
+            "aas_token": "short",  # < 16 chars
+            "oauth_token": None,  # not a string
+            "token": "valid_token_padding_xxxxxxxxxxxx",
+        }
+        cands = cf._extract_oauth_candidates_from_secrets(data)
+        assert [label for label, _token in cands] == ["token"]
+
+    def test_fcm_credentials_used_as_fallback(self) -> None:
+        data = {
+            "fcm_credentials": {
+                "installation": {"token": "fcm_install_token_padding_xxxx"},
+                "fcm": {
+                    "registration": {"token": "fcm_register_token_padding_xx"}
+                },
+            }
+        }
+        cands = cf._extract_oauth_candidates_from_secrets(data)
+        labels = {label for label, _token in cands}
+        assert {"fcm_installation", "fcm_registration"} <= labels
+
+    def test_partial_fcm_paths_swallowed(self) -> None:
+        # Missing nested key raises KeyError, caught by except.
+        data = {"fcm_credentials": {"installation": "not-a-dict"}}
+        # Should not raise; just return whatever else is plausible (here: nothing).
+        cands = cf._extract_oauth_candidates_from_secrets(data)
+        assert cands == []
+
+    def test_empty_payload(self) -> None:
+        assert cf._extract_oauth_candidates_from_secrets({}) == []
+
+
+class TestExtractFcmCredentialsFromSecrets:
+    """Empiricism: returns dict if present, otherwise None; swallows exceptions."""
+
+    def test_returns_dict_when_present(self) -> None:
+        creds = {"installation": {"token": "x"}}
+        assert cf._extract_fcm_credentials_from_secrets({"fcm_credentials": creds}) is creds
+
+    def test_returns_none_when_absent(self) -> None:
+        assert cf._extract_fcm_credentials_from_secrets({}) is None
+
+    def test_returns_none_when_not_a_dict(self) -> None:
+        assert (
+            cf._extract_fcm_credentials_from_secrets({"fcm_credentials": "string"})
+            is None
+        )
+
+
+# ---------------------------------------------------------------------------
+# Block G: candidate labels + credential interpreters (cf.py lines 1360-1478)
+# ---------------------------------------------------------------------------
+
+
+class TestCandLabels:
+    """Empiricism: lines 1360-1365 — sorted unique source labels or 'none'."""
+
+    def test_returns_none_for_empty_list(self) -> None:
+        assert cf._cand_labels([]) == "none"
+
+    def test_returns_none_when_all_labels_blank(self) -> None:
+        # Sources falsy → filtered out → empty set → "none".
+        assert cf._cand_labels([("", "tok1"), ("", "tok2")]) == "none"
+
+    def test_sorted_unique(self) -> None:
+        cands = [
+            ("oauth_token", "a" * 16),
+            ("aas_token", "b" * 16),
+            ("oauth_token", "c" * 16),  # duplicate label
+        ]
+        assert cf._cand_labels(cands) == "aas_token, oauth_token"
+
+
+class TestLogTokenValidationFailure:
+    """Empiricism: emits a single warning with masked email + candidate sources."""
+
+    def test_emits_warning_with_masked_email(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.WARNING, logger=cf._LOGGER.name)
+        cf._log_token_validation_failure(
+            email="user@example.com",
+            candidates=[("aas_token", "x" * 16)],
+        )
+        assert any(
+            "Token validation failed" in record.getMessage()
+            for record in caplog.records
+        )
+
+
+class TestInterpretCredentialsChoice:
+    """Empiricism: lines 1385-1435 — secrets XOR (token AND email)."""
+
+    def test_mixing_secrets_and_token_returns_choose_one(self) -> None:
+        method, email, cands, err = cf._interpret_credentials_choice(
+            {"secrets_json": "{}", "oauth_token": "tok", "email": ""},
+            secrets_field="secrets_json",
+            token_field="oauth_token",
+            email_field="email",
+        )
+        assert (method, email, cands, err) == (None, None, None, "choose_one")
+
+    def test_completely_empty_input_returns_choose_one(self) -> None:
+        method, email, cands, err = cf._interpret_credentials_choice(
+            {"secrets_json": "", "oauth_token": "", "email": ""},
+            secrets_field="secrets_json",
+            token_field="oauth_token",
+            email_field="email",
+        )
+        assert err == "choose_one"
+        assert method is None and email is None and cands is None
+
+    def test_invalid_json_returns_invalid_json(self) -> None:
+        method, email, cands, err = cf._interpret_credentials_choice(
+            {"secrets_json": "not json", "oauth_token": "", "email": ""},
+            secrets_field="secrets_json",
+            token_field="oauth_token",
+            email_field="email",
+        )
+        assert (method, email, cands, err) == ("secrets", None, None, "invalid_json")
+
+    def test_secrets_not_a_dict_returns_invalid_json(self) -> None:
+        # JSON arrays parse successfully but fail the dict check.
+        method, _email, _cands, err = cf._interpret_credentials_choice(
+            {"secrets_json": "[1, 2]", "oauth_token": "", "email": ""},
+            secrets_field="secrets_json",
+            token_field="oauth_token",
+            email_field="email",
+        )
+        assert (method, err) == ("secrets", "invalid_json")
+
+    def test_secrets_path_happy(self) -> None:
+        secrets = {
+            "googleHomeUsername": "user@example.com",
+            "aas_token": "aas_token_value_padding_xxxxxxx",
+        }
+        method, email, cands, err = cf._interpret_credentials_choice(
+            {
+                "secrets_json": json.dumps(secrets),
+                "oauth_token": "",
+                "email": "",
+            },
+            secrets_field="secrets_json",
+            token_field="oauth_token",
+            email_field="email",
+        )
+        assert method == "secrets"
+        assert email == "user@example.com"
+        assert cands and cands[0][0] == "aas_token"
+        assert err is None
+
+    def test_secrets_path_invalid_token(self) -> None:
+        # Email valid but no plausible tokens → invalid_token.
+        secrets = {"googleHomeUsername": "user@example.com", "aas_token": "short"}
+        method, _email, _cands, err = cf._interpret_credentials_choice(
+            {
+                "secrets_json": json.dumps(secrets),
+                "oauth_token": "",
+                "email": "",
+            },
+            secrets_field="secrets_json",
+            token_field="oauth_token",
+            email_field="email",
+        )
+        assert (method, err) == ("secrets", "invalid_token")
+
+    def test_manual_path_happy(self) -> None:
+        method, email, cands, err = cf._interpret_credentials_choice(
+            {
+                "secrets_json": "",
+                "oauth_token": "a" * 32,
+                "email": "user@example.com",
+            },
+            secrets_field="secrets_json",
+            token_field="oauth_token",
+            email_field="email",
+        )
+        assert method == "manual"
+        assert email == "user@example.com"
+        assert cands == [("manual", "a" * 32)]
+        assert err is None
+
+    def test_manual_path_rejects_jwt(self) -> None:
+        method, _email, _cands, err = cf._interpret_credentials_choice(
+            {
+                "secrets_json": "",
+                "oauth_token": "eyJabc.eyJdef.signature_padding_xxxx",
+                "email": "user@example.com",
+            },
+            secrets_field="secrets_json",
+            token_field="oauth_token",
+            email_field="email",
+        )
+        # JWT-shaped tokens cannot be persisted.
+        assert (method, err) == ("manual", "invalid_token")
+
+    def test_manual_path_invalid_email(self) -> None:
+        method, _email, _cands, err = cf._interpret_credentials_choice(
+            {
+                "secrets_json": "",
+                "oauth_token": "a" * 32,
+                "email": "not-an-email",
+            },
+            secrets_field="secrets_json",
+            token_field="oauth_token",
+            email_field="email",
+        )
+        assert (method, err) == ("manual", "invalid_token")
+
+
+class TestInterpretReauthChoice:
+    """Empiricism: lines 1445-1478 — secrets XOR (currently disabled) token."""
+
+    def test_both_paths_active_returns_choose_one(self) -> None:
+        method, data, err = cf._interpret_reauth_choice(
+            {"secrets_json": "{}", "new_oauth_token": "tok"}
+        )
+        assert (method, data, err) == (None, None, "choose_one")
+
+    def test_neither_path_returns_choose_one(self) -> None:
+        method, data, err = cf._interpret_reauth_choice(
+            {"secrets_json": "", "new_oauth_token": ""}
+        )
+        assert (method, data, err) == (None, None, "choose_one")
+
+    def test_secrets_path_happy(self) -> None:
+        payload = {
+            "googleHomeUsername": "user@example.com",
+            "aas_token": "aas_token_value_padding_xxxxxxx",
+        }
+        method, data, err = cf._interpret_reauth_choice(
+            {"secrets_json": json.dumps(payload), "new_oauth_token": ""}
+        )
+        assert method == "secrets"
+        assert isinstance(data, dict) and data["googleHomeUsername"] == "user@example.com"
+        assert err is None
+
+    def test_secrets_path_invalid_json(self) -> None:
+        method, data, err = cf._interpret_reauth_choice(
+            {"secrets_json": "garbage", "new_oauth_token": ""}
+        )
+        assert (method, data, err) == (None, None, "invalid_json")
+
+    def test_secrets_path_array_not_dict(self) -> None:
+        method, data, err = cf._interpret_reauth_choice(
+            {"secrets_json": "[]", "new_oauth_token": ""}
+        )
+        assert (method, data, err) == (None, None, "invalid_json")
+
+    def test_secrets_invalid_token_returns_invalid_token(self) -> None:
+        # Email present but no plausible candidate token.
+        payload = {"googleHomeUsername": "user@example.com"}
+        method, data, err = cf._interpret_reauth_choice(
+            {"secrets_json": json.dumps(payload), "new_oauth_token": ""}
+        )
+        assert (method, data, err) == (None, None, "invalid_token")
+
+    def test_token_only_path_falls_through_to_choose_one(self) -> None:
+        # The manual reauth token path is intentionally disabled — falls through
+        # to "choose_one" until re-enabled.
+        method, data, err = cf._interpret_reauth_choice(
+            {"secrets_json": "", "new_oauth_token": "a" * 32}
+        )
+        assert (method, data, err) == (None, None, "choose_one")
+
+
+# ---------------------------------------------------------------------------
+# Block H: entry resolver, masking, callbacks (cf.py lines 1481-1606, 745-774)
+# ---------------------------------------------------------------------------
+
+
+class TestMaskEmailForLogs:
+    """Empiricism: privacy-preserving mask for logs."""
+
+    def test_typical_email_masked(self) -> None:
+        assert cf._mask_email_for_logs("user@example.com") == "u***@example.com"
+
+    def test_single_char_local_part(self) -> None:
+        assert cf._mask_email_for_logs("a@example.com") == "*@example.com"
+
+    def test_missing_local_returns_star_at_domain(self) -> None:
+        # "@example.com" → local="" → returns "*@example.com" (line 771).
+        assert cf._mask_email_for_logs("@example.com") == "*@example.com"
+
+    def test_none_returns_unknown(self) -> None:
+        assert cf._mask_email_for_logs(None) == "<unknown>"
+
+    def test_empty_returns_unknown(self) -> None:
+        assert cf._mask_email_for_logs("") == "<unknown>"
+
+    def test_no_at_returns_unknown(self) -> None:
+        assert cf._mask_email_for_logs("no-at-sign") == "<unknown>"
+
+
+class TestTypedCallback:
+    """Empiricism: lines 745-748 — preserves the wrapped callable via HA callback."""
+
+    def test_returns_decorated_callable(self) -> None:
+        def fn(x: int) -> int:
+            return x * 2
+
+        wrapped = cf._typed_callback(fn)
+        assert callable(wrapped)
+        # The decorator from HA returns the same function instance (it just tags it),
+        # so behaviour must be preserved.
+        assert wrapped(3) == 6
+
+
+class TestIsDiscoveryUpdateInfo:
+    """Empiricism: lines 751-760 — recognizes two source identifiers."""
+
+    def test_recognizes_primary_source(self) -> None:
+        assert cf._is_discovery_update_info({"source": cf.DISCOVERY_UPDATE_SOURCE})
+
+    def test_recognizes_legacy_source(self) -> None:
+        assert cf._is_discovery_update_info(
+            {"source": cf.LEGACY_DISCOVERY_UPDATE_SOURCE}
+        )
+
+    def test_rejects_unrelated_source(self) -> None:
+        assert cf._is_discovery_update_info({"source": "user"}) is False
+
+    def test_rejects_none(self) -> None:
+        assert cf._is_discovery_update_info(None) is False
+
+    def test_rejects_non_mapping(self) -> None:
+        assert cf._is_discovery_update_info("not-a-mapping") is False  # type: ignore[arg-type]
+
+
+class TestRegisterDependencyError:
+    """Empiricism: lines 653-663 — single-shot record for "base" field."""
+
+    def test_records_import_failed_once(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.ERROR, logger=cf._LOGGER.name)
+        errors: dict[str, str] = {}
+        cf._register_dependency_error(errors, ImportError("boom"))
+        assert errors == {"base": "import_failed"}
+        # Second call with same field is a no-op.
+        cf._register_dependency_error(errors, ImportError("again"))
+        assert errors == {"base": "import_failed"}
+
+    def test_uses_custom_field(self) -> None:
+        errors: dict[str, str] = {}
+        cf._register_dependency_error(errors, ImportError("x"), field="oauth")
+        assert errors == {"oauth": "import_failed"}
+
+
+class TestEnsureOptionalEntryAttributes:
+    """Empiricism: lines 1586-1605 — fills missing attrs, defends against slot stubs."""
+
+    def test_none_entry_is_noop(self) -> None:
+        # No raise, no side effects.
+        cf._ensure_optional_entry_attributes(None)  # type: ignore[arg-type]
+
+    def test_missing_source_is_populated(self) -> None:
+        entry = SimpleNamespace()
+        cf._ensure_optional_entry_attributes(entry)  # type: ignore[arg-type]
+        assert hasattr(entry, "source")
+        assert entry.source is None  # type: ignore[attr-defined]
+
+    def test_existing_source_is_preserved(self) -> None:
+        entry = SimpleNamespace(source="user")
+        cf._ensure_optional_entry_attributes(entry)  # type: ignore[arg-type]
+        assert entry.source == "user"
+
+    def test_slots_object_does_not_raise(self) -> None:
+        # A class with __slots__ that does NOT include "source" must not crash
+        # the helper; the defensive try/except swallows the AttributeError.
+        class Slotted:
+            __slots__ = ("entry_id",)
+
+            def __init__(self) -> None:
+                self.entry_id = "e1"
+
+        cf._ensure_optional_entry_attributes(Slotted())  # type: ignore[arg-type]
+
+
+class TestResolveEntryEmailForLookup:
+    """Empiricism: lines 1481-1528 — caches resolver, defensively guards exceptions."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_resolver_cache(self) -> Any:
+        """Reset the module-level lazy cache between tests."""
+        original_resolve = cf._RESOLVE_ENTRY_EMAIL
+        original_coalesce = cf._COALESCE_ENTRIES
+        cf._RESOLVE_ENTRY_EMAIL = None
+        cf._COALESCE_ENTRIES = None
+        yield
+        cf._RESOLVE_ENTRY_EMAIL = original_resolve
+        cf._COALESCE_ENTRIES = original_coalesce
+
+    def test_uses_data_then_options_for_email(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Force the fallback resolver by making the integration import return a
+        # module without _resolve_entry_email.
+        fake_pkg = SimpleNamespace()
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.config_flow.import_integration_package",
+            lambda: fake_pkg,
+            raising=True,
+        )
+
+        entry = SimpleNamespace(
+            data={cf.CONF_GOOGLE_EMAIL: "  Found@Example.com  "},
+            options={},
+            entry_id="entry-1",
+        )
+        raw, normalized = cf._resolve_entry_email_for_lookup(entry)  # type: ignore[arg-type]
+        assert raw == "Found@Example.com"
+        assert normalized == "found@example.com"
+
+    def test_options_used_when_data_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_pkg = SimpleNamespace()
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.config_flow.import_integration_package",
+            lambda: fake_pkg,
+            raising=True,
+        )
+
+        entry = SimpleNamespace(
+            data={},
+            options={cf.CONF_GOOGLE_EMAIL: "opts@example.com"},
+            entry_id="entry-2",
+        )
+        raw, normalized = cf._resolve_entry_email_for_lookup(entry)  # type: ignore[arg-type]
+        assert raw == "opts@example.com"
+        assert normalized == "opts@example.com"
+
+    def test_no_email_returns_none_pair(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_pkg = SimpleNamespace()
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.config_flow.import_integration_package",
+            lambda: fake_pkg,
+            raising=True,
+        )
+        entry = SimpleNamespace(data={}, options={}, entry_id="entry-3")
+        raw, normalized = cf._resolve_entry_email_for_lookup(entry)  # type: ignore[arg-type]
+        assert raw is None and normalized is None
+
+    def test_custom_resolver_from_integration_is_used(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        called: list[Any] = []
+
+        def custom_resolver(entry: Any) -> tuple[str | None, str | None]:
+            called.append(entry)
+            return ("Raw@X.com", "raw@x.com")
+
+        fake_pkg = SimpleNamespace(_resolve_entry_email=custom_resolver)
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.config_flow.import_integration_package",
+            lambda: fake_pkg,
+            raising=True,
+        )
+        entry = SimpleNamespace(entry_id="e")
+        raw, normalized = cf._resolve_entry_email_for_lookup(entry)  # type: ignore[arg-type]
+        assert (raw, normalized) == ("Raw@X.com", "raw@x.com")
+        assert called and called[0] is entry
+
+
+class TestFindEntryByEmail:
+    """Empiricism: lines 1531-1542 — match against normalized email."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_resolver_cache(self) -> Any:
+        original = cf._RESOLVE_ENTRY_EMAIL
+        cf._RESOLVE_ENTRY_EMAIL = None
+        yield
+        cf._RESOLVE_ENTRY_EMAIL = original
+
+    def _make_hass_with_entries(self, entries: list[Any]) -> Any:
+        async_entries = lambda _domain: entries  # noqa: E731
+        return SimpleNamespace(
+            config_entries=SimpleNamespace(async_entries=async_entries)
+        )
+
+    def test_empty_target_returns_none(self) -> None:
+        hass = self._make_hass_with_entries([])
+        assert cf._find_entry_by_email(hass, "") is None
+
+    def test_matches_normalized_email(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_pkg = SimpleNamespace()
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.config_flow.import_integration_package",
+            lambda: fake_pkg,
+            raising=True,
+        )
+        e1 = SimpleNamespace(
+            data={cf.CONF_GOOGLE_EMAIL: "Match@Example.com"},
+            options={},
+            entry_id="e1",
+        )
+        e2 = SimpleNamespace(
+            data={cf.CONF_GOOGLE_EMAIL: "other@example.com"},
+            options={},
+            entry_id="e2",
+        )
+        hass = self._make_hass_with_entries([e2, e1])
+        result = cf._find_entry_by_email(hass, "MATCH@example.com")
+        assert result is e1
+
+    def test_no_match_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_pkg = SimpleNamespace()
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.config_flow.import_integration_package",
+            lambda: fake_pkg,
+            raising=True,
+        )
+        e1 = SimpleNamespace(
+            data={cf.CONF_GOOGLE_EMAIL: "x@example.com"},
+            options={},
+            entry_id="e1",
+        )
+        hass = self._make_hass_with_entries([e1])
+        assert cf._find_entry_by_email(hass, "y@example.com") is None
+
+
+# ---------------------------------------------------------------------------
+# Block I: discovery helpers (cf.py lines 1622-1740)
+# ---------------------------------------------------------------------------
+
+
+class TestSubentryOptionProperty:
+    """Empiricism: lines 901-916 — subentry_id falls through to None when missing."""
+
+    def test_subentry_id_returns_attribute_when_present(self) -> None:
+        sub = SimpleNamespace(subentry_id="abc")
+        opt = cf._SubentryOption(
+            key="k", label="L", subentry=sub, visible_device_ids=()  # type: ignore[arg-type]
+        )
+        assert opt.subentry_id == "abc"
+
+    def test_subentry_id_none_when_subentry_missing(self) -> None:
+        opt = cf._SubentryOption(
+            key="k", label="L", subentry=None, visible_device_ids=()
+        )
+        assert opt.subentry_id is None
+
+    def test_subentry_id_none_when_attribute_absent(self) -> None:
+        # A subentry object without subentry_id attribute → getattr returns None.
+        opt = cf._SubentryOption(
+            key="k", label="L", subentry=SimpleNamespace(), visible_device_ids=()  # type: ignore[arg-type]
+        )
+        assert opt.subentry_id is None
+
+
+class TestDiscoveryFlowError:
+    """Empiricism: lines 1613-1618 — exposes ``reason`` attribute."""
+
+    def test_reason_is_captured(self) -> None:
+        err = cf.DiscoveryFlowError("invalid_discovery_info")
+        assert err.reason == "invalid_discovery_info"
+        assert "invalid_discovery_info" in str(err)
+
+
+class TestDiscoveryPayloadEquivalent:
+    """Empiricism: lines 1632-1646 — three layered equality checks."""
+
+    def _make(
+        self,
+        *,
+        email: str = "user@example.com",
+        uid: str = "acct:user@example.com",
+        cands: tuple[tuple[str, str], ...] = (("aas_token", "x" * 16),),
+        bundle: Any | None = None,
+        title: str | None = None,
+    ) -> cf.CloudDiscoveryData:
+        return cf.CloudDiscoveryData(
+            email=email,
+            unique_id=uid,
+            candidates=cands,
+            secrets_bundle=bundle,
+            title=title,
+        )
+
+    def test_equal_when_all_fields_match(self) -> None:
+        a = self._make()
+        b = self._make()
+        assert cf._discovery_payload_equivalent(a, b) is True
+
+    def test_differing_unique_id(self) -> None:
+        a = self._make(uid="acct:a")
+        b = self._make(uid="acct:b")
+        assert cf._discovery_payload_equivalent(a, b) is False
+
+    def test_differing_email(self) -> None:
+        a = self._make(email="a@x.com")
+        b = self._make(email="b@x.com")
+        assert cf._discovery_payload_equivalent(a, b) is False
+
+    def test_differing_candidates(self) -> None:
+        a = self._make(cands=(("x", "y" * 16),))
+        b = self._make(cands=(("x", "z" * 16),))
+        assert cf._discovery_payload_equivalent(a, b) is False
+
+    def test_both_bundles_none_remains_equal(self) -> None:
+        a = self._make(bundle=None)
+        b = self._make(bundle=None)
+        assert cf._discovery_payload_equivalent(a, b) is True
+
+    def test_one_bundle_none_is_not_equivalent(self) -> None:
+        a = self._make(bundle=None)
+        b = self._make(bundle={"k": "v"})
+        assert cf._discovery_payload_equivalent(a, b) is False
+
+    def test_equal_bundles_match(self) -> None:
+        a = self._make(bundle={"k": "v"})
+        b = self._make(bundle={"k": "v"})
+        assert cf._discovery_payload_equivalent(a, b) is True
+
+
+class TestNormalizeAndValidateDiscoveryPayload:
+    """Empiricism: lines 1649-1740 — multi-branch normalizer for discovery info."""
+
+    def test_non_mapping_raises_invalid_discovery_info(self) -> None:
+        with pytest.raises(cf.DiscoveryFlowError) as exc_info:
+            cf._normalize_and_validate_discovery_payload(None)
+        assert exc_info.value.reason == "invalid_discovery_info"
+
+    def test_missing_email_raises(self) -> None:
+        with pytest.raises(cf.DiscoveryFlowError) as exc_info:
+            cf._normalize_and_validate_discovery_payload({"candidate_tokens": "tok"})
+        assert exc_info.value.reason == "invalid_discovery_info"
+
+    def test_invalid_secrets_json_raises(self) -> None:
+        with pytest.raises(cf.DiscoveryFlowError) as exc_info:
+            cf._normalize_and_validate_discovery_payload(
+                {cf.CONF_GOOGLE_EMAIL: "user@example.com", "secrets_json": "{bad"}
+            )
+        assert exc_info.value.reason == "invalid_discovery_info"
+
+    def test_email_only_without_candidates_raises_cannot_connect(self) -> None:
+        with pytest.raises(cf.DiscoveryFlowError) as exc_info:
+            cf._normalize_and_validate_discovery_payload(
+                {cf.CONF_GOOGLE_EMAIL: "user@example.com"}
+            )
+        # Valid email but no token candidates → cannot_connect.
+        assert exc_info.value.reason == "cannot_connect"
+
+    def test_secrets_provide_email_and_candidates(self) -> None:
+        secrets = {
+            "googleHomeUsername": "user@example.com",
+            "aas_token": "aas_token_value_padding_xxxxxxx",
+        }
+        payload = {cf.DATA_SECRET_BUNDLE: secrets}
+        result = cf._normalize_and_validate_discovery_payload(payload)
+        assert result.email == "user@example.com"
+        assert result.unique_id.startswith("acct:")
+        labels = {label for label, _token in result.candidates}
+        assert "aas_token" in labels
+        assert result.secrets_bundle is not None
+
+    def test_secrets_json_string_is_parsed(self) -> None:
+        secrets = {
+            "googleHomeUsername": "user@example.com",
+            "aas_token": "aas_token_value_padding_xxxxxxx",
+        }
+        payload = {
+            cf.CONF_GOOGLE_EMAIL: "user@example.com",
+            "secrets_json": json.dumps(secrets),
+        }
+        result = cf._normalize_and_validate_discovery_payload(payload)
+        assert result.email == "user@example.com"
+
+    def test_candidate_tokens_string_form(self) -> None:
+        payload = {
+            cf.CONF_GOOGLE_EMAIL: "user@example.com",
+            "candidate_tokens": "a" * 32,
+        }
+        result = cf._normalize_and_validate_discovery_payload(payload)
+        labels = {label for label, _token in result.candidates}
+        assert "candidate_tokens" in labels
+
+    def test_candidate_tokens_mapping_form(self) -> None:
+        payload = {
+            cf.CONF_GOOGLE_EMAIL: "user@example.com",
+            "candidates": {"primary": "a" * 32, "secondary": "b" * 32},
+        }
+        result = cf._normalize_and_validate_discovery_payload(payload)
+        labels = {label for label, _token in result.candidates}
+        assert {"primary", "secondary"} <= labels
+
+    def test_candidate_tokens_iterable_of_mappings(self) -> None:
+        payload = {
+            cf.CONF_GOOGLE_EMAIL: "user@example.com",
+            "tokens": [
+                {"label": "first", "token": "a" * 32},
+                {"source": "second", "token": "b" * 32},
+                {"token": "c" * 32},  # neither label nor source → falls back to key
+            ],
+        }
+        result = cf._normalize_and_validate_discovery_payload(payload)
+        labels = {label for label, _token in result.candidates}
+        assert {"first", "second", "tokens"} <= labels
+
+    def test_candidate_tokens_iterable_of_strings(self) -> None:
+        payload = {
+            cf.CONF_GOOGLE_EMAIL: "user@example.com",
+            "tokens": ["a" * 32, "b" * 32],
+        }
+        result = cf._normalize_and_validate_discovery_payload(payload)
+        labels = {label for label, _token in result.candidates}
+        # Strings in an iterable produce labels of the form "{key}_{idx}".
+        assert any(label.startswith("tokens_") for label in labels)
+
+    def test_direct_oauth_token_keys(self) -> None:
+        payload = {
+            cf.CONF_GOOGLE_EMAIL: "user@example.com",
+            cf.CONF_OAUTH_TOKEN: "a" * 32,
+        }
+        result = cf._normalize_and_validate_discovery_payload(payload)
+        assert any(
+            label == cf.CONF_OAUTH_TOKEN for label, _token in result.candidates
+        )
+
+    def test_title_propagated_when_string(self) -> None:
+        payload = {
+            cf.CONF_GOOGLE_EMAIL: "user@example.com",
+            cf.CONF_OAUTH_TOKEN: "a" * 32,
+            "title": "My Account",
+        }
+        result = cf._normalize_and_validate_discovery_payload(payload)
+        assert result.title == "My Account"
+
+    def test_non_string_title_becomes_none(self) -> None:
+        payload = {
+            cf.CONF_GOOGLE_EMAIL: "user@example.com",
+            cf.CONF_OAUTH_TOKEN: "a" * 32,
+            "title": 123,
+        }
+        result = cf._normalize_and_validate_discovery_payload(payload)
+        assert result.title is None
+
+    def test_invalid_email_raises_invalid_discovery_info(self) -> None:
+        # candidate_tokens valid, email malformed.
+        payload = {
+            cf.CONF_GOOGLE_EMAIL: "not-an-email",
+            cf.CONF_OAUTH_TOKEN: "a" * 32,
+        }
+        with pytest.raises(cf.DiscoveryFlowError) as exc_info:
+            cf._normalize_and_validate_discovery_payload(payload)
+        assert exc_info.value.reason == "invalid_discovery_info"
+
+
+# ---------------------------------------------------------------------------
+# Block J: module-level constants (cheap, smoke-tests imports)
+# ---------------------------------------------------------------------------
+
+
+class TestModuleConstants:
+    """Sanity-check module-level constants to lock the surface."""
+
+    def test_email_regex_is_compiled(self) -> None:
+        assert isinstance(cf._EMAIL_RE, re.Pattern)
+
+    def test_token_regex_is_compiled(self) -> None:
+        assert isinstance(cf._TOKEN_RE, re.Pattern)
+
+    def test_auth_method_constants_present(self) -> None:
+        assert cf._AUTH_METHOD_SECRETS == "secrets_json"
+        assert cf._AUTH_METHOD_INDIVIDUAL == "individual_tokens"
+
+    def test_discovery_update_sources_distinct(self) -> None:
+        assert cf.DISCOVERY_UPDATE_SOURCE != cf.LEGACY_DISCOVERY_UPDATE_SOURCE
+
+    def test_default_subentry_titles_cover_known_keys(self) -> None:
+        assert cf.TRACKER_SUBENTRY_KEY in cf._DEFAULT_SUBENTRY_TITLES
+        assert cf.SERVICE_SUBENTRY_KEY in cf._DEFAULT_SUBENTRY_TITLES
+
+    def test_step_user_schema_validates_secrets_method(self) -> None:
+        # Smoke-test the schema accepts the secrets_json auth method.
+        validated = cf.STEP_USER_DATA_SCHEMA({"auth_method": "secrets_json"})
+        assert validated == {"auth_method": "secrets_json"}
+
+    def test_step_secrets_schema_passes_through_string(self) -> None:
+        validated = cf.STEP_SECRETS_DATA_SCHEMA({"secrets_json": "{}"})
+        assert validated == {"secrets_json": "{}"}

--- a/tests/test_coordinator_identity_basics.py
+++ b/tests/test_coordinator_identity_basics.py
@@ -1,0 +1,485 @@
+# tests/test_coordinator_identity_basics.py
+"""Branch-coverage tests for the simple ``IdentityOperations`` mixin methods.
+
+PR 1.A.2 (Phase 2, AP-A). Scope: ``coordinator/identity.py`` lines 72-233
+(``_get_account_email``, ``_create_auth_issue``, ``_dismiss_auth_issue``,
+``_schedule_eid_resolver_refresh``, ``_register_identity_key``,
+``_reset_resolver_offset``). The complex ``get_active_device_identities``
+(lines 235-967) lands in a later AP.
+
+Aniche-style adequacy progression: Specification → Boundary → Structural.
+:class:`IdentityStub` (``tests.helpers.identity_mixin_stub``) seeds every
+attribute ``_MixinBase`` declares and pre-mocks ``_entry_id``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import issue_registry as ir
+
+from custom_components.googlefindmy.const import (
+    CONF_GOOGLE_EMAIL,
+    DATA_EID_RESOLVER,
+    DOMAIN,
+    ISSUE_AUTH_EXPIRED_KEY,
+    issue_id_for,
+)
+from custom_components.googlefindmy.coordinator import identity as identity_mod
+from tests.helpers.config_entries_stub import make_config_entry
+from tests.helpers.identity_mixin_stub import IdentityStub, make_hass_stub
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def coord() -> IdentityStub:
+    """Return a default :class:`IdentityStub` bound to a synthetic config entry."""
+
+    entry = make_config_entry(
+        entry_id="entry-xyz",
+        title="My GFM Account",
+        data={CONF_GOOGLE_EMAIL: "user@example.com"},
+    )
+    return IdentityStub(hass=make_hass_stub(), config_entry=entry)
+
+
+@pytest.fixture
+def coord_no_entry() -> IdentityStub:
+    """Return a stub without a bound ``ConfigEntry`` (early-startup state)."""
+
+    return IdentityStub(hass=make_hass_stub(), config_entry=None)
+
+
+# ---------------------------------------------------------------------------
+# M1 ``_get_account_email`` (3 branches)
+# ---------------------------------------------------------------------------
+
+
+class TestGetAccountEmail:
+    """B1: no entry → ''; B2: email is str → return; B3: missing/non-str → ''."""
+
+    def test_no_entry_returns_empty(self, coord_no_entry: IdentityStub) -> None:
+        assert coord_no_entry._get_account_email() == ""
+
+    def test_str_email_is_returned(self, coord: IdentityStub) -> None:
+        assert coord._get_account_email() == "user@example.com"
+
+    def test_missing_email_key_returns_empty(self) -> None:
+        # ``data`` is an empty dict — ``.get`` returns ``None`` (non-str branch).
+        entry = make_config_entry(entry_id="entry-abc", data={})
+        stub = IdentityStub(config_entry=entry)
+        assert stub._get_account_email() == ""
+
+    def test_non_str_email_returns_empty(self) -> None:
+        # ``data`` carries a non-str value (e.g. int from corrupted storage).
+        entry = make_config_entry(entry_id="entry-abc", data={CONF_GOOGLE_EMAIL: 42})
+        stub = IdentityStub(config_entry=entry)
+        assert stub._get_account_email() == ""
+
+
+# ---------------------------------------------------------------------------
+# M2 ``_create_auth_issue`` (3 branches)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateAuthIssue:
+    """B1: no entry → no-op; B2: success path; B3: exception swallowed."""
+
+    def test_no_entry_is_noop(
+        self, coord_no_entry: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        called = MagicMock()
+        monkeypatch.setattr(ir, "async_create_issue", called)
+        coord_no_entry._create_auth_issue()
+        called.assert_not_called()
+
+    def test_success_path_passes_email_and_translation_key(
+        self, coord: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict[str, Any] = {}
+
+        def _fake(
+            hass: Any,
+            domain: str,
+            issue_id: str,
+            *,
+            is_fixable: bool,
+            severity: Any,
+            translation_key: str,
+            translation_placeholders: dict[str, str],
+        ) -> None:
+            captured.update(
+                hass=hass,
+                domain=domain,
+                issue_id=issue_id,
+                is_fixable=is_fixable,
+                severity=severity,
+                translation_key=translation_key,
+                translation_placeholders=translation_placeholders,
+            )
+
+        monkeypatch.setattr(ir, "async_create_issue", _fake)
+        coord._create_auth_issue()
+
+        assert captured["domain"] == DOMAIN
+        assert captured["issue_id"] == issue_id_for("entry-xyz")
+        assert captured["is_fixable"] is False
+        assert captured["severity"] is ir.IssueSeverity.ERROR
+        assert captured["translation_key"] == ISSUE_AUTH_EXPIRED_KEY
+        assert captured["translation_placeholders"] == {
+            "email": "user@example.com",
+            "entry_title": "My GFM Account",
+        }
+
+    def test_unknown_email_falls_back_to_placeholder(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        entry = make_config_entry(entry_id="entry-abc", data={})
+        stub = IdentityStub(hass=make_hass_stub(), config_entry=entry)
+        captured: dict[str, Any] = {}
+        monkeypatch.setattr(
+            ir,
+            "async_create_issue",
+            lambda *a, **kw: captured.update(kw),
+        )
+        stub._create_auth_issue()
+        assert captured["translation_placeholders"]["email"] == "unknown"
+
+    def test_empty_title_falls_back_to_entry_id(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Build the entry with the factory's strict-typed default title, then
+        # override ``entry.title`` to ``None`` after construction so the
+        # ``entry.title or entry.entry_id`` fallback branch is exercised
+        # without breaking ``make_config_entry``'s ``title: str`` signature.
+        entry = make_config_entry(
+            entry_id="entry-abc",
+            data={CONF_GOOGLE_EMAIL: "x@y"},
+        )
+        entry.title = None  # Override: exercises fallback branch for empty title
+        stub = IdentityStub(hass=make_hass_stub(), config_entry=entry)
+        captured: dict[str, Any] = {}
+        monkeypatch.setattr(
+            ir,
+            "async_create_issue",
+            lambda *a, **kw: captured.update(kw),
+        )
+        stub._create_auth_issue()
+        assert captured["translation_placeholders"]["entry_title"] == "entry-abc"
+
+    def test_exception_is_swallowed(
+        self, coord: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _boom(*_args: Any, **_kwargs: Any) -> None:
+            raise RuntimeError("registry corrupted")
+
+        monkeypatch.setattr(ir, "async_create_issue", _boom)
+        # Must not propagate; debug-logged only.
+        coord._create_auth_issue()
+
+
+# ---------------------------------------------------------------------------
+# M3 ``_dismiss_auth_issue`` (5 branches)
+# ---------------------------------------------------------------------------
+
+
+class TestDismissAuthIssue:
+    """B1: no entry → False; B2: registry-get raises → False if delete works;
+    B3: issue present → True; B4: issue absent → False; B5: delete raises → False.
+    """
+
+    def test_no_entry_returns_false(self, coord_no_entry: IdentityStub) -> None:
+        assert coord_no_entry._dismiss_auth_issue() is False
+
+    def test_issue_present_returns_true(
+        self, coord: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        registry = SimpleNamespace(async_get_issue=MagicMock(return_value=object()))
+        deleted: list[tuple[Any, str, str]] = []
+        monkeypatch.setattr(ir, "async_get", lambda hass: registry)
+        monkeypatch.setattr(
+            ir,
+            "async_delete_issue",
+            lambda hass, domain, issue_id: deleted.append((hass, domain, issue_id)),
+        )
+
+        assert coord._dismiss_auth_issue() is True
+        assert deleted == [(coord.hass, DOMAIN, issue_id_for("entry-xyz"))]
+        registry.async_get_issue.assert_called_once_with(
+            DOMAIN, issue_id_for("entry-xyz")
+        )
+
+    def test_issue_absent_returns_false(
+        self, coord: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        registry = SimpleNamespace(async_get_issue=MagicMock(return_value=None))
+        monkeypatch.setattr(ir, "async_get", lambda hass: registry)
+        monkeypatch.setattr(ir, "async_delete_issue", lambda *a, **kw: None)
+
+        assert coord._dismiss_auth_issue() is False
+
+    def test_registry_async_get_raises_then_delete_succeeds_returns_false(
+        self, coord: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _raise(_hass: Any) -> Any:
+            raise RuntimeError("registry init failed")
+
+        monkeypatch.setattr(ir, "async_get", _raise)
+        monkeypatch.setattr(ir, "async_delete_issue", lambda *a, **kw: None)
+        # ``issue_present`` defaults to ``False`` after the registry lookup
+        # failed; delete succeeds, so return value is ``False``.
+        assert coord._dismiss_auth_issue() is False
+
+    def test_registry_without_get_method_returns_false(
+        self, coord: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Registry object exists but lacks ``async_get_issue`` (defensive branch).
+        registry = SimpleNamespace()
+        monkeypatch.setattr(ir, "async_get", lambda hass: registry)
+        monkeypatch.setattr(ir, "async_delete_issue", lambda *a, **kw: None)
+        assert coord._dismiss_auth_issue() is False
+
+    def test_get_issue_raises_then_delete_succeeds_returns_false(
+        self, coord: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        registry = SimpleNamespace(
+            async_get_issue=MagicMock(side_effect=RuntimeError("boom"))
+        )
+        monkeypatch.setattr(ir, "async_get", lambda hass: registry)
+        monkeypatch.setattr(ir, "async_delete_issue", lambda *a, **kw: None)
+        assert coord._dismiss_auth_issue() is False
+
+    def test_delete_raises_returns_false(
+        self, coord: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        registry = SimpleNamespace(async_get_issue=MagicMock(return_value=object()))
+        monkeypatch.setattr(ir, "async_get", lambda hass: registry)
+
+        def _boom(*_args: Any, **_kwargs: Any) -> None:
+            raise RuntimeError("delete failed")
+
+        monkeypatch.setattr(ir, "async_delete_issue", _boom)
+        # When delete raises, the function returns ``False`` early — it does
+        # not surface the registry-present flag.
+        assert coord._dismiss_auth_issue() is False
+
+
+# ---------------------------------------------------------------------------
+# M4 ``_schedule_eid_resolver_refresh`` (5 branches)
+# ---------------------------------------------------------------------------
+
+
+class TestScheduleEidResolverRefresh:
+    """B1: ``hass.data`` not a dict; B2: ``DOMAIN`` bucket missing/non-dict;
+    B3: resolver missing; B4: ``async_refresh`` not callable; B5: success.
+    """
+
+    def test_hass_data_not_dict_is_noop(self, coord: IdentityStub) -> None:
+        coord.hass = SimpleNamespace(data=None)
+        coord._schedule_eid_resolver_refresh()  # must not raise
+
+    def test_no_hass_attribute_is_noop(self, coord: IdentityStub) -> None:
+        # ``hass`` itself is ``None`` (rare but defensive).
+        coord.hass = None  # type: ignore[assignment]
+        coord._schedule_eid_resolver_refresh()  # must not raise
+
+    def test_missing_domain_bucket_is_noop(self, coord: IdentityStub) -> None:
+        coord.hass.data = {}
+        coord._schedule_eid_resolver_refresh()  # must not raise
+
+    def test_non_dict_domain_bucket_is_noop(self, coord: IdentityStub) -> None:
+        coord.hass.data = {DOMAIN: "not-a-dict"}
+        coord._schedule_eid_resolver_refresh()  # must not raise
+
+    def test_missing_resolver_is_noop(self, coord: IdentityStub) -> None:
+        coord.hass.data = {DOMAIN: {}}
+        coord._schedule_eid_resolver_refresh()  # must not raise
+
+    def test_resolver_without_async_refresh_is_noop(self, coord: IdentityStub) -> None:
+        coord.hass.data = {DOMAIN: {DATA_EID_RESOLVER: SimpleNamespace()}}
+        coord._schedule_eid_resolver_refresh()
+        coord.hass.async_create_task.assert_not_called()
+
+    def test_success_schedules_refresh(self, coord: IdentityStub) -> None:
+        refreshed: list[bool] = []
+
+        async def _refresh() -> None:
+            refreshed.append(True)
+
+        resolver = SimpleNamespace(async_refresh=_refresh)
+        coord.hass.data = {DOMAIN: {DATA_EID_RESOLVER: resolver}}
+        coord._schedule_eid_resolver_refresh()
+        # ``async_create_task`` is called with the coroutine returned by
+        # ``async_refresh``; we don't await it here.
+        coord.hass.async_create_task.assert_called_once()
+        # Close the coroutine to avoid the ``RuntimeWarning: coroutine was
+        # never awaited`` since pytest-asyncio is not driving this test.
+        (coro,) = coord.hass.async_create_task.call_args.args
+        coro.close()
+
+    def test_hass_without_async_create_task_is_noop(self, coord: IdentityStub) -> None:
+        async def _refresh() -> None:  # pragma: no cover - never awaited
+            return None
+
+        resolver = SimpleNamespace(async_refresh=_refresh)
+        # Replace ``hass`` with a stub lacking ``async_create_task``.
+        coord.hass = SimpleNamespace(data={DOMAIN: {DATA_EID_RESOLVER: resolver}})
+        # The implementation tolerates this defensively (``callable(None)`` is
+        # ``False``); no exception should escape.
+        coord._schedule_eid_resolver_refresh()
+
+
+# ---------------------------------------------------------------------------
+# M5 ``_register_identity_key`` (3 branches + shared-tracker log)
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterIdentityKey:
+    """B1: non-bytes is rejected; B2: wrong length is rejected;
+    B3: new device added; B4: duplicate is a no-op; B5: shared tracker logs.
+    """
+
+    def test_non_bytes_key_is_rejected(self, coord: IdentityStub) -> None:
+        coord._register_identity_key("dev-1", "not-bytes")  # type: ignore[arg-type]
+        assert coord._identity_key_to_devices == {}
+
+    def test_wrong_length_key_is_rejected(self, coord: IdentityStub) -> None:
+        coord._register_identity_key("dev-1", b"\x00" * 31)  # too short
+        coord._register_identity_key("dev-2", b"\x00" * 33)  # too long
+        assert coord._identity_key_to_devices == {}
+
+    def test_new_device_is_added(self, coord: IdentityStub) -> None:
+        key = b"\xaa" * 32
+        coord._register_identity_key("dev-1", key)
+        assert coord._identity_key_to_devices == {key: {"dev-1"}}
+
+    def test_duplicate_device_is_idempotent(self, coord: IdentityStub) -> None:
+        key = b"\xaa" * 32
+        coord._register_identity_key("dev-1", key)
+        coord._register_identity_key("dev-1", key)
+        assert coord._identity_key_to_devices == {key: {"dev-1"}}
+
+    def test_shared_tracker_logs_info(
+        self, coord: IdentityStub, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        key = b"\xbb" * 32
+        coord._register_identity_key("dev-1", key)
+        with caplog.at_level("INFO", logger=identity_mod.__name__):
+            coord._register_identity_key("dev-2", key)
+        assert coord._identity_key_to_devices == {key: {"dev-1", "dev-2"}}
+        assert any(
+            "Shared tracker detected" in record.message for record in caplog.records
+        )
+
+
+# ---------------------------------------------------------------------------
+# M6 ``_reset_resolver_offset`` (multiple defensive branches)
+# ---------------------------------------------------------------------------
+
+
+class _FakeDeviceReg:
+    """Minimal ``dr.async_get(hass)`` substitute for tests."""
+
+    def __init__(self, device: SimpleNamespace | None) -> None:
+        self._device = device
+        self.calls: list[set[tuple[str, str]]] = []
+
+    def async_get_device(
+        self, *, identifiers: set[tuple[str, str]] | None = None
+    ) -> SimpleNamespace | None:
+        self.calls.append(set(identifiers or set()))
+        return self._device
+
+
+class TestResetResolverOffset:
+    """B1: no hass → return; B2: no entry_id → debug log + return;
+    B3: device missing → return; B4: hass.data not dict → return;
+    B5: bucket missing → return; B6: resolver None → return;
+    B7: ``reset_device_offset`` not callable → return; B8: success.
+    """
+
+    def test_no_hass_returns_early(self, coord: IdentityStub) -> None:
+        coord.hass = None  # type: ignore[assignment]
+        coord._reset_resolver_offset("dev-1")  # must not raise
+
+    def test_no_entry_id_returns_without_call(
+        self, coord_no_entry: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        called = MagicMock()
+        monkeypatch.setattr(dr, "async_get", called)
+        # ``IdentityStub._entry_id`` returns ``None`` when entry is missing.
+        coord_no_entry._reset_resolver_offset("dev-1")
+        # ``dr.async_get(hass)`` is invoked anyway (guarded by ``entry_id``
+        # only for the identifier lookup, not for the registry fetch);
+        # ensure no side effects beyond that.
+        assert called.called
+
+    def test_device_not_found_logs_and_returns(
+        self, coord: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_reg = _FakeDeviceReg(device=None)
+        monkeypatch.setattr(dr, "async_get", lambda hass: fake_reg)
+        coord._reset_resolver_offset("dev-1")
+        # The lookup was attempted with both identifier shapes.
+        assert fake_reg.calls == [{(DOMAIN, "entry-xyz:dev-1"), (DOMAIN, "dev-1")}]
+
+    def test_hass_data_not_dict_returns(
+        self, coord: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        device = SimpleNamespace(id="reg-123")
+        monkeypatch.setattr(dr, "async_get", lambda hass: _FakeDeviceReg(device))
+        coord.hass.data = None
+        coord._reset_resolver_offset("dev-1")  # must not raise
+
+    def test_missing_domain_bucket_returns(
+        self, coord: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        device = SimpleNamespace(id="reg-123")
+        monkeypatch.setattr(dr, "async_get", lambda hass: _FakeDeviceReg(device))
+        coord.hass.data = {}
+        coord._reset_resolver_offset("dev-1")  # must not raise
+
+    def test_non_dict_domain_bucket_returns(
+        self, coord: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        device = SimpleNamespace(id="reg-123")
+        monkeypatch.setattr(dr, "async_get", lambda hass: _FakeDeviceReg(device))
+        coord.hass.data = {DOMAIN: "not-a-dict"}
+        coord._reset_resolver_offset("dev-1")  # must not raise
+
+    def test_resolver_none_returns(
+        self, coord: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        device = SimpleNamespace(id="reg-123")
+        monkeypatch.setattr(dr, "async_get", lambda hass: _FakeDeviceReg(device))
+        coord.hass.data = {DOMAIN: {DATA_EID_RESOLVER: None}}
+        coord._reset_resolver_offset("dev-1")  # must not raise
+
+    def test_resolver_without_reset_is_noop(
+        self, coord: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        device = SimpleNamespace(id="reg-123")
+        monkeypatch.setattr(dr, "async_get", lambda hass: _FakeDeviceReg(device))
+        resolver = SimpleNamespace()  # no reset_device_offset
+        coord.hass.data = {DOMAIN: {DATA_EID_RESOLVER: resolver}}
+        coord._reset_resolver_offset("dev-1")  # must not raise
+
+    def test_success_calls_reset_with_registry_id(
+        self, coord: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        device = SimpleNamespace(id="reg-123")
+        monkeypatch.setattr(dr, "async_get", lambda hass: _FakeDeviceReg(device))
+        reset_calls: list[str] = []
+        # Pass ``list.append`` directly (no wrapping lambda) to satisfy
+        # Ruff PLW0108 (unnecessary-lambda) under the repo's PL selector.
+        resolver = SimpleNamespace(reset_device_offset=reset_calls.append)
+        coord.hass.data = {DOMAIN: {DATA_EID_RESOLVER: resolver}}
+        coord._reset_resolver_offset("dev-1")
+        assert reset_calls == ["reg-123"]

--- a/tests/test_coordinator_locate_basics.py
+++ b/tests/test_coordinator_locate_basics.py
@@ -1,0 +1,326 @@
+# tests/test_coordinator_locate_basics.py
+"""Branch-Coverage tests for ``coordinator.locate``.
+
+Phase 3 AP-C: target ``coordinator/locate.py`` branch-coverage by
+exercising the pure helpers (``_normalize_coords``, ``_get_device_lock``,
+``can_request_location``, ``can_play_sound``) and the gating branches of
+the async helpers (``async_locate_device``, ``async_play_sound``,
+``async_stop_sound``). Deep success-path branches (Nova roundtrip,
+Google Home filter, weighted fusion, cache commit) remain out of scope
+and stay for Phase 4.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import math
+
+import pytest
+
+from custom_components.googlefindmy.const import DEFAULT_MIN_POLL_INTERVAL
+from tests.helpers.config_entries_stub import make_config_entry
+from tests.helpers.locate_mixin_stub import LocateStub
+
+
+@pytest.fixture
+def coord() -> LocateStub:
+    """Return a default :class:`LocateStub` bound to a synthetic config entry."""
+
+    entry = make_config_entry(entry_id="locate-test-entry")
+    return LocateStub(config_entry=entry)
+
+
+class TestNormalizeCoords:
+    """Exercise ``_normalize_coords`` branches."""
+
+    def test_missing_lat_returns_false(self, coord: LocateStub) -> None:
+        payload: dict = {"longitude": 12.0}
+        assert coord._normalize_coords(payload) is False
+        coord.increment_stat.assert_not_called()
+
+    def test_missing_lon_returns_false(self, coord: LocateStub) -> None:
+        payload: dict = {"latitude": 50.0}
+        assert coord._normalize_coords(payload) is False
+        coord.increment_stat.assert_not_called()
+
+    def test_non_numeric_increments_invalid_and_returns_false(
+        self, coord: LocateStub
+    ) -> None:
+        payload: dict = {"latitude": "abc", "longitude": "def"}
+        assert coord._normalize_coords(payload) is False
+        coord.increment_stat.assert_called_once_with("invalid_coords")
+
+    def test_non_numeric_warn_off_skips_warning(self, coord: LocateStub) -> None:
+        payload: dict = {"latitude": "abc", "longitude": "def"}
+        assert coord._normalize_coords(payload, warn_on_invalid=False) is False
+        coord.increment_stat.assert_called_once_with("invalid_coords")
+
+    @pytest.mark.parametrize(
+        ("lat", "lon"),
+        [
+            (math.nan, 0.0),
+            (math.inf, 0.0),
+            (0.0, math.inf),
+            (95.0, 0.0),
+            (0.0, -181.0),
+        ],
+    )
+    def test_out_of_range_increments_invalid(
+        self, coord: LocateStub, lat: float, lon: float
+    ) -> None:
+        payload: dict = {"latitude": lat, "longitude": lon}
+        assert coord._normalize_coords(payload) is False
+        coord.increment_stat.assert_called_once_with("invalid_coords")
+
+    def test_valid_coords_returns_true_and_normalizes(self, coord: LocateStub) -> None:
+        payload: dict = {"latitude": "50.0", "longitude": "12.0"}
+        assert coord._normalize_coords(payload) is True
+        assert payload["latitude"] == 50.0
+        assert payload["longitude"] == 12.0
+
+    def test_accuracy_valid_kept(self, coord: LocateStub) -> None:
+        payload: dict = {"latitude": 50.0, "longitude": 12.0, "accuracy": "5.0"}
+        assert coord._normalize_coords(payload) is True
+        assert payload["accuracy"] == 5.0
+
+    def test_accuracy_invalid_dropped(self, coord: LocateStub) -> None:
+        payload: dict = {"latitude": 50.0, "longitude": 12.0, "accuracy": 0.0}
+        assert coord._normalize_coords(payload) is True
+        assert "accuracy" not in payload
+
+    def test_accuracy_unparsable_dropped(self, coord: LocateStub) -> None:
+        payload: dict = {"latitude": 50.0, "longitude": 12.0, "accuracy": "junk"}
+        assert coord._normalize_coords(payload) is True
+        assert "accuracy" not in payload
+
+
+class TestGetDeviceLock:
+    """Exercise ``_get_device_lock`` branches."""
+
+    def test_create_new_lock(self, coord: LocateStub) -> None:
+        lock = coord._get_device_lock("dev-1")
+        assert isinstance(lock, asyncio.Lock)
+        assert coord._device_action_locks["dev-1"] is lock
+
+    def test_return_existing_lock(self, coord: LocateStub) -> None:
+        first = coord._get_device_lock("dev-1")
+        second = coord._get_device_lock("dev-1")
+        assert first is second
+
+
+class TestCanRequestLocation:
+    """Exercise ``can_request_location`` branches."""
+
+    def test_ignored_device_blocked(self, coord: LocateStub) -> None:
+        coord.is_ignored.return_value = True
+        assert coord.can_request_location("dev-1") is False
+
+    def test_polling_in_progress_blocked(self, coord: LocateStub) -> None:
+        coord._is_polling = True
+        assert coord.can_request_location("dev-1") is False
+
+    def test_inflight_blocked(self, coord: LocateStub) -> None:
+        coord._locate_inflight.add("dev-1")
+        assert coord.can_request_location("dev-1") is False
+
+    def test_manual_cooldown_active_blocked(
+        self, coord: LocateStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+            lambda: 100.0,
+        )
+        coord._locate_cooldown_until["dev-1"] = 200.0
+        assert coord.can_request_location("dev-1") is False
+
+    def test_poll_cooldown_active_blocked(
+        self, coord: LocateStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+            lambda: 100.0,
+        )
+        coord._device_poll_cooldown_until["dev-1"] = 200.0
+        assert coord.can_request_location("dev-1") is False
+
+    def test_all_clear_allows(
+        self, coord: LocateStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+            lambda: 1000.0,
+        )
+        assert coord.can_request_location("dev-1") is True
+
+    def test_expired_cooldown_allows(
+        self, coord: LocateStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+            lambda: 300.0,
+        )
+        coord._locate_cooldown_until["dev-1"] = 200.0
+        coord._device_poll_cooldown_until["dev-1"] = 250.0
+        assert coord.can_request_location("dev-1") is True
+
+
+class TestCanPlaySound:
+    """Exercise ``can_play_sound`` branches."""
+
+    def test_capability_known_true(self, coord: LocateStub) -> None:
+        coord._device_caps["dev-1"] = {"can_ring": True}
+        assert coord.can_play_sound("dev-1") is True
+
+    def test_capability_known_false(self, coord: LocateStub) -> None:
+        coord._device_caps["dev-1"] = {"can_ring": False}
+        assert coord.can_play_sound("dev-1") is False
+
+    def test_push_not_ready_with_cooldown_blocks(
+        self, coord: LocateStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        coord._api_push_ready.return_value = False
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+            lambda: 100.0,
+        )
+        coord._push_cooldown_until = 200.0
+        assert coord.can_play_sound("dev-1") is False
+
+    def test_push_not_ready_no_cooldown_falls_back_optimistic(
+        self, coord: LocateStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        coord._api_push_ready.return_value = False
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+            lambda: 1000.0,
+        )
+        coord._ensure_device_name_cache.return_value = {"dev-1": "Phone"}
+        assert coord.can_play_sound("dev-1") is True
+
+    def test_known_device_optimistic_true(self, coord: LocateStub) -> None:
+        coord._ensure_device_name_cache.return_value = {"dev-1": "Phone"}
+        assert coord.can_play_sound("dev-1") is True
+
+    def test_unknown_device_falls_back_optimistic(self, coord: LocateStub) -> None:
+        coord._ensure_device_name_cache.return_value = {}
+        assert coord.can_play_sound("dev-1") is True
+
+
+class TestAsyncLocateDeviceGating:
+    """Exercise gating branches of ``async_locate_device`` (no Nova roundtrip)."""
+
+    async def test_blocks_when_cannot_request_location(self, coord: LocateStub) -> None:
+        coord.is_ignored.return_value = True
+        result = await coord.async_locate_device("dev-1")
+        assert result == {}
+        coord.api.async_get_device_location.assert_not_called()
+
+    async def test_blocks_when_push_cooldown_active(
+        self, coord: LocateStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+            lambda: 100.0,
+        )
+        coord._api_push_ready.return_value = False
+        coord._push_cooldown_until = 200.0
+        result = await coord.async_locate_device("dev-1")
+        assert result == {}
+        coord.api.async_get_device_location.assert_not_called()
+
+    async def test_empty_payload_returns_empty(
+        self, coord: LocateStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+            lambda: 1000.0,
+        )
+        coord.api.async_get_device_location.return_value = None
+        result = await coord.async_locate_device("dev-1")
+        assert result == {}
+        assert "dev-1" not in coord._locate_inflight  # finally branch cleared it
+
+    async def test_payload_without_coords_returns_empty(
+        self, coord: LocateStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+            lambda: 1000.0,
+        )
+        coord.api.async_get_device_location.return_value = {
+            "last_seen": 1234567890,
+        }
+        result = await coord.async_locate_device("dev-1")
+        assert result == {}
+
+
+class TestAsyncPlaySoundGating:
+    """Exercise gating branches of ``async_play_sound``."""
+
+    async def test_blocks_when_cannot_play_sound(self, coord: LocateStub) -> None:
+        coord._device_caps["dev-1"] = {"can_ring": False}
+        ok = await coord.async_play_sound("dev-1")
+        assert ok is False
+        coord.api.async_play_sound.assert_not_called()
+
+    async def test_success_stores_uuid(self, coord: LocateStub) -> None:
+        coord._device_caps["dev-1"] = {"can_ring": True}
+        ok = await coord.async_play_sound("dev-1")
+        assert ok is True
+        assert coord._sound_request_uuids.get("dev-1") == "uuid-stub"
+        coord._async_save_sound_uuids.assert_awaited_once()
+
+    async def test_failure_notes_problem(self, coord: LocateStub) -> None:
+        coord._device_caps["dev-1"] = {"can_ring": True}
+        coord.api.async_play_sound.return_value = (False, None)
+        ok = await coord.async_play_sound("dev-1")
+        assert ok is False
+        coord._note_push_transport_problem.assert_called_once()
+
+    async def test_unexpected_exception_returns_false(self, coord: LocateStub) -> None:
+        coord._device_caps["dev-1"] = {"can_ring": True}
+        coord.api.async_play_sound.side_effect = RuntimeError("boom")
+        ok = await coord.async_play_sound("dev-1")
+        assert ok is False
+        coord.note_error.assert_called_once()
+        coord._note_push_transport_problem.assert_called_once()
+
+
+class TestAsyncStopSoundGating:
+    """Exercise gating branches of ``async_stop_sound``."""
+
+    async def test_blocks_when_push_not_ready(self, coord: LocateStub) -> None:
+        coord._api_push_ready.return_value = False
+        ok = await coord.async_stop_sound("dev-1")
+        assert ok is False
+        coord.api.async_stop_sound.assert_not_called()
+
+    async def test_uses_cached_uuid_when_none_passed(self, coord: LocateStub) -> None:
+        coord._sound_request_uuids["dev-1"] = "cached-uuid"
+        ok = await coord.async_stop_sound("dev-1")
+        assert ok is True
+        coord.api.async_stop_sound.assert_awaited_once_with("dev-1", "cached-uuid")
+        # successful stop removes the uuid
+        assert "dev-1" not in coord._sound_request_uuids
+
+    async def test_explicit_uuid_overrides_cache(self, coord: LocateStub) -> None:
+        coord._sound_request_uuids["dev-1"] = "cached-uuid"
+        ok = await coord.async_stop_sound("dev-1", request_uuid="explicit")
+        assert ok is True
+        coord.api.async_stop_sound.assert_awaited_once_with("dev-1", "explicit")
+
+    async def test_missing_uuid_warns_but_attempts_stop(
+        self, coord: LocateStub
+    ) -> None:
+        ok = await coord.async_stop_sound("dev-1")
+        assert ok is True
+        coord.api.async_stop_sound.assert_awaited_once_with("dev-1", None)
+
+    async def test_failure_notes_problem(self, coord: LocateStub) -> None:
+        coord.api.async_stop_sound.return_value = False
+        ok = await coord.async_stop_sound("dev-1", request_uuid="x")
+        assert ok is False
+        coord._note_push_transport_problem.assert_called_once()
+
+
+_ = DEFAULT_MIN_POLL_INTERVAL  # silence unused-import lint when production no-ops

--- a/tests/test_coordinator_main_basics.py
+++ b/tests/test_coordinator_main_basics.py
@@ -1,0 +1,864 @@
+# tests/test_coordinator_main_basics.py
+"""Branch-coverage tests for ``coordinator.main`` pure helpers and static methods.
+
+Phase 3 AP-F: target the pure helpers and ``GoogleFindMyCoordinator`` static
+methods exposed by ``coordinator/main.py``. Async lifecycle methods
+(``async_setup``, ``async_shutdown``, ``async_update_data``) stay out of
+scope; they land in Phase 4 with HA-loop test methodology.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from types import ModuleType, SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.coordinator import main as main_module
+from custom_components.googlefindmy.coordinator.main import (
+    DeviceIdentity,
+    GoogleFindMyCoordinator,
+    SemanticLabelRecord,
+    _as_ha_attributes,
+    _get_api_class,
+    _normalize_epoch_seconds,
+    _parse_last_seen_timestamp,
+    _RecorderHistoryProxy,
+    _resolve_last_seen_from_attributes,
+    _sync_get_last_gps_from_history,
+    _update_preserve_metadata,
+    format_epoch_utc,
+    get_recorder,
+    normalize_epoch_seconds,
+)
+from tests.helpers.config_entries_stub import make_config_entry
+from tests.helpers.main_coordinator_stub import MainCoordinatorStub
+
+# ---------------------------------------------------------------------------
+# Module-level pure helpers
+# ---------------------------------------------------------------------------
+
+
+class TestUpdatePreserveMetadata:
+    """``_update_preserve_metadata`` keeps persisted metadata sticky."""
+
+    def test_non_metadata_keys_use_dict_update_semantics(self) -> None:
+        target = {"battery_level": 70, "name": "Old"}
+        source = {"name": "New", "status": "Online"}
+
+        _update_preserve_metadata(target, source)
+
+        assert target == {"battery_level": 70, "name": "New", "status": "Online"}
+
+    def test_metadata_key_with_none_value_does_not_clobber_existing(self) -> None:
+        target = {"battery_level": 80}
+        source = {"battery_level": None}
+
+        _update_preserve_metadata(target, source)
+
+        assert target == {"battery_level": 80}
+
+    def test_metadata_key_with_real_value_overwrites(self) -> None:
+        target = {"battery_level": 80}
+        source = {"battery_level": 90}
+
+        _update_preserve_metadata(target, source)
+
+        assert target == {"battery_level": 90}
+
+    def test_metadata_key_added_when_target_missing(self) -> None:
+        target: dict[str, Any] = {}
+        source = {"identity_key": b"\xaa\xbb"}
+
+        _update_preserve_metadata(target, source)
+
+        assert target == {"identity_key": b"\xaa\xbb"}
+
+    def test_metadata_none_does_not_add_key(self) -> None:
+        target: dict[str, Any] = {}
+        source = {"identity_key": None, "battery_level": None}
+
+        _update_preserve_metadata(target, source)
+
+        assert target == {}
+
+
+class TestEpochHelpers:
+    """``normalize_epoch_seconds`` and ``format_epoch_utc`` are tolerant aliases."""
+
+    def test_normalize_epoch_seconds_public_and_alias_agree(self) -> None:
+        public_result = normalize_epoch_seconds(1_700_000_000)
+        alias_result = _normalize_epoch_seconds(1_700_000_000)
+
+        assert public_result == 1_700_000_000
+        assert alias_result == 1_700_000_000
+
+    def test_normalize_epoch_seconds_accepts_milliseconds(self) -> None:
+        # 1.7e12 looks like ms-since-epoch; the helper normalises to seconds.
+        result = normalize_epoch_seconds(1_700_000_000_000)
+
+        assert result == 1_700_000_000
+
+    def test_normalize_epoch_seconds_returns_none_for_invalid(self) -> None:
+        assert normalize_epoch_seconds("not a number") is None
+        assert normalize_epoch_seconds(None) is None
+
+    def test_format_epoch_utc_returns_iso8601(self) -> None:
+        # 2023-11-14T22:13:20Z = 1700000000
+        result = format_epoch_utc(1_700_000_000)
+
+        assert isinstance(result, str)
+        assert result.startswith("2023-11-14T22:13:20")
+
+    def test_format_epoch_utc_none_in_none_out(self) -> None:
+        assert format_epoch_utc(None) is None
+
+
+class TestLastSeenHelpers:
+    """``_parse_last_seen_timestamp`` and ``_resolve_last_seen_from_attributes``."""
+
+    def test_parse_last_seen_accepts_epoch_int(self) -> None:
+        assert _parse_last_seen_timestamp(1_700_000_000) == 1_700_000_000.0
+
+    def test_parse_last_seen_returns_none_for_unparseable(self) -> None:
+        assert _parse_last_seen_timestamp("not a timestamp") is None
+
+    def test_resolve_returns_fallback_when_attributes_empty(self) -> None:
+        result = _resolve_last_seen_from_attributes(None, 42.0)
+
+        assert result == 42.0
+
+    def test_resolve_returns_fallback_when_attributes_lack_last_seen(self) -> None:
+        result = _resolve_last_seen_from_attributes({"other": "key"}, 99.0)
+
+        assert result == 99.0
+
+    def test_resolve_prefers_last_seen_attribute(self) -> None:
+        attrs = {"last_seen": 1_700_000_000}
+
+        result = _resolve_last_seen_from_attributes(attrs, 0.0)
+
+        assert result == 1_700_000_000.0
+
+    def test_resolve_falls_back_to_last_seen_utc(self) -> None:
+        attrs = {"last_seen": None, "last_seen_utc": 1_700_000_000}
+
+        result = _resolve_last_seen_from_attributes(attrs, 0.0)
+
+        assert result == 1_700_000_000.0
+
+
+class TestAsHaAttributes:
+    """``_as_ha_attributes`` curates HA-recorder-friendly attribute dicts."""
+
+    def test_empty_row_returns_none(self) -> None:
+        assert _as_ha_attributes(None) is None
+        assert _as_ha_attributes({}) is None
+
+    def test_full_row_includes_lat_lon_and_optional_fields(self) -> None:
+        row = {
+            "name": "Phone",
+            "device_id": "abc",
+            "status": "Online",
+            "semantic_name": "Home",
+            "battery_level": 90,
+            "latitude": 1.0,
+            "longitude": 2.0,
+            "accuracy": 5.0,
+            "altitude": 100.0,
+            "last_seen": 1_700_000_000,
+        }
+
+        result = _as_ha_attributes(row)
+
+        assert result is not None
+        assert result["device_name"] == "Phone"
+        assert result["device_id"] == "abc"
+        assert result["latitude"] == 1.0
+        assert result["longitude"] == 2.0
+        assert result["accuracy_m"] == 5.0
+        assert result["altitude_m"] == 100.0
+        assert result["last_seen"].startswith("2023-11-14T22:13:20")
+
+    def test_partial_row_drops_lat_lon_when_one_missing(self) -> None:
+        row = {"name": "Phone", "latitude": 1.0, "longitude": None}
+
+        result = _as_ha_attributes(row)
+
+        assert result is not None
+        assert "latitude" not in result
+        assert "longitude" not in result
+
+    def test_non_finite_lat_lon_are_dropped(self) -> None:
+        row = {"latitude": math.nan, "longitude": math.inf}
+
+        result = _as_ha_attributes(row)
+
+        assert result is not None
+        assert "latitude" not in result
+        assert "longitude" not in result
+
+    def test_id_falls_back_to_device_id_field(self) -> None:
+        row = {"id": "fallback-id"}
+
+        result = _as_ha_attributes(row)
+
+        assert result is not None
+        assert result["device_id"] == "fallback-id"
+
+
+# ---------------------------------------------------------------------------
+# _RecorderHistoryProxy & get_recorder
+# ---------------------------------------------------------------------------
+
+
+class TestRecorderHistoryProxy:
+    """``_RecorderHistoryProxy`` is a lazy passthrough to the HA history module."""
+
+    def test_load_caches_module_after_first_call(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # ``_RecorderHistoryProxy._load`` executes
+        # ``from homeassistant.components.recorder import history as history_module``.
+        # That statement resolves through ``sys.modules``, so the test must
+        # replace the module entries there rather than ``setattr`` on the
+        # parent package (which only retargets the attribute lookup, not the
+        # cached import path used by ``from ... import history``).
+        fake_history = ModuleType("homeassistant.components.recorder.history")
+        fake_recorder = ModuleType("homeassistant.components.recorder")
+        fake_recorder.history = fake_history  # type: ignore[attr-defined]
+        monkeypatch.setitem(
+            sys.modules, "homeassistant.components.recorder", fake_recorder
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "homeassistant.components.recorder.history",
+            fake_history,
+        )
+
+        proxy = _RecorderHistoryProxy()
+        first = proxy._load()
+        second = proxy._load()
+
+        assert first is fake_history
+        assert first is second
+
+    def test_get_recorder_imports_lazily(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # ``get_recorder`` runs
+        # ``from homeassistant.components.recorder import get_instance as ...``;
+        # the lookup goes through ``sys.modules["homeassistant.components.recorder"]``.
+        # ``monkeypatch.setattr("homeassistant.components.recorder", ...)`` only
+        # rebinds the ``recorder`` attribute on the parent package and leaves
+        # the conftest stub in ``sys.modules`` in place, so we replace the
+        # cached module instead.
+        sentinel = object()
+        fake_recorder = ModuleType("homeassistant.components.recorder")
+        fake_recorder.get_instance = lambda hass: sentinel  # type: ignore[attr-defined]
+        monkeypatch.setitem(
+            sys.modules, "homeassistant.components.recorder", fake_recorder
+        )
+
+        result = get_recorder(MagicMock())
+
+        assert result is sentinel
+
+
+class TestSyncGetLastGpsFromHistory:
+    """``_sync_get_last_gps_from_history`` reads the most recent GPS state."""
+
+    def test_no_samples_returns_none(self) -> None:
+        history = MagicMock()
+        history.get_last_state_changes = MagicMock(return_value={"entity": []})
+
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr(main_module, "recorder_history", history)
+            result = _sync_get_last_gps_from_history(MagicMock(), "entity")
+
+        assert result is None
+
+    def test_missing_lat_lon_returns_none(self) -> None:
+        sample = SimpleNamespace(
+            attributes={"gps_accuracy": 10},
+            last_updated=SimpleNamespace(timestamp=lambda: 1_700_000_000.0),
+        )
+        history = MagicMock()
+        history.get_last_state_changes = MagicMock(return_value={"entity": [sample]})
+
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr(main_module, "recorder_history", history)
+            result = _sync_get_last_gps_from_history(MagicMock(), "entity")
+
+        assert result is None
+
+    def test_happy_path_returns_dict(self) -> None:
+        sample = SimpleNamespace(
+            attributes={
+                "latitude": 1.0,
+                "longitude": 2.0,
+                "gps_accuracy": 5,
+                "last_seen": 1_700_000_000,
+            },
+            last_updated=SimpleNamespace(timestamp=lambda: 1_700_000_000.0),
+        )
+        history = MagicMock()
+        history.get_last_state_changes = MagicMock(return_value={"entity": [sample]})
+
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr(main_module, "recorder_history", history)
+            result = _sync_get_last_gps_from_history(MagicMock(), "entity")
+
+        assert result is not None
+        assert result["latitude"] == 1.0
+        assert result["longitude"] == 2.0
+        assert result["accuracy"] == 5
+        assert result["last_seen"] == 1_700_000_000.0
+        assert result["status"] == "Using historical data"
+
+    def test_history_exception_returns_none(self) -> None:
+        history = MagicMock()
+        history.get_last_state_changes = MagicMock(side_effect=RuntimeError("boom"))
+
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr(main_module, "recorder_history", history)
+            result = _sync_get_last_gps_from_history(MagicMock(), "entity")
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+class TestSemanticLabelRecordCopy:
+    """``SemanticLabelRecord.copy`` returns an independent device set."""
+
+    def test_copy_clones_device_set(self) -> None:
+        record = SemanticLabelRecord(
+            label="Home", first_seen=1.0, last_seen=2.0, devices={"a", "b"}
+        )
+
+        snapshot = record.copy()
+        snapshot.devices.add("c")
+
+        assert record.devices == {"a", "b"}
+        assert snapshot.devices == {"a", "b", "c"}
+
+    def test_copy_preserves_scalar_fields(self) -> None:
+        record = SemanticLabelRecord(label="Work", first_seen=10.0, last_seen=11.0)
+
+        snapshot = record.copy()
+
+        assert snapshot.label == "Work"
+        assert snapshot.first_seen == 10.0
+        assert snapshot.last_seen == 11.0
+
+
+class TestDeviceIdentityDataclass:
+    """``DeviceIdentity`` is a slotted dataclass with sensible defaults."""
+
+    def test_required_fields_only(self) -> None:
+        identity = DeviceIdentity(
+            registry_id="reg-1",
+            canonical_id="canon-1",
+            identity_key=None,
+        )
+
+        assert identity.registry_id == "reg-1"
+        assert identity.canonical_id == "canon-1"
+        assert identity.identity_key is None
+        assert identity.encrypted_identity_key is None
+        assert identity.owner_key_version is None
+        assert identity.device_type is None
+
+    def test_optional_fields_round_trip(self) -> None:
+        identity = DeviceIdentity(
+            registry_id="reg-2",
+            canonical_id="canon-2",
+            identity_key=b"\x01",
+            owner_key_version=7,
+            device_type=3,
+            manufacturer="Acme",
+            model="ABC-123",
+        )
+
+        assert identity.identity_key == b"\x01"
+        assert identity.owner_key_version == 7
+        assert identity.manufacturer == "Acme"
+        assert identity.model == "ABC-123"
+
+
+# ---------------------------------------------------------------------------
+# _get_api_class
+# ---------------------------------------------------------------------------
+
+
+class TestGetApiClass:
+    """``_get_api_class`` honours module- and package-level monkeypatches."""
+
+    def test_no_patch_returns_original(self) -> None:
+        original = main_module._OriginalGoogleFindMyAPI
+
+        assert _get_api_class() is original
+
+    def test_module_level_patch_takes_priority(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sentinel = type("PatchedAPI", (), {})
+
+        monkeypatch.setattr(main_module, "GoogleFindMyAPI", sentinel, raising=True)
+
+        assert _get_api_class() is sentinel
+
+    def test_package_level_patch_used_when_module_unchanged(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        coordinator_pkg = __import__(
+            "custom_components.googlefindmy.coordinator", fromlist=["GoogleFindMyAPI"]
+        )
+        sentinel = type("PackagePatchedAPI", (), {})
+
+        monkeypatch.setattr(coordinator_pkg, "GoogleFindMyAPI", sentinel, raising=False)
+
+        assert _get_api_class() is sentinel
+
+
+# ---------------------------------------------------------------------------
+# Coordinator static methods (no stub needed)
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeContributorMode:
+    """``_sanitize_contributor_mode`` normalises optional strings."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("high_traffic", "high_traffic"),
+            ("HIGH_TRAFFIC", "high_traffic"),
+            ("  in_all_areas  ", "in_all_areas"),
+            ("unsupported", "in_all_areas"),
+            (None, "in_all_areas"),
+            (123, "in_all_areas"),
+        ],
+    )
+    def test_normalisation(self, raw: Any, expected: str) -> None:
+        # DEFAULT_CONTRIBUTOR_MODE is "in_all_areas"; unsupported / non-string
+        # inputs fall back to the default.
+        assert GoogleFindMyCoordinator._sanitize_contributor_mode(raw) == expected
+
+
+class TestCoerceFloat:
+    """``_coerce_float`` rejects non-numeric and non-finite values."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            (1, 1.0),
+            (1.5, 1.5),
+            ("2.5", 2.5),
+            (None, None),
+            ("not a number", None),
+        ],
+    )
+    def test_round_trip(self, raw: Any, expected: float | None) -> None:
+        assert GoogleFindMyCoordinator._coerce_float(raw) == expected
+
+
+class TestNormalizeIdentityKey:
+    """``_normalize_identity_key`` accepts bytes, bytearray and hex strings."""
+
+    def test_bytes_pass_through(self) -> None:
+        assert (
+            GoogleFindMyCoordinator._normalize_identity_key(b"\xaa\xbb") == b"\xaa\xbb"
+        )
+
+    def test_bytearray_converts_to_bytes(self) -> None:
+        result = GoogleFindMyCoordinator._normalize_identity_key(bytearray(b"\xcc"))
+
+        assert isinstance(result, bytes)
+        assert result == b"\xcc"
+
+    def test_hex_string_decodes(self) -> None:
+        assert GoogleFindMyCoordinator._normalize_identity_key("aabb") == b"\xaa\xbb"
+
+    def test_invalid_hex_returns_none(self) -> None:
+        assert GoogleFindMyCoordinator._normalize_identity_key("not hex") is None
+
+    def test_non_string_non_bytes_returns_none(self) -> None:
+        assert GoogleFindMyCoordinator._normalize_identity_key(123) is None
+        assert GoogleFindMyCoordinator._normalize_identity_key(None) is None
+
+
+class TestNormalizeIdentityKeyCandidates:
+    """``_normalize_identity_key_candidates`` flattens scalar or iterable input."""
+
+    def test_none_returns_empty(self) -> None:
+        assert GoogleFindMyCoordinator._normalize_identity_key_candidates(None) == []
+
+    def test_single_bytes_wrapped(self) -> None:
+        result = GoogleFindMyCoordinator._normalize_identity_key_candidates(b"\x01")
+
+        assert result == [b"\x01"]
+
+    def test_iterable_deduplicates(self) -> None:
+        result = GoogleFindMyCoordinator._normalize_identity_key_candidates(
+            [b"\x01", b"\x01", b"\x02"]
+        )
+
+        assert result == [b"\x01", b"\x02"]
+
+    def test_iterable_with_invalid_entries_skipped(self) -> None:
+        result = GoogleFindMyCoordinator._normalize_identity_key_candidates(
+            [b"\x01", "not hex", 123, b"\x02"]
+        )
+
+        assert result == [b"\x01", b"\x02"]
+
+    def test_unsupported_input_returns_empty(self) -> None:
+        assert GoogleFindMyCoordinator._normalize_identity_key_candidates(42) == []
+
+
+class TestNormalizeOptionalString:
+    """``_normalize_optional_string`` strips and returns None for empty input."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            (" hello ", "hello"),
+            ("", None),
+            ("   ", None),
+            (None, None),
+            (123, None),
+        ],
+    )
+    def test_round_trip(self, raw: Any, expected: str | None) -> None:
+        assert GoogleFindMyCoordinator._normalize_optional_string(raw) == expected
+
+
+class TestNormalizeEncryptedBlob:
+    """``_normalize_encrypted_blob`` mirrors ``_normalize_identity_key`` semantics."""
+
+    def test_bytes_pass_through(self) -> None:
+        assert GoogleFindMyCoordinator._normalize_encrypted_blob(b"\xaa") == b"\xaa"
+
+    def test_hex_string_decodes(self) -> None:
+        assert GoogleFindMyCoordinator._normalize_encrypted_blob("aa") == b"\xaa"
+
+    def test_invalid_hex_returns_none(self) -> None:
+        assert GoogleFindMyCoordinator._normalize_encrypted_blob("not hex") is None
+
+    def test_non_string_non_bytes_returns_none(self) -> None:
+        assert GoogleFindMyCoordinator._normalize_encrypted_blob(123) is None
+
+
+# ---------------------------------------------------------------------------
+# Stub-based tests (instance methods reading attribute state)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def coord() -> MainCoordinatorStub:
+    """Return a default :class:`MainCoordinatorStub` bound to a config entry."""
+
+    entry = make_config_entry(entry_id="entry-abc")
+    return MainCoordinatorStub(config_entry=entry)
+
+
+class TestCacheProperty:
+    """``cache`` is a read-only property returning the bound cache."""
+
+    def test_returns_seeded_cache(self, coord: MainCoordinatorStub) -> None:
+        assert coord.cache is coord._cache
+
+
+class TestRecentReconfigure:
+    """``mark_recent_reconfigure`` and ``recent_reconfigure_at`` are paired."""
+
+    def test_initially_none(self, coord: MainCoordinatorStub) -> None:
+        assert coord.recent_reconfigure_at is None
+
+    def test_mark_uses_supplied_timestamp(self, coord: MainCoordinatorStub) -> None:
+        coord.mark_recent_reconfigure(when=42.0)
+
+        assert coord.recent_reconfigure_at == 42.0
+
+    def test_mark_uses_time_time_when_omitted(
+        self, coord: MainCoordinatorStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(main_module.time, "time", lambda: 99.0)
+
+        coord.mark_recent_reconfigure()
+
+        assert coord.recent_reconfigure_at == 99.0
+
+
+class TestSafeUpdateMetric:
+    """``safe_update_metric`` coerces floats and swallows errors."""
+
+    def test_writes_metric(self, coord: MainCoordinatorStub) -> None:
+        coord.safe_update_metric("latency_ms", 12.5)
+
+        assert coord.performance_metrics["latency_ms"] == 12.5
+
+    def test_string_numeric_coerced(self, coord: MainCoordinatorStub) -> None:
+        coord.safe_update_metric("count", "3")  # type: ignore[arg-type]
+
+        assert coord.performance_metrics["count"] == 3.0
+
+    def test_invalid_value_swallowed(self, coord: MainCoordinatorStub) -> None:
+        coord.safe_update_metric("bad", "not a number")  # type: ignore[arg-type]
+
+        assert "bad" not in coord.performance_metrics
+
+
+class TestGetIgnoredSet:
+    """``_get_ignored_set`` reads from entry options (preferred) or attribute."""
+
+    def test_empty_when_entry_options_missing(self, coord: MainCoordinatorStub) -> None:
+        coord.config_entry = make_config_entry(entry_id="e", options={})
+
+        assert coord._get_ignored_set() == set()
+
+    def test_reads_mapping_from_options(self) -> None:
+        entry = make_config_entry(
+            entry_id="e",
+            options={"ignored_devices": {"dev-1": {}, "dev-2": {}}},
+        )
+        coord = MainCoordinatorStub(config_entry=entry)
+
+        assert coord._get_ignored_set() == {"dev-1", "dev-2"}
+
+    def test_falls_back_to_attribute(self, coord: MainCoordinatorStub) -> None:
+        coord.config_entry = None
+        coord.ignored_devices = ["a", "b", 3]  # type: ignore[list-item]
+
+        assert coord._get_ignored_set() == {"a", "b"}
+
+    def test_attribute_not_list_returns_empty(self, coord: MainCoordinatorStub) -> None:
+        coord.config_entry = None
+        coord.ignored_devices = "not a list"  # type: ignore[assignment]
+
+        assert coord._get_ignored_set() == set()
+
+
+class TestIsIgnored:
+    """``is_ignored`` delegates to ``_get_ignored_set``."""
+
+    def test_true_when_in_set(self, coord: MainCoordinatorStub) -> None:
+        coord._get_ignored_set = MagicMock(return_value={"dev-1"})  # type: ignore[method-assign]
+
+        assert coord.is_ignored("dev-1") is True
+
+    def test_false_when_not_in_set(self, coord: MainCoordinatorStub) -> None:
+        coord._get_ignored_set = MagicMock(return_value={"dev-1"})  # type: ignore[method-assign]
+
+        assert coord.is_ignored("dev-2") is False
+
+
+class TestFindSemanticMatch:
+    """``_find_semantic_match`` is case- and 'Near '-prefix-insensitive."""
+
+    def test_exact_match(self, coord: MainCoordinatorStub) -> None:
+        mapping = {"Home": {"latitude": 1.0}}
+
+        result = coord._find_semantic_match("home", mapping)
+
+        assert result == {"latitude": 1.0}
+
+    def test_strips_near_prefix(self, coord: MainCoordinatorStub) -> None:
+        mapping = {"Home": {"latitude": 1.0}}
+
+        result = coord._find_semantic_match("Near Home", mapping)
+
+        assert result == {"latitude": 1.0}
+
+    def test_returns_none_when_missing(self, coord: MainCoordinatorStub) -> None:
+        result = coord._find_semantic_match("Unknown", {"Home": {"latitude": 1.0}})
+
+        assert result is None
+
+
+class TestApplySemanticMapping:
+    """``_apply_semantic_mapping`` rewrites payload coordinates when matched."""
+
+    def test_returns_false_when_no_semantic_name(
+        self, coord: MainCoordinatorStub
+    ) -> None:
+        assert coord._apply_semantic_mapping({}) is False
+
+    def test_returns_false_for_blank_string(self, coord: MainCoordinatorStub) -> None:
+        assert coord._apply_semantic_mapping({"semantic_name": "   "}) is False
+
+    def test_returns_false_for_replayed_payload(
+        self, coord: MainCoordinatorStub
+    ) -> None:
+        payload = {"semantic_name": "Home", "is_replayed": True}
+
+        assert coord._apply_semantic_mapping(payload) is False
+
+    def test_returns_false_without_entry(self) -> None:
+        coord = MainCoordinatorStub(config_entry=None)
+
+        assert coord._apply_semantic_mapping({"semantic_name": "Home"}) is False
+
+    def test_returns_false_when_no_mappings_configured(
+        self, coord: MainCoordinatorStub
+    ) -> None:
+        # Default entry has empty options + empty data → no mappings
+        assert coord._apply_semantic_mapping({"semantic_name": "Home"}) is False
+
+    def test_rewrites_payload_on_match(self) -> None:
+        entry = make_config_entry(
+            entry_id="e",
+            options={
+                "semantic_locations": {
+                    "Home": {"latitude": 50.0, "longitude": 10.0, "accuracy": 25.0}
+                }
+            },
+        )
+        coord = MainCoordinatorStub(config_entry=entry)
+        payload: dict[str, Any] = {"semantic_name": "Home"}
+
+        result = coord._apply_semantic_mapping(payload)
+
+        assert result is True
+        assert payload["latitude"] == 50.0
+        assert payload["longitude"] == 10.0
+        assert payload["accuracy"] == 25.0
+        assert payload["location_type"] == "trusted"
+
+    def test_skips_mapping_with_invalid_coords(self) -> None:
+        entry = make_config_entry(
+            entry_id="e",
+            options={
+                "semantic_locations": {"Home": {"latitude": "bad", "longitude": 1.0}}
+            },
+        )
+        coord = MainCoordinatorStub(config_entry=entry)
+
+        assert coord._apply_semantic_mapping({"semantic_name": "Home"}) is False
+
+
+class TestSemanticLabelTracking:
+    """``_record_semantic_label`` + ``get_observed_semantic_labels``."""
+
+    def test_record_ignores_non_string(self, coord: MainCoordinatorStub) -> None:
+        coord._record_semantic_label({"semantic_name": 123})
+
+        assert coord.get_observed_semantic_labels() == []
+
+    def test_record_ignores_empty_string(self, coord: MainCoordinatorStub) -> None:
+        coord._record_semantic_label({"semantic_name": "   "})
+
+        assert coord.get_observed_semantic_labels() == []
+
+    def test_record_creates_entry(
+        self, coord: MainCoordinatorStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(main_module.time, "time", lambda: 100.0)
+
+        coord._record_semantic_label({"semantic_name": "Home"}, device_id="dev-1")
+
+        snapshot = coord.get_observed_semantic_labels()
+        assert len(snapshot) == 1
+        assert snapshot[0].label == "Home"
+        assert snapshot[0].first_seen == 100.0
+        assert snapshot[0].devices == {"dev-1"}
+
+    def test_record_updates_existing(
+        self, coord: MainCoordinatorStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ticks = iter([100.0, 200.0])
+        monkeypatch.setattr(main_module.time, "time", lambda: next(ticks))
+
+        coord._record_semantic_label({"semantic_name": "Home"}, device_id="dev-1")
+        coord._record_semantic_label({"semantic_name": "Home"}, device_id="dev-2")
+
+        snapshot = coord.get_observed_semantic_labels()
+        assert len(snapshot) == 1
+        assert snapshot[0].first_seen == 100.0
+        assert snapshot[0].last_seen == 200.0
+        assert snapshot[0].devices == {"dev-1", "dev-2"}
+
+    def test_snapshot_is_independent_of_cache(
+        self, coord: MainCoordinatorStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(main_module.time, "time", lambda: 1.0)
+
+        coord._record_semantic_label({"semantic_name": "Home"}, device_id="dev-1")
+        snapshot = coord.get_observed_semantic_labels()
+        snapshot[0].devices.add("dev-X")
+
+        # Cache untouched
+        live = coord.get_observed_semantic_labels()
+        assert live[0].devices == {"dev-1"}
+
+    def test_empty_cache_returns_empty_list(self, coord: MainCoordinatorStub) -> None:
+        assert coord.get_observed_semantic_labels() == []
+
+
+class TestShouldPreservePreciseHomeCoordinates:
+    """``_should_preserve_precise_home_coordinates`` guards against semantic drift."""
+
+    def test_no_prev_location_returns_false(self, coord: MainCoordinatorStub) -> None:
+        result = coord._should_preserve_precise_home_coordinates(None, {})
+
+        assert result is False
+
+    def test_invalid_prev_location_returns_false(
+        self, coord: MainCoordinatorStub
+    ) -> None:
+        prev = {"latitude": "bad", "longitude": 0.0, "accuracy": 1.0}
+        proposed = {"latitude": 0.0, "longitude": 0.0, "radius": 100.0}
+
+        assert coord._should_preserve_precise_home_coordinates(prev, proposed) is False
+
+    def test_non_finite_values_return_false(self, coord: MainCoordinatorStub) -> None:
+        prev = {"latitude": math.nan, "longitude": 0.0, "accuracy": 1.0}
+        proposed = {"latitude": 0.0, "longitude": 0.0, "radius": 100.0}
+
+        assert coord._should_preserve_precise_home_coordinates(prev, proposed) is False
+
+    def test_prev_accuracy_worse_than_radius_returns_false(
+        self, coord: MainCoordinatorStub
+    ) -> None:
+        prev = {"latitude": 0.0, "longitude": 0.0, "accuracy": 200.0}
+        proposed = {"latitude": 0.0, "longitude": 0.0, "radius": 100.0}
+
+        assert coord._should_preserve_precise_home_coordinates(prev, proposed) is False
+
+    def test_zero_radius_returns_false(self, coord: MainCoordinatorStub) -> None:
+        prev = {"latitude": 0.0, "longitude": 0.0, "accuracy": 1.0}
+        proposed = {"latitude": 0.0, "longitude": 0.0, "radius": 0.0}
+
+        assert coord._should_preserve_precise_home_coordinates(prev, proposed) is False
+
+    def test_within_radius_returns_true(self, coord: MainCoordinatorStub) -> None:
+        coord._haversine_distance = MagicMock(return_value=50.0)  # type: ignore[method-assign]
+        prev = {"latitude": 0.0, "longitude": 0.0, "accuracy": 1.0}
+        proposed = {"latitude": 0.0, "longitude": 0.0, "radius": 100.0}
+
+        assert coord._should_preserve_precise_home_coordinates(prev, proposed) is True
+
+    def test_outside_radius_returns_false(self, coord: MainCoordinatorStub) -> None:
+        coord._haversine_distance = MagicMock(return_value=500.0)  # type: ignore[method-assign]
+        prev = {"latitude": 0.0, "longitude": 0.0, "accuracy": 1.0}
+        proposed = {"latitude": 0.0, "longitude": 0.0, "radius": 100.0}
+
+        assert coord._should_preserve_precise_home_coordinates(prev, proposed) is False
+
+
+class TestAuthErrorActive:
+    """``auth_error_active`` reads the private auth-failure flag."""
+
+    def test_initially_false(self, coord: MainCoordinatorStub) -> None:
+        assert coord.auth_error_active is False
+
+    def test_reflects_private_flag(self, coord: MainCoordinatorStub) -> None:
+        coord._auth_error_active = True
+
+        assert coord.auth_error_active is True

--- a/tests/test_coordinator_polling_basics.py
+++ b/tests/test_coordinator_polling_basics.py
@@ -1,0 +1,503 @@
+# tests/test_coordinator_polling_basics.py
+"""Branch-coverage tests for the simple ``PollingOperations`` mixin methods.
+
+PR 1.A.3 (Phase 2, AP-B). Scope: ``coordinator/polling.py`` simple helpers
+(``_set_api_status``, ``_set_fcm_status``, ``api_status``, ``fcm_status``,
+``is_fcm_connected``, ``consecutive_timeouts``, ``last_poll_result``,
+``_is_on_hass_loop``, ``_run_on_hass_loop``,
+``_compute_type_cooldown_seconds``, ``_apply_report_type_cooldown``,
+``is_polling``, ``get_fcm_acquire_duration_seconds``,
+``get_last_poll_duration_seconds``, ``_clear_fcm_deferral``,
+``_nudge_fcm_supervisor``, ``_get_predicted_poll_time``,
+``_note_push_transport_problem``, ``force_poll_due``). The complex async
+methods (``_async_update_data``, ``_async_start_poll_cycle``,
+``_handle_dr_event``, ``_dispatch_async_request_refresh``,
+``_schedule_short_retry``, ``_is_fcm_ready_soft``, ``_note_fcm_deferral``)
+remain out of scope here; they land in a later AP.
+
+Aniche-style adequacy progression: Specification → Boundary → Structural.
+:class:`PollingStub` (``tests.helpers.polling_mixin_stub``) seeds every
+attribute ``_MixinBase`` declares and pre-mocks cross-mixin methods
+(``_entry_id``, ``get_metric``, ``_get_duration``,
+``async_set_updated_data``, ``_reindex_poll_targets_from_device_registry``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import deque
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.const import DOMAIN
+from custom_components.googlefindmy.coordinator.helpers.stats import (
+    ApiStatus,
+    FcmStatus,
+    StatusSnapshot,
+)
+from tests.helpers.config_entries_stub import make_config_entry
+from tests.helpers.polling_mixin_stub import PollingStub, make_hass_stub
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def coord() -> PollingStub:
+    """Return a default :class:`PollingStub` bound to a synthetic config entry."""
+
+    entry = make_config_entry(entry_id="entry-xyz")
+    return PollingStub(hass=make_hass_stub(), config_entry=entry)
+
+
+# ---------------------------------------------------------------------------
+# T1 ``_set_api_status``
+# ---------------------------------------------------------------------------
+
+
+class TestSetApiStatus:
+    """B1: no change → early return; B2: change → update + notify;
+    B3: ``async_set_updated_data`` raises → swallow."""
+
+    def test_no_change_is_noop(self, coord: PollingStub) -> None:
+        coord._api_status_state = ApiStatus.OK
+        coord._api_status_reason = "stable"
+        coord._api_status_changed_at = 12345.0
+        coord._set_api_status(ApiStatus.OK, reason="stable")
+        # No state mutation, no listener notification.
+        assert coord._api_status_changed_at == 12345.0
+        coord.async_set_updated_data.assert_not_called()
+
+    def test_state_change_updates_and_notifies(self, coord: PollingStub) -> None:
+        before = time.time()
+        coord._set_api_status(ApiStatus.ERROR, reason="boom")
+        assert coord._api_status_state == ApiStatus.ERROR
+        assert coord._api_status_reason == "boom"
+        assert coord._api_status_changed_at is not None
+        assert coord._api_status_changed_at >= before
+        coord.async_set_updated_data.assert_called_once_with(coord.data)
+
+    def test_reason_change_only_still_notifies(self, coord: PollingStub) -> None:
+        coord._api_status_state = ApiStatus.OK
+        coord._api_status_reason = None
+        coord._set_api_status(ApiStatus.OK, reason="hint")
+        assert coord._api_status_reason == "hint"
+        coord.async_set_updated_data.assert_called_once_with(coord.data)
+
+    def test_set_updated_data_exception_is_swallowed(self, coord: PollingStub) -> None:
+        coord.async_set_updated_data = MagicMock(side_effect=RuntimeError("early"))
+        coord._set_api_status(ApiStatus.OK, reason="startup")
+        # State persists despite the listener failure.
+        assert coord._api_status_state == ApiStatus.OK
+        assert coord._api_status_reason == "startup"
+
+
+# ---------------------------------------------------------------------------
+# T2 ``_set_fcm_status``
+# ---------------------------------------------------------------------------
+
+
+class TestSetFcmStatus:
+    """B1: no change → early return; B2: change → update + notify;
+    B3: ``async_set_updated_data`` raises → swallow."""
+
+    def test_no_change_is_noop(self, coord: PollingStub) -> None:
+        coord._fcm_status_state = FcmStatus.CONNECTED
+        coord._fcm_status_reason = None
+        coord._fcm_status_changed_at = 999.0
+        coord._set_fcm_status(FcmStatus.CONNECTED, reason=None)
+        assert coord._fcm_status_changed_at == 999.0
+        coord.async_set_updated_data.assert_not_called()
+
+    def test_state_change_updates_and_notifies(self, coord: PollingStub) -> None:
+        coord._set_fcm_status(FcmStatus.DEGRADED, reason="slow")
+        assert coord._fcm_status_state == FcmStatus.DEGRADED
+        assert coord._fcm_status_reason == "slow"
+        coord.async_set_updated_data.assert_called_once_with(coord.data)
+
+    def test_set_updated_data_exception_is_swallowed(self, coord: PollingStub) -> None:
+        coord.async_set_updated_data = MagicMock(side_effect=RuntimeError("early"))
+        coord._set_fcm_status(FcmStatus.DISCONNECTED, reason="gone")
+        assert coord._fcm_status_state == FcmStatus.DISCONNECTED
+
+
+# ---------------------------------------------------------------------------
+# T3 / T4 / T5 / T6 Property getters
+# ---------------------------------------------------------------------------
+
+
+class TestStatusProperties:
+    """Snapshot dataclasses + scalar getters mirror the underlying attrs."""
+
+    def test_api_status_snapshot(self, coord: PollingStub) -> None:
+        coord._api_status_state = ApiStatus.OK
+        coord._api_status_reason = "happy"
+        coord._api_status_changed_at = 42.0
+        snapshot = coord.api_status
+        assert isinstance(snapshot, StatusSnapshot)
+        assert snapshot.state == ApiStatus.OK
+        assert snapshot.reason == "happy"
+        assert snapshot.changed_at == 42.0
+
+    def test_fcm_status_snapshot(self, coord: PollingStub) -> None:
+        coord._fcm_status_state = FcmStatus.DEGRADED
+        coord._fcm_status_reason = "slow"
+        coord._fcm_status_changed_at = 1.5
+        snapshot = coord.fcm_status
+        assert isinstance(snapshot, StatusSnapshot)
+        assert snapshot.state == FcmStatus.DEGRADED
+        assert snapshot.reason == "slow"
+        assert snapshot.changed_at == 1.5
+
+    def test_is_fcm_connected_true(self, coord: PollingStub) -> None:
+        coord._fcm_status_state = FcmStatus.CONNECTED
+        assert coord.is_fcm_connected is True
+
+    @pytest.mark.parametrize(
+        "state",
+        [FcmStatus.UNKNOWN, FcmStatus.DEGRADED, FcmStatus.DISCONNECTED, "other"],
+    )
+    def test_is_fcm_connected_false(self, coord: PollingStub, state: str) -> None:
+        coord._fcm_status_state = state
+        assert coord.is_fcm_connected is False
+
+    def test_scalar_getters_read_through(self, coord: PollingStub) -> None:
+        coord._consecutive_timeouts = 5
+        coord._last_poll_result = "success"
+        coord._is_polling = True
+        assert coord.consecutive_timeouts == 5
+        assert coord.last_poll_result == "success"
+        assert coord.is_polling is True
+
+
+# ---------------------------------------------------------------------------
+# T7 ``_is_on_hass_loop``
+# ---------------------------------------------------------------------------
+
+
+class TestIsOnHassLoop:
+    """B1: running loop equals hass.loop → True; B2: differs → False;
+    B3: RuntimeError (no running loop) → False."""
+
+    def test_returns_false_when_no_running_loop(self, coord: PollingStub) -> None:
+        # No event loop is running in this sync test → RuntimeError → False.
+        assert coord._is_on_hass_loop() is False
+
+    async def test_returns_true_when_running_loop_matches(self) -> None:
+        # ``asyncio_mode = "auto"`` (pyproject.toml) supplies the running loop;
+        # avoid ``asyncio.run()`` here so the architecture guard
+        # (tests/test_guard_asyncio_run_antipattern.py) stays satisfied.
+        loop = asyncio.get_running_loop()
+        stub = PollingStub(hass=make_hass_stub(loop=loop))
+        assert stub._is_on_hass_loop() is True
+
+    async def test_returns_false_when_running_loop_differs(self) -> None:
+        # hass.loop is a MagicMock (different identity from the running loop),
+        # so the equality check returns ``False`` even on the HA loop thread.
+        stub = PollingStub(hass=make_hass_stub())
+        assert stub._is_on_hass_loop() is False
+
+
+# ---------------------------------------------------------------------------
+# T8 ``_run_on_hass_loop``
+# ---------------------------------------------------------------------------
+
+
+class TestRunOnHassLoop:
+    """B1: no kwargs → loop.call_soon_threadsafe(func, *args);
+    B2: kwargs → loop.call_soon_threadsafe(functools.partial(...))."""
+
+    def test_without_kwargs_passes_func_and_args(self, coord: PollingStub) -> None:
+        captured: list[tuple[object, ...]] = []
+        coord.hass.loop.call_soon_threadsafe = MagicMock(
+            side_effect=lambda *args: captured.append(args)
+        )
+
+        def _noop(*_args: object) -> None:
+            pass
+
+        coord._run_on_hass_loop(_noop, "a", "b")
+        assert len(captured) == 1
+        assert captured[0][0] is _noop
+        assert captured[0][1:] == ("a", "b")
+
+    def test_with_kwargs_wraps_in_partial(self, coord: PollingStub) -> None:
+        captured: list[tuple[object, ...]] = []
+        coord.hass.loop.call_soon_threadsafe = MagicMock(
+            side_effect=lambda *args: captured.append(args)
+        )
+
+        def _noop(*_args: object, **_kwargs: object) -> None:
+            pass
+
+        coord._run_on_hass_loop(_noop, 1, key="value")
+        assert len(captured) == 1
+        # functools.partial wraps the function; first positional must be callable.
+        wrapped = captured[0][0]
+        assert callable(wrapped)
+        # Confirm the partial captured the right args/kwargs without invoking.
+        assert getattr(wrapped, "args", ()) == (1,)
+        assert getattr(wrapped, "keywords", {}) == {"key": "value"}
+
+
+# ---------------------------------------------------------------------------
+# T9 ``_compute_type_cooldown_seconds``
+# ---------------------------------------------------------------------------
+
+
+class TestComputeTypeCooldownSeconds:
+    """B1: no hint → 0; B2: ``in_all_areas`` base; B3: ``high_traffic`` base;
+    B4: unknown hint → 0; B5: ``max(base, effective_poll)``."""
+
+    def test_none_hint_returns_zero(self, coord: PollingStub) -> None:
+        assert coord._compute_type_cooldown_seconds(None) == 0
+
+    def test_empty_hint_returns_zero(self, coord: PollingStub) -> None:
+        assert coord._compute_type_cooldown_seconds("") == 0
+
+    def test_in_all_areas_uses_10_minute_floor(self, coord: PollingStub) -> None:
+        coord.location_poll_interval = 60
+        assert coord._compute_type_cooldown_seconds("in_all_areas") == 10 * 60
+
+    def test_high_traffic_uses_5_minute_floor(self, coord: PollingStub) -> None:
+        coord.location_poll_interval = 60
+        assert coord._compute_type_cooldown_seconds("high_traffic") == 5 * 60
+
+    def test_unknown_hint_returns_zero(self, coord: PollingStub) -> None:
+        assert coord._compute_type_cooldown_seconds("unknown") == 0
+
+    def test_long_poll_interval_dominates_base(self, coord: PollingStub) -> None:
+        coord.location_poll_interval = 30 * 60  # 30 min
+        assert coord._compute_type_cooldown_seconds("in_all_areas") == 30 * 60
+
+    def test_zero_poll_interval_clamped_to_one_minimum(
+        self, coord: PollingStub
+    ) -> None:
+        coord.location_poll_interval = 0
+        # base 10*60 still wins over effective_poll=max(1,0)=1
+        assert coord._compute_type_cooldown_seconds("in_all_areas") == 10 * 60
+
+
+# ---------------------------------------------------------------------------
+# T10 ``_apply_report_type_cooldown``
+# ---------------------------------------------------------------------------
+
+
+class TestApplyReportTypeCooldown:
+    """B1: zero seconds → skip; B2: new > prev → set;
+    B3: new <= prev → no-op; B4: ``_compute_type_cooldown_seconds`` raises → swallow."""
+
+    def test_zero_seconds_skips(self, coord: PollingStub) -> None:
+        coord._apply_report_type_cooldown("dev-1", None)
+        assert "dev-1" not in coord._device_poll_cooldown_until
+
+    def test_new_deadline_writes_entry(self, coord: PollingStub) -> None:
+        coord.location_poll_interval = 60
+        before = time.monotonic()
+        coord._apply_report_type_cooldown("dev-1", "in_all_areas")
+        deadline = coord._device_poll_cooldown_until["dev-1"]
+        assert deadline >= before + 10 * 60 - 1  # tolerate clock skew
+
+    def test_existing_longer_deadline_kept(self, coord: PollingStub) -> None:
+        coord.location_poll_interval = 60
+        future = time.monotonic() + 9999
+        coord._device_poll_cooldown_until["dev-1"] = future
+        coord._apply_report_type_cooldown("dev-1", "high_traffic")
+        assert coord._device_poll_cooldown_until["dev-1"] == future
+
+    def test_compute_exception_is_swallowed(self, coord: PollingStub) -> None:
+        original = coord._compute_type_cooldown_seconds
+        try:
+            coord._compute_type_cooldown_seconds = MagicMock(  # type: ignore[method-assign]
+                side_effect=RuntimeError("boom")
+            )
+            coord._apply_report_type_cooldown("dev-1", "in_all_areas")
+            assert "dev-1" not in coord._device_poll_cooldown_until
+        finally:
+            coord._compute_type_cooldown_seconds = original  # type: ignore[method-assign]
+
+
+# ---------------------------------------------------------------------------
+# T11 ``get_fcm_acquire_duration_seconds`` + ``get_last_poll_duration_seconds``
+# ---------------------------------------------------------------------------
+
+
+class TestDurationGetters:
+    """B1: ``get_fcm_acquire_duration_seconds`` delegates to ``helpers.stats``;
+    B2: ``get_last_poll_duration_seconds`` delegates to ``_get_duration``."""
+
+    def test_get_fcm_acquire_duration_uses_recorded_metrics(
+        self, coord: PollingStub
+    ) -> None:
+        coord.get_metric = MagicMock(side_effect=[10.0, 25.5])
+        assert coord.get_fcm_acquire_duration_seconds() == pytest.approx(15.5)
+
+    def test_get_fcm_acquire_duration_returns_none_when_missing(
+        self, coord: PollingStub
+    ) -> None:
+        coord.get_metric = MagicMock(return_value=None)
+        assert coord.get_fcm_acquire_duration_seconds() is None
+
+    def test_get_last_poll_duration_delegates(self, coord: PollingStub) -> None:
+        coord._get_duration = MagicMock(return_value=7.25)  # type: ignore[method-assign]
+        assert coord.get_last_poll_duration_seconds() == 7.25
+        coord._get_duration.assert_called_once_with(
+            "last_poll_start_mono", "last_poll_end_mono"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T12 ``_clear_fcm_deferral``
+# ---------------------------------------------------------------------------
+
+
+class TestClearFcmDeferral:
+    """B1: was deferred → log info + clear; B2: not deferred → silent clear."""
+
+    def test_clears_state_when_previously_deferred(self, coord: PollingStub) -> None:
+        coord._fcm_defer_started_mono = 100.0
+        coord._fcm_last_stage = 2
+        coord._degraded_mode_warned = True
+        coord._clear_fcm_deferral()
+        assert coord._fcm_defer_started_mono == 0.0
+        assert coord._fcm_last_stage == 0
+        assert coord._degraded_mode_warned is False
+        assert coord._fcm_status_state == FcmStatus.CONNECTED
+
+    def test_clear_when_not_deferred_still_sets_connected(
+        self, coord: PollingStub
+    ) -> None:
+        coord._fcm_defer_started_mono = 0.0
+        coord._fcm_status_state = FcmStatus.UNKNOWN
+        coord._clear_fcm_deferral()
+        assert coord._fcm_status_state == FcmStatus.CONNECTED
+
+
+# ---------------------------------------------------------------------------
+# T13 ``_nudge_fcm_supervisor``
+# ---------------------------------------------------------------------------
+
+
+class TestNudgeFcmSupervisor:
+    """B1: no fcm receiver → silent; B2: receiver lacks ``nudge_retry`` → silent;
+    B3: callable nudge → invoked with entry_id; B4: nudge raises → swallow."""
+
+    def test_no_fcm_is_silent(self, coord: PollingStub) -> None:
+        coord.hass.data = {DOMAIN: {}}
+        # Should not raise.
+        coord._nudge_fcm_supervisor()
+
+    def test_missing_nudge_retry_is_silent(self, coord: PollingStub) -> None:
+        receiver = MagicMock(spec_set=["other_attr"])
+        receiver.other_attr = "x"
+        coord.hass.data = {DOMAIN: {"fcm_receiver": receiver}}
+        coord._nudge_fcm_supervisor()
+
+    def test_callable_nudge_invoked_with_entry_id(self, coord: PollingStub) -> None:
+        receiver = MagicMock()
+        coord.hass.data = {DOMAIN: {"fcm_receiver": receiver}}
+        coord._entry_id = MagicMock(return_value="entry-xyz")
+        coord._nudge_fcm_supervisor()
+        receiver.nudge_retry.assert_called_once_with("entry-xyz")
+
+    def test_nudge_exception_is_swallowed(self, coord: PollingStub) -> None:
+        receiver = MagicMock()
+        receiver.nudge_retry = MagicMock(side_effect=RuntimeError("boom"))
+        coord.hass.data = {DOMAIN: {"fcm_receiver": receiver}}
+        coord._nudge_fcm_supervisor()
+
+
+# ---------------------------------------------------------------------------
+# T14 ``_get_predicted_poll_time``
+# ---------------------------------------------------------------------------
+
+
+class TestGetPredictedPollTime:
+    """B1: no history store → None; B2: empty store → None;
+    B3: histories with <2 entries skipped; B4: high stdev skipped;
+    B5: returns ``min(predictions)``."""
+
+    def test_no_history_attribute_returns_none(self, coord: PollingStub) -> None:
+        # Remove the attribute so getattr returns None.
+        del coord._device_update_history
+        assert coord._get_predicted_poll_time() is None
+
+    def test_empty_history_returns_none(self, coord: PollingStub) -> None:
+        coord._device_update_history = {}
+        assert coord._get_predicted_poll_time() is None
+
+    def test_only_short_histories_returns_none(self, coord: PollingStub) -> None:
+        # len(history) < 2 → no intervals computable.
+        coord._device_update_history = {"dev-1": deque([100.0])}
+        assert coord._get_predicted_poll_time() is None
+
+    def test_steady_history_predicts_next_update(self, coord: PollingStub) -> None:
+        # Three samples spaced 60s apart → avg interval 60s → next at 220.0.
+        coord._device_update_history = {"dev-1": deque([100.0, 160.0, 220.0])}
+        assert coord._get_predicted_poll_time() == pytest.approx(280.0)
+
+    def test_chooses_earliest_prediction(self, coord: PollingStub) -> None:
+        coord._device_update_history = {
+            "early": deque([0.0, 30.0, 60.0]),  # next at 90.0
+            "late": deque([100.0, 160.0, 220.0]),  # next at 280.0
+        }
+        assert coord._get_predicted_poll_time() == pytest.approx(90.0)
+
+    def test_high_stdev_history_is_skipped(self, coord: PollingStub) -> None:
+        # Intervals [10, 1000] → stdev far above 300 → device excluded.
+        coord._device_update_history = {
+            "noisy": deque([0.0, 10.0, 1010.0]),
+            "calm": deque([100.0, 160.0, 220.0]),
+        }
+        assert coord._get_predicted_poll_time() == pytest.approx(280.0)
+
+    def test_all_high_stdev_returns_none(self, coord: PollingStub) -> None:
+        coord._device_update_history = {
+            "noisy": deque([0.0, 10.0, 1010.0]),
+        }
+        assert coord._get_predicted_poll_time() is None
+
+
+# ---------------------------------------------------------------------------
+# T15 ``_note_push_transport_problem`` + ``force_poll_due``
+# ---------------------------------------------------------------------------
+
+
+class TestNotePushTransportProblem:
+    """B1: default 90s cooldown applied; B2: explicit cooldown honored;
+    B3: ``_push_ready_memo`` invalidated; B4: FCM status set to DEGRADED."""
+
+    def test_default_cooldown_sets_state(self, coord: PollingStub) -> None:
+        before = time.monotonic()
+        coord._note_push_transport_problem()
+        assert coord._push_cooldown_until >= before + 89  # tolerate skew
+        assert coord._push_ready_memo is False
+        assert coord._fcm_status_state == FcmStatus.DEGRADED
+
+    def test_custom_cooldown_used(self, coord: PollingStub) -> None:
+        before = time.monotonic()
+        coord._note_push_transport_problem(cooldown_s=30)
+        assert coord._push_cooldown_until >= before + 29
+        assert coord._push_cooldown_until < before + 120
+
+
+class TestForcePollDue:
+    """B1: backshift baseline by effective interval."""
+
+    def test_backshifts_last_poll_mono(self, coord: PollingStub) -> None:
+        coord.location_poll_interval = 90
+        coord.min_poll_interval = 60
+        coord.force_poll_due()
+        # _last_poll_mono = now - max(90, 60) = now - 90.
+        elapsed_since_baseline = time.monotonic() - coord._last_poll_mono
+        assert elapsed_since_baseline >= 90 - 0.5  # tolerate skew
+
+    def test_uses_min_when_location_smaller(self, coord: PollingStub) -> None:
+        coord.location_poll_interval = 10
+        coord.min_poll_interval = 60
+        coord.force_poll_due()
+        elapsed_since_baseline = time.monotonic() - coord._last_poll_mono
+        assert elapsed_since_baseline >= 60 - 0.5

--- a/tests/test_coordinator_polling_branches.py
+++ b/tests/test_coordinator_polling_branches.py
@@ -1,0 +1,461 @@
+# tests/test_coordinator_polling_branches.py
+"""Branch-coverage tests for :mod:`coordinator.polling` (Phase 4 AP-J).
+
+Phase 2 AP-B covered the simple read-through mixin methods. This module
+exercises the harder branch logic: loop-detection dispatch, coalesced retry
+scheduling, device-registry event handling, 3-tier FCM-ready probing and the
+escalation timeline. Class names use the ``Branches`` suffix to keep
+disjoint from ``test_coordinator_polling_basics.py`` (CA-F6).
+
+Scope (Phase 4 AP-J):
+- ``_dispatch_async_request_refresh`` (5 branches)
+- ``_schedule_short_retry`` (6 branches)
+- ``_handle_dr_event`` (1 branch)
+- ``_is_fcm_ready_soft`` (3-tier priority, ~12 branches)
+- ``_note_fcm_deferral`` (4 stages)
+
+Out of scope (Phase 5):
+- ``_async_update_data``, ``_async_start_poll_cycle`` (full poll-cycle roundtrip)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.coordinator.helpers.stats import FcmStatus
+from tests.helpers.polling_branches_stub import PollingBranchesStub
+
+
+@pytest.fixture
+def coord() -> PollingBranchesStub:
+    """Return a fresh :class:`PollingBranchesStub` with default scalars."""
+
+    return PollingBranchesStub()
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_async_request_refresh
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchAsyncRequestRefreshBranches:
+    """Loop detection, awaitable scheduling, exception swallowing."""
+
+    def test_no_async_request_refresh_callable_returns(
+        self, coord: PollingBranchesStub
+    ) -> None:
+        coord.async_request_refresh = None  # type: ignore[assignment]
+        coord._is_on_hass_loop = MagicMock(return_value=True)
+
+        coord._dispatch_async_request_refresh(task_name="t", log_context="ctx")
+
+        coord.hass.async_create_task.assert_not_called()
+
+    def test_on_loop_with_non_awaitable_result_skips_task_create(
+        self, coord: PollingBranchesStub
+    ) -> None:
+        coord.async_request_refresh = MagicMock(return_value=None)
+        coord._is_on_hass_loop = MagicMock(return_value=True)
+
+        coord._dispatch_async_request_refresh(task_name="t", log_context="ctx")
+
+        coord.async_request_refresh.assert_called_once_with()
+        coord.hass.async_create_task.assert_not_called()
+
+    def test_on_loop_with_awaitable_schedules_task(
+        self, coord: PollingBranchesStub
+    ) -> None:
+        async def _awaitable() -> None:
+            return None
+
+        coro = _awaitable()
+        coord.async_request_refresh = MagicMock(return_value=coro)
+        coord._is_on_hass_loop = MagicMock(return_value=True)
+
+        coord._dispatch_async_request_refresh(task_name="task-x", log_context="on-loop")
+
+        coord.hass.async_create_task.assert_called_once_with(coro, name="task-x")
+        coro.close()
+
+    def test_on_loop_exception_swallowed_and_logged(
+        self, coord: PollingBranchesStub, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        coord.async_request_refresh = MagicMock(side_effect=RuntimeError("boom"))
+        coord._is_on_hass_loop = MagicMock(return_value=True)
+
+        with caplog.at_level(logging.DEBUG, logger="custom_components.googlefindmy"):
+            coord._dispatch_async_request_refresh(task_name="t", log_context="explode")
+
+        assert "explode" in caplog.text
+        coord.hass.async_create_task.assert_not_called()
+
+    def test_off_loop_uses_run_on_hass_loop(self, coord: PollingBranchesStub) -> None:
+        coord.async_request_refresh = MagicMock(return_value=None)
+        coord._is_on_hass_loop = MagicMock(return_value=False)
+
+        captured: list[Any] = []
+        coord._run_on_hass_loop = lambda fn, *a, **kw: captured.append(fn)  # type: ignore[assignment]
+
+        coord._dispatch_async_request_refresh(task_name="t", log_context="off")
+
+        assert len(captured) == 1
+        # The deferred callable still works: invoke it and verify no task scheduled.
+        captured[0]()
+        coord.async_request_refresh.assert_called_once_with()
+
+
+# ---------------------------------------------------------------------------
+# _schedule_short_retry
+# ---------------------------------------------------------------------------
+
+
+class TestScheduleShortRetryBranches:
+    """Coalesce, delay clamp, callback dispatch."""
+
+    def test_on_loop_uses_async_call_later(
+        self, coord: PollingBranchesStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sentinel = object()
+        fake_call_later = MagicMock(return_value=sentinel)
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.polling.async_call_later",
+            fake_call_later,
+        )
+        coord._is_on_hass_loop = MagicMock(return_value=True)
+
+        coord._schedule_short_retry(delay_s=3.0)
+
+        fake_call_later.assert_called_once()
+        args, _kwargs = fake_call_later.call_args
+        assert args[0] is coord.hass
+        assert args[1] == 3.0
+        assert callable(args[2])
+        assert coord._short_retry_cancel is sentinel
+
+    def test_off_loop_routes_through_run_on_hass_loop(
+        self, coord: PollingBranchesStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_call_later = MagicMock(return_value=MagicMock())
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.polling.async_call_later",
+            fake_call_later,
+        )
+        coord._is_on_hass_loop = MagicMock(return_value=False)
+
+        captured: list[Any] = []
+        coord._run_on_hass_loop = lambda fn, *a, **kw: captured.append(fn)  # type: ignore[assignment]
+
+        coord._schedule_short_retry(delay_s=1.5)
+
+        fake_call_later.assert_not_called()
+        assert len(captured) == 1
+        captured[0]()  # invoke the deferred scheduler
+        fake_call_later.assert_called_once()
+
+    def test_pending_cancel_called_before_new_schedule(
+        self, coord: PollingBranchesStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        prev_cancel = MagicMock()
+        coord._short_retry_cancel = prev_cancel
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.polling.async_call_later",
+            MagicMock(return_value=MagicMock()),
+        )
+        coord._is_on_hass_loop = MagicMock(return_value=True)
+
+        coord._schedule_short_retry(delay_s=2.0)
+
+        prev_cancel.assert_called_once_with()
+
+    def test_pending_cancel_exception_swallowed(
+        self, coord: PollingBranchesStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        prev_cancel = MagicMock(side_effect=RuntimeError("nope"))
+        coord._short_retry_cancel = prev_cancel
+        new_handle = MagicMock()
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.polling.async_call_later",
+            MagicMock(return_value=new_handle),
+        )
+        coord._is_on_hass_loop = MagicMock(return_value=True)
+
+        coord._schedule_short_retry(delay_s=1.0)
+
+        # Cancel raised, schedule must still proceed and overwrite the handle.
+        assert coord._short_retry_cancel is new_handle
+
+    def test_negative_delay_clamped_to_zero(
+        self, coord: PollingBranchesStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_call_later = MagicMock(return_value=MagicMock())
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.polling.async_call_later",
+            fake_call_later,
+        )
+        coord._is_on_hass_loop = MagicMock(return_value=True)
+
+        coord._schedule_short_retry(delay_s=-5.0)
+
+        args, _ = fake_call_later.call_args
+        assert args[1] == 0.0
+
+    def test_callback_clears_handle_and_dispatches(
+        self, coord: PollingBranchesStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured_cb: dict[str, Any] = {}
+
+        def _capture(_hass: Any, _delay: float, cb: Any) -> Any:
+            captured_cb["cb"] = cb
+            return MagicMock()  # the cancel handle
+
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.polling.async_call_later",
+            _capture,
+        )
+        coord._is_on_hass_loop = MagicMock(return_value=True)
+        dispatch_mock = MagicMock()
+        coord._dispatch_async_request_refresh = dispatch_mock  # type: ignore[assignment]
+
+        coord._schedule_short_retry(delay_s=1.0)
+        assert coord._short_retry_cancel is not None
+        captured_cb["cb"](object())  # fake datetime arg
+
+        assert coord._short_retry_cancel is None
+        dispatch_mock.assert_called_once()
+        _, kwargs = dispatch_mock.call_args
+        assert kwargs["log_context"] == "short retry"
+
+
+# ---------------------------------------------------------------------------
+# _handle_dr_event
+# ---------------------------------------------------------------------------
+
+
+class TestHandleDrEventBranches:
+    """Device-registry event triggers reindex + refresh dispatch."""
+
+    async def test_reindex_and_dispatch_invoked(
+        self, coord: PollingBranchesStub
+    ) -> None:
+        dispatch_mock = MagicMock()
+        coord._dispatch_async_request_refresh = dispatch_mock  # type: ignore[assignment]
+        event = MagicMock()
+
+        await coord._handle_dr_event(event)
+
+        coord._reindex_poll_targets_from_device_registry.assert_called_once_with()
+        dispatch_mock.assert_called_once()
+        _, kwargs = dispatch_mock.call_args
+        assert kwargs["log_context"] == "device registry event"
+
+
+# ---------------------------------------------------------------------------
+# _is_fcm_ready_soft (3-tier priority)
+# ---------------------------------------------------------------------------
+
+
+class TestIsFcmReadySoftBranches:
+    """API > receiver-flags > push-client heuristic; defensive returns."""
+
+    def test_api_is_push_ready_true_short_circuits(
+        self, coord: PollingBranchesStub
+    ) -> None:
+        coord.api = MagicMock(is_push_ready=MagicMock(return_value=True))
+        # Even with no receiver, the API short-circuit wins.
+        coord.hass.data = {}
+
+        assert coord._is_fcm_ready_soft() is True
+
+    def test_api_is_push_ready_false_short_circuits(
+        self, coord: PollingBranchesStub
+    ) -> None:
+        coord.api = MagicMock(is_push_ready=MagicMock(return_value=False))
+
+        assert coord._is_fcm_ready_soft() is False
+
+    def test_api_raises_falls_through_to_receiver(
+        self, coord: PollingBranchesStub
+    ) -> None:
+        coord.api = MagicMock(
+            is_push_ready=MagicMock(side_effect=RuntimeError("api fail"))
+        )
+        fcm = MagicMock(spec_set=["is_ready", "_fatal_error", "_fatal_errors", "pc"])
+        fcm.is_ready = True
+        fcm._fatal_error = None
+        fcm._fatal_errors = None
+        fcm.pc = None
+        coord.hass.data = {"googlefindmy": {"fcm_receiver": fcm}}
+
+        assert coord._is_fcm_ready_soft() is True
+
+    def test_no_fcm_receiver_returns_false(self, coord: PollingBranchesStub) -> None:
+        coord.api = MagicMock(spec_set=[])  # no is_push_ready attribute
+        coord.hass.data = {}
+
+        assert coord._is_fcm_ready_soft() is False
+
+    def test_fatal_error_string_returns_false(self, coord: PollingBranchesStub) -> None:
+        coord.api = MagicMock(spec_set=[])
+        fcm = MagicMock(spec_set=["_fatal_error", "_fatal_errors", "is_ready", "pc"])
+        fcm._fatal_error = "boom"
+        fcm._fatal_errors = None
+        fcm.is_ready = True
+        fcm.pc = None
+        coord.hass.data = {"googlefindmy": {"fcm_receiver": fcm}}
+
+        assert coord._is_fcm_ready_soft() is False
+
+    def test_fatal_error_by_entry_returns_false(
+        self, coord: PollingBranchesStub
+    ) -> None:
+        coord.api = MagicMock(spec_set=[])
+        coord._entry_id = MagicMock(return_value="entry-xyz")
+        fcm = MagicMock(spec_set=["_fatal_error", "_fatal_errors", "is_ready", "pc"])
+        fcm._fatal_error = None
+        fcm._fatal_errors = {"entry-xyz": "auth-broken"}
+        fcm.is_ready = True
+        fcm.pc = None
+        coord.hass.data = {"googlefindmy": {"fcm_receiver": fcm}}
+
+        assert coord._is_fcm_ready_soft() is False
+
+    def test_receiver_ready_attribute_wins_over_pc(
+        self, coord: PollingBranchesStub
+    ) -> None:
+        coord.api = MagicMock(spec_set=[])
+        fcm = MagicMock(spec_set=["ready", "_fatal_error", "_fatal_errors", "pc"])
+        fcm.ready = False
+        fcm._fatal_error = None
+        fcm._fatal_errors = None
+        # ``pc`` would say True, but the explicit ready=False wins.
+        fcm.pc = MagicMock(run_state=MagicMock(name="STARTED"), do_listen=True)
+        coord.hass.data = {"googlefindmy": {"fcm_receiver": fcm}}
+
+        assert coord._is_fcm_ready_soft() is False
+
+    def test_pc_started_with_do_listen_true(self, coord: PollingBranchesStub) -> None:
+        coord.api = MagicMock(spec_set=[])
+        pc = MagicMock(spec_set=["run_state", "do_listen"])
+        pc.run_state = MagicMock(name="STARTED")
+        pc.run_state.name = "STARTED"
+        pc.do_listen = True
+        fcm = MagicMock(spec_set=["_fatal_error", "_fatal_errors", "is_ready", "pc"])
+        fcm._fatal_error = None
+        fcm._fatal_errors = None
+        fcm.is_ready = None  # not a bool -> skip receiver-flag branch
+        fcm.pc = pc
+        coord.hass.data = {"googlefindmy": {"fcm_receiver": fcm}}
+
+        assert coord._is_fcm_ready_soft() is True
+
+    def test_pc_started_without_do_listen_returns_false(
+        self, coord: PollingBranchesStub
+    ) -> None:
+        coord.api = MagicMock(spec_set=[])
+        pc = MagicMock(spec_set=["run_state", "do_listen"])
+        pc.run_state = MagicMock()
+        pc.run_state.name = "STARTED"
+        pc.do_listen = False
+        fcm = MagicMock(spec_set=["_fatal_error", "_fatal_errors", "is_ready", "pc"])
+        fcm._fatal_error = None
+        fcm._fatal_errors = None
+        fcm.is_ready = None
+        fcm.pc = pc
+        coord.hass.data = {"googlefindmy": {"fcm_receiver": fcm}}
+
+        assert coord._is_fcm_ready_soft() is False
+
+    def test_pc_other_state_returns_false(self, coord: PollingBranchesStub) -> None:
+        coord.api = MagicMock(spec_set=[])
+        pc = MagicMock(spec_set=["run_state", "do_listen"])
+        pc.run_state = MagicMock()
+        pc.run_state.name = "STOPPED"
+        pc.do_listen = True
+        fcm = MagicMock(spec_set=["_fatal_error", "_fatal_errors", "is_ready", "pc"])
+        fcm._fatal_error = None
+        fcm._fatal_errors = None
+        fcm.is_ready = None
+        fcm.pc = pc
+        coord.hass.data = {"googlefindmy": {"fcm_receiver": fcm}}
+
+        assert coord._is_fcm_ready_soft() is False
+
+    def test_outer_exception_returns_false(self, coord: PollingBranchesStub) -> None:
+        # An attribute that raises on access on coord.hass.data forces the
+        # outer ``except Exception`` branch.
+        broken_data = MagicMock()
+        broken_data.get = MagicMock(side_effect=RuntimeError("data broken"))
+        coord.hass.data = broken_data
+        coord.api = MagicMock(spec_set=[])
+
+        assert coord._is_fcm_ready_soft() is False
+
+
+# ---------------------------------------------------------------------------
+# _note_fcm_deferral (escalation timeline)
+# ---------------------------------------------------------------------------
+
+
+class TestNoteFcmDeferralBranches:
+    """Stage 0 (start) -> Stage 1 (120s INFO) -> Stage 2 (300s WARNING)."""
+
+    def test_first_call_sets_started_and_degraded(
+        self, coord: PollingBranchesStub
+    ) -> None:
+        coord._fcm_defer_started_mono = 0.0
+        coord._fcm_last_stage = 0
+
+        coord._note_fcm_deferral(now_mono=1000.0)
+
+        assert coord._fcm_defer_started_mono == 1000.0
+        assert coord._fcm_last_stage == 0
+        assert coord._fcm_status_state == FcmStatus.DEGRADED
+
+    def test_subsequent_call_under_2min_does_not_escalate(
+        self, coord: PollingBranchesStub
+    ) -> None:
+        coord._fcm_defer_started_mono = 1000.0
+        coord._fcm_last_stage = 0
+
+        coord._note_fcm_deferral(now_mono=1050.0)  # 50s elapsed
+
+        assert coord._fcm_last_stage == 0
+
+    def test_at_2min_emits_stage_1_info(
+        self, coord: PollingBranchesStub, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        coord._fcm_defer_started_mono = 1000.0
+        coord._fcm_last_stage = 0
+
+        with caplog.at_level(logging.INFO, logger="custom_components.googlefindmy"):
+            coord._note_fcm_deferral(now_mono=1120.0)
+
+        assert coord._fcm_last_stage == 1
+        assert coord._fcm_status_state == FcmStatus.DEGRADED
+        assert any("2 min" in r.message for r in caplog.records)
+
+    def test_at_5min_emits_stage_2_warning_and_disconnects(
+        self, coord: PollingBranchesStub, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        coord._fcm_defer_started_mono = 1000.0
+        coord._fcm_last_stage = 1  # already emitted stage 1
+
+        with caplog.at_level(logging.WARNING, logger="custom_components.googlefindmy"):
+            coord._note_fcm_deferral(now_mono=1300.0)
+
+        assert coord._fcm_last_stage == 2
+        assert coord._fcm_status_state == FcmStatus.DISCONNECTED
+
+    def test_after_stage2_no_further_escalation(
+        self, coord: PollingBranchesStub
+    ) -> None:
+        coord._fcm_defer_started_mono = 1000.0
+        coord._fcm_last_stage = 2
+
+        coord._note_fcm_deferral(now_mono=2000.0)
+
+        assert coord._fcm_last_stage == 2

--- a/tests/test_coordinator_polling_fatal_channel.py
+++ b/tests/test_coordinator_polling_fatal_channel.py
@@ -1,0 +1,102 @@
+# tests/test_coordinator_polling_fatal_channel.py
+"""Channel-confusion regression tests for ``coordinator.polling``.
+
+Iter-14 (Codex follow-up): the FCM receiver's supervisor-level "short-run
+crash loop" cap publishes its terminal state into the SAME ``_fatal_errors``
+map that the coordinator's re-auth escalation consumes. Without explicit
+classification the crash-loop fatal would be reclassified as an auth fatal
+after ``_FCM_ERROR_RETRY_THRESHOLD`` consecutive update cycles and push users
+into Home Assistant's re-auth flow for what is structurally a listener-
+lifecycle fatal (the repair issue carries the actual user-visible guidance).
+
+This module pins three contracts:
+
+1. ``_classify_fcm_fatal`` (free function, branch-coverage friendly):
+   - crash-loop prefix => ``_FCM_FATAL_CLASS_CRASH_LOOP_EXCLUDED``
+   - classic auth fatal (401/404/credentials text) =>
+     ``_FCM_FATAL_CLASS_AUTH_IMMEDIATE``
+   - any other non-empty fatal => ``_FCM_FATAL_CLASS_AUTH_AFTER_THRESHOLD``
+2. The polling-side fatal-classification call is the SSOT consumer for the
+   crash-loop prefix exported by ``Auth.fcm_receiver_ha``.
+3. The crash-loop prefix matches the message produced by the cap-fire
+   branch in ``Auth.fcm_receiver_ha`` (cross-module wire contract).
+"""
+
+from __future__ import annotations
+
+from custom_components.googlefindmy.Auth.fcm_receiver_ha import (
+    _MAX_CONSECUTIVE_SHORT_RUNS,
+    _SHORT_RUN_THRESHOLD_S,
+    CRASH_LOOP_FATAL_PREFIX,
+)
+from custom_components.googlefindmy.coordinator.polling import (
+    _FCM_FATAL_CLASS_AUTH_AFTER_THRESHOLD,
+    _FCM_FATAL_CLASS_AUTH_IMMEDIATE,
+    _FCM_FATAL_CLASS_CRASH_LOOP_EXCLUDED,
+    _classify_fcm_fatal,
+)
+
+
+class TestClassifyFcmFatal:
+    """Branch coverage for the channel-confusion fix."""
+
+    def test_crash_loop_prefix_is_excluded(self) -> None:
+        """A cap-fired crash-loop fatal must never escalate to re-auth."""
+        cap_message = (
+            f"{CRASH_LOOP_FATAL_PREFIX} 10 consecutive runs ended within 30s "
+            f"(persistent poison message suspected)"
+        )
+
+        assert (
+            _classify_fcm_fatal(cap_message) == _FCM_FATAL_CLASS_CRASH_LOOP_EXCLUDED
+        )
+
+    def test_bare_prefix_is_also_excluded(self) -> None:
+        """Defense is on the prefix alone, not the full message body."""
+        assert (
+            _classify_fcm_fatal(CRASH_LOOP_FATAL_PREFIX)
+            == _FCM_FATAL_CLASS_CRASH_LOOP_EXCLUDED
+        )
+
+    def test_classic_auth_fatal_is_immediate(self) -> None:
+        """A 401 credentials fatal must classify as auth_immediate.
+
+        ``is_fatal_fcm_auth_error`` matches plain ``"401"`` substrings, so a
+        message that contains ``"HTTP 401"`` classifies as the immediate
+        auth-fatal path.
+        """
+        msg = "FCM auth failed: invalid credentials (HTTP 401)"
+
+        assert _classify_fcm_fatal(msg) == _FCM_FATAL_CLASS_AUTH_IMMEDIATE
+
+    def test_unrelated_transient_fatal_uses_threshold_path(self) -> None:
+        """An unrecognised non-crash-loop fatal goes through the counter."""
+        # A network error that does not match auth patterns AND does not
+        # start with the crash-loop prefix.
+        msg = "Transient FCM error: connection reset"
+
+        assert (
+            _classify_fcm_fatal(msg) == _FCM_FATAL_CLASS_AUTH_AFTER_THRESHOLD
+        )
+
+    def test_wire_contract_cap_message_matches_prefix(self) -> None:
+        """The cap-fire branch must produce a message the classifier excludes.
+
+        This pins the cross-module wire contract: if the cap-fire branch in
+        ``Auth.fcm_receiver_ha`` ever changes its message template, this test
+        fails fast and forces the change to be propagated through
+        ``CRASH_LOOP_FATAL_PREFIX`` rather than diverging silently.
+        """
+        # Reproduce the cap-fire branch's f-string template literally.
+        cap_message = (
+            f"{CRASH_LOOP_FATAL_PREFIX} "
+            f"{_MAX_CONSECUTIVE_SHORT_RUNS} consecutive "
+            f"runs ended within "
+            f"{_SHORT_RUN_THRESHOLD_S:.0f}s "
+            f"(persistent poison message suspected)"
+        )
+
+        assert cap_message.startswith(CRASH_LOOP_FATAL_PREFIX)
+        assert (
+            _classify_fcm_fatal(cap_message) == _FCM_FATAL_CLASS_CRASH_LOOP_EXCLUDED
+        )

--- a/tests/test_coordinator_registry_basics.py
+++ b/tests/test_coordinator_registry_basics.py
@@ -1,0 +1,863 @@
+# tests/test_coordinator_registry_basics.py
+"""Branch-coverage tests for ``RegistryOperations`` mixin methods M1-M14 + M17.
+
+PR 1.A.1b (AP-1.1a-β). Scope: ``coordinator/registry.py`` lines 121-499
+(M1-M14) and lines 1289-1293 (M17). M15/M16/M18 land in PR 1.A.2.
+
+Aniche-style adequacy progression: Specification → Boundary → Structural.
+:class:`RegistryStub` (``tests.helpers.registry_mixin_stub``) seeds every
+attribute ``_MixinBase`` declares and pre-mocks the cross-mixin
+``NotImplementedError`` traps (notes sidecar risk R-NEU-3).
+"""
+
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.const import (
+    DOMAIN,
+    LEGACY_SERVICE_IDENTIFIER,
+    SERVICE_DEVICE_IDENTIFIER_PREFIX,
+)
+from custom_components.googlefindmy.coordinator import registry as registry_mod
+from tests.helpers.config_entries_stub import make_config_entry
+from tests.helpers.registry_mixin_stub import (
+    RegistryStub,
+    _DevRegStub,
+    _EntRegStub,
+    make_hass_stub,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def coord() -> RegistryStub:
+    """Return a default :class:`RegistryStub` bound to a synthetic config entry."""
+
+    entry = make_config_entry(entry_id="entry-xyz")
+    return RegistryStub(hass=make_hass_stub(), config_entry=entry)
+
+
+@pytest.fixture
+def coord_no_entry() -> RegistryStub:
+    """Return a stub without a bound ``ConfigEntry`` (early-startup state)."""
+
+    return RegistryStub(hass=make_hass_stub(), config_entry=None)
+
+
+# ---------------------------------------------------------------------------
+# M14 ``_redact_text`` (3 documented branches) — start with the trivial Pure
+# function so a smoke failure surfaces as a stub problem, not a Mixin issue.
+# ---------------------------------------------------------------------------
+
+
+class TestRedactText:
+    """B1: ``None``/empty → ``''``; B2: short → identity; B3: long → truncated."""
+
+    def test_none_returns_empty(self, coord: RegistryStub) -> None:
+        assert coord._redact_text(None) == ""
+
+    def test_empty_string_returns_empty(self, coord: RegistryStub) -> None:
+        # `not value` short-circuits on the empty string (falsy);
+        # whitespace-only strings are truthy and pass through unchanged.
+        assert coord._redact_text("") == ""
+
+    @pytest.mark.parametrize("value", ["   ", "\t"])
+    def test_whitespace_is_truthy_and_passes_through(
+        self, coord: RegistryStub, value: str
+    ) -> None:
+        # Documents the current contract: only Python-falsy values short-circuit.
+        # Whitespace strings are returned verbatim (no .strip() in production).
+        assert coord._redact_text(value) == value
+
+    def test_short_returns_identity(self, coord: RegistryStub) -> None:
+        assert coord._redact_text("hello") == "hello"
+
+    def test_long_is_truncated_with_ellipsis(self, coord: RegistryStub) -> None:
+        long = "x" * 200
+        out = coord._redact_text(long, max_len=120)
+        assert out == "x" * 120 + "…"
+        assert len(out) == 121  # 120 chars + ellipsis
+
+    def test_default_max_len_is_120(self, coord: RegistryStub) -> None:
+        assert coord._redact_text("x" * 121).endswith("…")
+        assert coord._redact_text("x" * 120) == "x" * 120
+
+
+# ---------------------------------------------------------------------------
+# M12 ``_entry_id`` (3 branches) + M13 ``_config_entry_exists`` (5 branches)
+# ---------------------------------------------------------------------------
+
+
+class TestEntryId:
+    """B1: no entry → None; B2: entry without entry_id → None; B3: present → str."""
+
+    def test_no_entry_returns_none(self, coord_no_entry: RegistryStub) -> None:
+        assert coord_no_entry._entry_id() is None
+
+    def test_entry_without_attr_returns_none(self) -> None:
+        coord = RegistryStub(config_entry=SimpleNamespace())  # no entry_id attr
+        assert coord._entry_id() is None
+
+    def test_entry_with_id_returns_str(self, coord: RegistryStub) -> None:
+        assert coord._entry_id() == "entry-xyz"
+
+
+class TestConfigEntryExists:
+    """5 branches: missing id, no hass, getter ok/None/raises."""
+
+    def test_no_entry_id_returns_false(self, coord_no_entry: RegistryStub) -> None:
+        coord_no_entry.hass = None
+        assert coord_no_entry._config_entry_exists() is False
+
+    def test_no_hass_returns_true_defensively(self, coord: RegistryStub) -> None:
+        coord.hass = None
+        assert coord._config_entry_exists() is True
+
+    def test_getter_returns_entry(self, coord: RegistryStub) -> None:
+        coord.hass.config_entries.async_get_entry = MagicMock(
+            return_value=SimpleNamespace(entry_id="entry-xyz")
+        )
+        assert coord._config_entry_exists() is True
+
+    def test_getter_returns_none(self, coord: RegistryStub) -> None:
+        coord.hass.config_entries.async_get_entry = MagicMock(return_value=None)
+        assert coord._config_entry_exists() is False
+
+    def test_getter_raises_returns_true_defensively(
+        self, coord: RegistryStub
+    ) -> None:
+        def _boom(_eid: str) -> Any:
+            raise RuntimeError("registry corrupted")
+
+        coord.hass.config_entries.async_get_entry = _boom
+        assert coord._config_entry_exists() is True
+
+    def test_no_callable_getter_returns_true(self, coord: RegistryStub) -> None:
+        coord.hass.config_entries.async_get_entry = "not-callable"
+        assert coord._config_entry_exists() is True
+
+    def test_explicit_entry_id_argument(self, coord: RegistryStub) -> None:
+        coord.hass.config_entries.async_get_entry = MagicMock(return_value=object())
+        assert coord._config_entry_exists("custom-id") is True
+        coord.hass.config_entries.async_get_entry.assert_called_once_with("custom-id")
+
+
+# ---------------------------------------------------------------------------
+# M9 ``_ensure_device_name_cache`` (2 branches) + M10 ``_apply_pending_via_updates``
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureDeviceNameCache:
+    """B1: not initialized → fresh dict; B2: initialized → identity."""
+
+    def test_first_call_initializes_empty_dict(self, coord: RegistryStub) -> None:
+        cache = coord._ensure_device_name_cache()
+        assert cache == {}
+        assert coord._device_names is cache
+
+    def test_second_call_returns_same_object(self, coord: RegistryStub) -> None:
+        first = coord._ensure_device_name_cache()
+        first["abc"] = "Alice"
+        second = coord._ensure_device_name_cache()
+        assert second is first
+        assert second["abc"] == "Alice"
+
+
+class TestApplyPendingViaUpdates:
+    """M10 is a documented no-op for backward compatibility."""
+
+    def test_returns_none_without_side_effects(self, coord: RegistryStub) -> None:
+        snapshot = vars(coord).copy()
+        assert coord._apply_pending_via_updates() is None
+        assert vars(coord) == snapshot
+
+
+# ---------------------------------------------------------------------------
+# M11 ``_device_display_name`` (passthrough)
+# ---------------------------------------------------------------------------
+
+
+class TestDeviceDisplayName:
+    """Passes through to ``extract_device_display_name`` helper."""
+
+    def test_prefers_name_by_user(self, coord: RegistryStub) -> None:
+        dev = SimpleNamespace(name_by_user="Custom", name="Default")
+        assert coord._device_display_name(dev, "fallback") == "Custom"
+
+    def test_falls_back_to_name(self, coord: RegistryStub) -> None:
+        dev = SimpleNamespace(name_by_user=None, name="Default")
+        assert coord._device_display_name(dev, "fallback") == "Default"
+
+    def test_uses_fallback_when_both_empty(self, coord: RegistryStub) -> None:
+        dev = SimpleNamespace(name_by_user=None, name=None)
+        assert coord._device_display_name(dev, "fallback") == "fallback"
+
+
+# ---------------------------------------------------------------------------
+# M3 ``_device_registry_build_legacy_kwargs`` (delegation) + M2 retry detection
+# ---------------------------------------------------------------------------
+
+
+class TestBuildLegacyKwargs:
+    """Static-passthrough to ``build_legacy_device_registry_kwargs``."""
+
+    def test_translates_modern_keys(self) -> None:
+        out = RegistryStub._device_registry_build_legacy_kwargs(
+            {"add_config_entry_id": "e1", "add_config_subentry_id": "s1"}
+        )
+        assert out == {"config_entry_id": "e1", "config_subentry_id": "s1"}
+
+    def test_drops_remove_config_subentry_id(self) -> None:
+        out = RegistryStub._device_registry_build_legacy_kwargs(
+            {"remove_config_subentry_id": "s1", "name": "Phone"}
+        )
+        assert out == {"name": "Phone"}
+
+    def test_does_not_mutate_input(self) -> None:
+        original = {"add_config_entry_id": "e1"}
+        RegistryStub._device_registry_build_legacy_kwargs(original)
+        assert original == {"add_config_entry_id": "e1"}
+
+
+class TestKwargsNeedLegacyRetry:
+    """Delegates to ``needs_legacy_kwarg_retry`` helper after kwarg-name lookup."""
+
+    def test_modern_registry_does_not_retry(self, coord: RegistryStub) -> None:
+        def modern_api(*, add_config_subentry_id: str | None = None) -> None: ...
+
+        err = TypeError("add_config_subentry_id rejected")
+        assert (
+            coord._device_registry_kwargs_need_legacy_retry(
+                modern_api, err, {"add_config_subentry_id": "s1"}
+            )
+            is False
+        )
+
+    def test_legacy_registry_triggers_retry(self, coord: RegistryStub) -> None:
+        def legacy_api(*, config_subentry_id: str | None = None) -> None: ...
+
+        err = TypeError("got unexpected keyword argument 'add_config_entry_id'")
+        assert (
+            coord._device_registry_kwargs_need_legacy_retry(
+                legacy_api, err, {"add_config_entry_id": "e1"}
+            )
+            is True
+        )
+
+
+# ---------------------------------------------------------------------------
+# M4 ``_device_registry_config_subentry_kwarg_name`` (7+ branches)
+# ---------------------------------------------------------------------------
+
+
+class TestConfigSubentryKwargName:
+    """Cover signature-based detection, caching, and defensive fallbacks."""
+
+    def test_returns_config_subentry_id_when_present(
+        self, coord: RegistryStub
+    ) -> None:
+        def api(*, config_subentry_id: str | None = None) -> None: ...
+
+        assert (
+            coord._device_registry_config_subentry_kwarg_name(api)
+            == "config_subentry_id"
+        )
+
+    def test_returns_add_config_subentry_id_when_present(
+        self, coord: RegistryStub
+    ) -> None:
+        def api(*, add_config_subentry_id: str | None = None) -> None: ...
+
+        assert (
+            coord._device_registry_config_subentry_kwarg_name(api)
+            == "add_config_subentry_id"
+        )
+
+    def test_var_keyword_returns_config_subentry_id(
+        self, coord: RegistryStub
+    ) -> None:
+        def api(**kwargs: Any) -> None: ...
+
+        assert (
+            coord._device_registry_config_subentry_kwarg_name(api)
+            == "config_subentry_id"
+        )
+
+    def test_unrelated_signature_returns_none(self, coord: RegistryStub) -> None:
+        def api(a: int, b: int) -> None: ...
+
+        assert coord._device_registry_config_subentry_kwarg_name(api) is None
+
+    def test_signature_typeerror_returns_none(
+        self, coord: RegistryStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def api() -> None: ...
+
+        def _raise(_call: Any) -> Any:
+            raise TypeError("C extension")
+
+        monkeypatch.setattr(inspect, "signature", _raise)
+        assert coord._device_registry_config_subentry_kwarg_name(api) is None
+
+    def test_signature_valueerror_returns_none(
+        self, coord: RegistryStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def api() -> None: ...
+
+        def _raise(_call: Any) -> Any:
+            raise ValueError("no signature")
+
+        monkeypatch.setattr(inspect, "signature", _raise)
+        assert coord._device_registry_config_subentry_kwarg_name(api) is None
+
+    def test_cache_hit_avoids_second_signature_call(
+        self, coord: RegistryStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def api(*, config_subentry_id: str | None = None) -> None: ...
+
+        original_signature = inspect.signature
+        call_count = {"n": 0}
+
+        def _counting(call: Any) -> Any:
+            call_count["n"] += 1
+            return original_signature(call)
+
+        monkeypatch.setattr(inspect, "signature", _counting)
+
+        assert coord._device_registry_config_subentry_kwarg_name(api) == (
+            "config_subentry_id"
+        )
+        assert coord._device_registry_config_subentry_kwarg_name(api) == (
+            "config_subentry_id"
+        )
+        assert call_count["n"] == 1
+
+    def test_cache_resets_when_attribute_is_not_a_dict(
+        self, coord: RegistryStub
+    ) -> None:
+        coord._device_registry_config_subentry_kwarg_cache = "not-a-dict"  # type: ignore[assignment]
+
+        def api(*, config_subentry_id: str | None = None) -> None: ...
+
+        assert (
+            coord._device_registry_config_subentry_kwarg_name(api)
+            == "config_subentry_id"
+        )
+        assert isinstance(coord._device_registry_config_subentry_kwarg_cache, dict)
+
+    def test_bound_method_uses_underlying_func_for_cache_key(
+        self, coord: RegistryStub
+    ) -> None:
+        class _Api:
+            def call(self, *, config_subentry_id: str | None = None) -> None: ...
+
+        a = _Api()
+        b = _Api()
+        # First call seeds the cache via the unbound function.
+        assert (
+            coord._device_registry_config_subentry_kwarg_name(a.call)
+            == "config_subentry_id"
+        )
+        cache = coord._device_registry_config_subentry_kwarg_cache
+        assert isinstance(cache, dict)
+        assert len(cache) == 1
+        # Different bound instance, same underlying ``__func__`` → reuses entry.
+        assert (
+            coord._device_registry_config_subentry_kwarg_name(b.call)
+            == "config_subentry_id"
+        )
+        assert len(cache) == 1
+
+
+# ---------------------------------------------------------------------------
+# M5 ``_device_registry_allows_translation_update`` (5 branches)
+# ---------------------------------------------------------------------------
+
+
+class TestAllowsTranslationUpdate:
+    """Detect translation kwarg support in ``async_update_device``."""
+
+    def test_cached_true_returned_directly(self, coord: RegistryStub) -> None:
+        coord._device_registry_supports_translation_update = True
+        assert coord._device_registry_allows_translation_update(MagicMock()) is True
+
+    def test_cached_false_returned_directly(self, coord: RegistryStub) -> None:
+        coord._device_registry_supports_translation_update = False
+        assert coord._device_registry_allows_translation_update(MagicMock()) is False
+
+    def test_missing_update_helper_returns_false(
+        self, coord: RegistryStub
+    ) -> None:
+        dev_reg = SimpleNamespace()  # no async_update_device attribute
+        assert (
+            coord._device_registry_allows_translation_update(dev_reg) is False
+        )
+        assert coord._device_registry_supports_translation_update is False
+
+    def test_both_translation_params_returns_true(
+        self, coord: RegistryStub
+    ) -> None:
+        def async_update_device(
+            device_id: str,
+            *,
+            translation_key: str | None = None,
+            translation_placeholders: dict[str, str] | None = None,
+        ) -> None: ...
+
+        dev_reg = SimpleNamespace(async_update_device=async_update_device)
+        assert coord._device_registry_allows_translation_update(dev_reg) is True
+
+    def test_partial_translation_params_returns_false(
+        self, coord: RegistryStub
+    ) -> None:
+        def async_update_device(
+            device_id: str, *, translation_key: str | None = None
+        ) -> None: ...
+
+        dev_reg = SimpleNamespace(async_update_device=async_update_device)
+        assert (
+            coord._device_registry_allows_translation_update(dev_reg) is False
+        )
+
+    def test_signature_failure_returns_false(
+        self, coord: RegistryStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        dev_reg = SimpleNamespace(async_update_device=lambda *a, **k: None)
+
+        def _raise(_call: Any) -> Any:
+            raise TypeError("C extension")
+
+        monkeypatch.setattr(inspect, "signature", _raise)
+        assert (
+            coord._device_registry_allows_translation_update(dev_reg) is False
+        )
+
+
+# ---------------------------------------------------------------------------
+# M1 ``_call_device_registry_api`` (10 branches)
+# ---------------------------------------------------------------------------
+
+
+class TestCallDeviceRegistryApi:
+    """B1..B10: kwargs handling, retry, fallback paths."""
+
+    def test_no_base_kwargs_calls_with_empty_kwargs(
+        self, coord: RegistryStub
+    ) -> None:
+        call = MagicMock(return_value="ok")
+        assert coord._call_device_registry_api(call) == "ok"
+        call.assert_called_once_with()
+
+    def test_config_subentry_dropped_when_replacement_is_none(
+        self, coord: RegistryStub
+    ) -> None:
+        def api(*, name: str) -> str:
+            return f"name={name}"
+
+        result = coord._call_device_registry_api(
+            api,
+            base_kwargs={"name": "Phone", "config_subentry_id": "s1"},
+        )
+        assert result == "name=Phone"
+
+    def test_replacement_equal_to_config_subentry_id_no_rename(
+        self, coord: RegistryStub
+    ) -> None:
+        captured: dict[str, Any] = {}
+
+        def api(*, config_subentry_id: str) -> None:
+            captured["seen"] = config_subentry_id
+
+        coord._call_device_registry_api(api, base_kwargs={"config_subentry_id": "s1"})
+        assert captured == {"seen": "s1"}
+
+    def test_replacement_renames_kwarg(self, coord: RegistryStub) -> None:
+        captured: dict[str, Any] = {}
+
+        def api(*, add_config_subentry_id: str) -> None:
+            captured["seen"] = add_config_subentry_id
+
+        coord._call_device_registry_api(api, base_kwargs={"config_subentry_id": "s1"})
+        assert captured == {"seen": "s1"}
+
+    def test_typeerror_without_legacy_match_reraises(
+        self, coord: RegistryStub
+    ) -> None:
+        def api(*, name: str) -> None:
+            raise TypeError("unrelated error about 'name'")
+
+        with pytest.raises(TypeError, match="unrelated error"):
+            coord._call_device_registry_api(api, base_kwargs={"name": "Phone"})
+
+    def test_typeerror_with_legacy_match_triggers_retry(
+        self, coord: RegistryStub
+    ) -> None:
+        attempts: list[dict[str, Any]] = []
+
+        def api(**kwargs: Any) -> str:
+            attempts.append(kwargs.copy())
+            if "add_config_entry_id" in kwargs:
+                raise TypeError("got unexpected keyword 'add_config_entry_id'")
+            return "ok"
+
+        result = coord._call_device_registry_api(
+            api, base_kwargs={"add_config_entry_id": "e1"}
+        )
+        assert result == "ok"
+        assert len(attempts) == 2
+        assert attempts[0] == {"add_config_entry_id": "e1"}
+        assert attempts[1] == {"config_entry_id": "e1"}
+
+    def test_unknown_subentry_with_add_config_kwarg_reraises(
+        self, coord: RegistryStub
+    ) -> None:
+        from homeassistant.config_entries import UnknownSubEntry
+
+        def api(*, add_config_subentry_id: str | None = None) -> None:
+            raise UnknownSubEntry()
+
+        with pytest.raises(UnknownSubEntry):
+            coord._call_device_registry_api(
+                api, base_kwargs={"config_subentry_id": "missing"}
+            )
+
+    def test_unknown_subentry_without_config_subentry_id_reraises(
+        self, coord: RegistryStub
+    ) -> None:
+        from homeassistant.config_entries import UnknownEntry
+
+        def api(*, name: str) -> None:
+            raise UnknownEntry()
+
+        with pytest.raises(UnknownEntry):
+            coord._call_device_registry_api(api, base_kwargs={"name": "Phone"})
+
+    def test_unknown_subentry_with_legacy_kwarg_falls_back(
+        self, coord: RegistryStub
+    ) -> None:
+        from homeassistant.config_entries import UnknownSubEntry
+
+        attempts: list[dict[str, Any]] = []
+
+        def api(*, config_subentry_id: str | None = None, name: str = "") -> str:
+            attempts.append(
+                {"config_subentry_id": config_subentry_id, "name": name}
+            )
+            if config_subentry_id == "missing":
+                raise UnknownSubEntry()
+            return "ok"
+
+        result = coord._call_device_registry_api(
+            api,
+            base_kwargs={"name": "Phone", "config_subentry_id": "missing"},
+        )
+        assert result == "ok"
+        # First attempt with subentry, fallback without it.
+        assert attempts[0]["config_subentry_id"] == "missing"
+        assert attempts[1]["config_subentry_id"] is None
+        assert attempts[1]["name"] == "Phone"
+
+
+# ---------------------------------------------------------------------------
+# M7 ``_extract_our_identifier`` (3 branches)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractOurIdentifier:
+    """Walks ``device.identifiers``; first valid wins, else ``None``."""
+
+    def test_empty_identifiers_returns_none(self, coord: RegistryStub) -> None:
+        device = SimpleNamespace(identifiers=set())
+        assert coord._extract_our_identifier(device) is None
+
+    def test_only_foreign_identifiers_returns_none(
+        self, coord: RegistryStub
+    ) -> None:
+        device = SimpleNamespace(identifiers={("other-domain", "xyz")})
+        assert coord._extract_our_identifier(device) is None
+
+    def test_entry_scoped_identifier_returns_raw_device_id(
+        self, coord: RegistryStub
+    ) -> None:
+        device = SimpleNamespace(
+            identifiers={(DOMAIN, "entry-xyz:dev-1")}
+        )
+        assert coord._extract_our_identifier(device) == "dev-1"
+
+    def test_legacy_identifier_returns_device_id(
+        self, coord: RegistryStub
+    ) -> None:
+        device = SimpleNamespace(identifiers={(DOMAIN, "dev-legacy")})
+        assert coord._extract_our_identifier(device) == "dev-legacy"
+
+    def test_service_device_identifier_returns_none(
+        self, coord: RegistryStub
+    ) -> None:
+        # SERVICE_DEVICE_IDENTIFIER_PREFIX-based identifiers are not tracker IDs;
+        # the helper filters them out at parse time.
+        device = SimpleNamespace(
+            identifiers={
+                (DOMAIN, f"{SERVICE_DEVICE_IDENTIFIER_PREFIX}entry-xyz")
+            }
+        )
+        assert coord._extract_our_identifier(device) is None
+
+    def test_legacy_service_identifier_returns_none(
+        self, coord: RegistryStub
+    ) -> None:
+        device = SimpleNamespace(
+            identifiers={(DOMAIN, LEGACY_SERVICE_IDENTIFIER)}
+        )
+        assert coord._extract_our_identifier(device) is None
+
+
+# ---------------------------------------------------------------------------
+# M8 ``_sync_owner_index`` (8+ branches)
+# ---------------------------------------------------------------------------
+
+
+class TestSyncOwnerIndex:
+    """Cover early-exit, defensive, prune, and overwrite-guard branches."""
+
+    def test_no_hass_returns_early(self, coord: RegistryStub) -> None:
+        coord.hass = None
+        # Should not raise.
+        coord._sync_owner_index([{"canonicalId": "abc"}])
+
+    def test_no_entry_id_returns_early(
+        self, coord_no_entry: RegistryStub
+    ) -> None:
+        coord_no_entry._sync_owner_index([{"canonicalId": "abc"}])
+        assert "device_owner_index" not in coord_no_entry.hass.data.get(DOMAIN, {})
+
+    def test_setdefault_error_does_not_raise(self) -> None:
+        coord = RegistryStub(
+            hass=make_hass_stub(with_setdefault_error=True),
+            config_entry=SimpleNamespace(entry_id="e1"),
+        )
+        # Defensive guard: error logged at DEBUG, no exception propagated.
+        coord._sync_owner_index([{"canonicalId": "abc"}])
+
+    def test_none_devices_is_no_op(self, coord: RegistryStub) -> None:
+        coord._sync_owner_index(None)
+        bucket = coord.hass.data.get(DOMAIN, {})
+        assert bucket.get("device_owner_index", {}) == {}
+
+    def test_canonical_id_field_wins(self, coord: RegistryStub) -> None:
+        coord._sync_owner_index(
+            [
+                {"canonicalId": "cid-1"},
+                {"canonical_id": "cid-2"},
+                {"id": "id-3"},
+                {"device_id": "id-4"},
+            ]
+        )
+        index = coord.hass.data[DOMAIN]["device_owner_index"]
+        assert index == {
+            "cid-1": "entry-xyz",
+            "cid-2": "entry-xyz",
+            "id-3": "entry-xyz",
+            "id-4": "entry-xyz",
+        }
+
+    def test_missing_id_skipped(self, coord: RegistryStub) -> None:
+        coord._sync_owner_index([{"unrelated": "value"}])
+        assert coord.hass.data.get(DOMAIN, {}).get("device_owner_index", {}) == {}
+
+    def test_non_string_canonical_is_coerced(self, coord: RegistryStub) -> None:
+        coord._sync_owner_index([{"id": 12345}])
+        assert (
+            coord.hass.data[DOMAIN]["device_owner_index"]["12345"] == "entry-xyz"
+        )
+
+    def test_empty_canonical_after_strip_skipped(
+        self, coord: RegistryStub
+    ) -> None:
+        coord._sync_owner_index([{"id": "   "}])
+        assert coord.hass.data.get(DOMAIN, {}).get("device_owner_index", {}) == {}
+
+    def test_existing_owner_from_other_entry_not_overwritten(
+        self, coord: RegistryStub
+    ) -> None:
+        coord.hass.data[DOMAIN] = {
+            "device_owner_index": {"shared": "entry-other"}
+        }
+        coord._sync_owner_index([{"id": "shared"}])
+        assert (
+            coord.hass.data[DOMAIN]["device_owner_index"]["shared"]
+            == "entry-other"
+        )
+
+    def test_stale_entries_for_this_entry_are_pruned(
+        self, coord: RegistryStub
+    ) -> None:
+        coord.hass.data[DOMAIN] = {
+            "device_owner_index": {
+                "stale": "entry-xyz",
+                "fresh": "entry-xyz",
+                "other": "entry-other",
+            }
+        }
+        coord._sync_owner_index([{"id": "fresh"}])
+        index = coord.hass.data[DOMAIN]["device_owner_index"]
+        assert "stale" not in index  # pruned: belonged to this entry, not seen
+        assert index["fresh"] == "entry-xyz"
+        assert index["other"] == "entry-other"  # other entry never pruned
+
+
+# ---------------------------------------------------------------------------
+# M6 ``_reindex_poll_targets_from_device_registry`` (7 branches + cross-call)
+# ---------------------------------------------------------------------------
+
+
+class TestReindexPollTargets:
+    """Drive every documented branch via monkeypatched dr/er modules."""
+
+    @pytest.fixture
+    def reindex_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> tuple[_DevRegStub, _EntRegStub]:
+        dev_reg = _DevRegStub()
+        ent_reg = _EntRegStub()
+        monkeypatch.setattr(registry_mod.dr, "async_get", lambda _hass: dev_reg)
+        monkeypatch.setattr(registry_mod.er, "async_get", lambda _hass: ent_reg)
+        monkeypatch.setattr(
+            registry_mod.dr,
+            "async_entries_for_config_entry",
+            lambda _reg, _eid: list(dev_reg.devices),
+        )
+        monkeypatch.setattr(
+            registry_mod.er,
+            "async_entries_for_config_entry",
+            lambda _reg, _eid: list(ent_reg.entries),
+        )
+        return dev_reg, ent_reg
+
+    def test_no_entry_id_resets_sets_and_returns(
+        self,
+        coord_no_entry: RegistryStub,
+        reindex_env: tuple[_DevRegStub, _EntRegStub],
+    ) -> None:
+        coord_no_entry._devices_with_entry = {"stale"}
+        coord_no_entry._enabled_poll_device_ids = {"stale"}
+        coord_no_entry._reindex_poll_targets_from_device_registry()
+        assert coord_no_entry._devices_with_entry == set()
+        assert coord_no_entry._enabled_poll_device_ids == set()
+        coord_no_entry._refresh_subentry_index.assert_not_called()
+
+    def test_happy_path_two_devices_one_enabled(
+        self,
+        coord: RegistryStub,
+        reindex_env: tuple[_DevRegStub, _EntRegStub],
+    ) -> None:
+        dev_reg, ent_reg = reindex_env
+        d1 = dev_reg.add_device(identifiers={(DOMAIN, "entry-xyz:tracker-1")})
+        d2 = dev_reg.add_device(identifiers={(DOMAIN, "entry-xyz:tracker-2")})
+        ent_reg.add_entry(device_id=d1.id)
+        # d2 has no entity → present but not enabled.
+        # d1 has tracker entity → enabled.
+
+        coord._reindex_poll_targets_from_device_registry()
+
+        assert coord._devices_with_entry == {"tracker-1", "tracker-2"}
+        assert coord._enabled_poll_device_ids == {"tracker-1"}
+        coord._refresh_subentry_index.assert_called_once()
+        coord._schedule_eid_resolver_refresh.assert_called_once()
+        # Silence unused-fixture warning.
+        assert d2.id in {dev.id for dev in dev_reg.devices}
+
+    def test_disabled_entity_does_not_enable_device(
+        self,
+        coord: RegistryStub,
+        reindex_env: tuple[_DevRegStub, _EntRegStub],
+    ) -> None:
+        dev_reg, ent_reg = reindex_env
+        d1 = dev_reg.add_device(identifiers={(DOMAIN, "entry-xyz:t1")})
+        ent_reg.add_entry(device_id=d1.id, disabled_by="user")
+
+        coord._reindex_poll_targets_from_device_registry()
+        assert coord._devices_with_entry == {"t1"}
+        assert coord._enabled_poll_device_ids == set()
+
+    def test_wrong_platform_entity_skipped(
+        self,
+        coord: RegistryStub,
+        reindex_env: tuple[_DevRegStub, _EntRegStub],
+    ) -> None:
+        dev_reg, ent_reg = reindex_env
+        d1 = dev_reg.add_device(identifiers={(DOMAIN, "entry-xyz:t1")})
+        ent_reg.add_entry(platform="other", device_id=d1.id)
+
+        coord._reindex_poll_targets_from_device_registry()
+        assert coord._enabled_poll_device_ids == set()
+
+    def test_wrong_domain_entity_skipped(
+        self,
+        coord: RegistryStub,
+        reindex_env: tuple[_DevRegStub, _EntRegStub],
+    ) -> None:
+        dev_reg, ent_reg = reindex_env
+        d1 = dev_reg.add_device(identifiers={(DOMAIN, "entry-xyz:t1")})
+        ent_reg.add_entry(domain="sensor", device_id=d1.id)
+
+        coord._reindex_poll_targets_from_device_registry()
+        assert coord._enabled_poll_device_ids == set()
+
+    def test_disabled_device_present_but_not_enabled(
+        self,
+        coord: RegistryStub,
+        reindex_env: tuple[_DevRegStub, _EntRegStub],
+    ) -> None:
+        dev_reg, ent_reg = reindex_env
+        d1 = dev_reg.add_device(
+            identifiers={(DOMAIN, "entry-xyz:t1")}, disabled_by="user"
+        )
+        ent_reg.add_entry(device_id=d1.id)
+
+        coord._reindex_poll_targets_from_device_registry()
+        assert coord._devices_with_entry == {"t1"}
+        assert coord._enabled_poll_device_ids == set()
+
+    def test_device_without_known_identifier_skipped(
+        self,
+        coord: RegistryStub,
+        reindex_env: tuple[_DevRegStub, _EntRegStub],
+    ) -> None:
+        dev_reg, _ent_reg = reindex_env
+        dev_reg.add_device(identifiers={("other-domain", "stranger")})
+
+        coord._reindex_poll_targets_from_device_registry()
+        assert coord._devices_with_entry == set()
+
+
+# ---------------------------------------------------------------------------
+# M17 ``find_tracker_entity_entry`` (public wrapper)
+# ---------------------------------------------------------------------------
+
+
+class TestFindTrackerEntityEntry:
+    """Wraps :meth:`_find_tracker_entity_entry`; pure delegation."""
+
+    def test_passes_device_id_and_returns_result(
+        self, coord: RegistryStub
+    ) -> None:
+        sentinel = SimpleNamespace(entity_id="device_tracker.x")
+        coord._find_tracker_entity_entry = MagicMock(return_value=sentinel)  # type: ignore[method-assign]
+
+        assert coord.find_tracker_entity_entry("dev-1") is sentinel
+        coord._find_tracker_entity_entry.assert_called_once_with("dev-1")
+
+    def test_returns_none_when_inner_returns_none(
+        self, coord: RegistryStub
+    ) -> None:
+        coord._find_tracker_entity_entry = MagicMock(return_value=None)  # type: ignore[method-assign]
+        assert coord.find_tracker_entity_entry("missing") is None

--- a/tests/test_coordinator_sound_uuid.py
+++ b/tests/test_coordinator_sound_uuid.py
@@ -2,11 +2,16 @@
 from __future__ import annotations
 
 import logging
+import time
 from types import SimpleNamespace
 
 import pytest
 
 from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
+from custom_components.googlefindmy.coordinator.helpers.cache import (
+    SOUND_UUID_MAX_AGE_S,
+    is_sound_uuid_expired,
+)
 
 
 @pytest.mark.asyncio
@@ -137,6 +142,188 @@ async def test_post_dispatch_ambiguous_play_caches_uuid() -> None:
     # The ambiguous-dispatch key is cached so a later Stop can target it.
     assert coordinator._sound_request_uuids == {"device-1": "uuid-postsend"}  # type: ignore[attr-defined]
     assert transport_problems == [True]
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_play_does_not_overwrite_known_cancel_key() -> None:
+    """An ambiguous new Play must not clobber a known-good cancel key.
+
+    Codex regression (PR #1106, follow-up): a device is already ringing from an
+    earlier accepted Play whose cancel key is cached. A *new* Play attempt hits a
+    transient 5xx that may have been generated before Nova accepted the command,
+    so api.async_play_sound returns ``(False, <new-uuid>)`` — ok is False but a
+    fresh UUID is present. Storing every non-null UUID would overwrite the
+    known-good key for the still-ringing earlier play, making the default Stop
+    target the wrong request. The storing rule (overwrite only on ok=True or an
+    empty slot) keeps the cached key intact while still flagging the transport
+    problem.
+    """
+
+    coordinator = GoogleFindMyCoordinator.__new__(GoogleFindMyCoordinator)
+    # Earlier accepted Play cached a valid cancel key for this device.
+    coordinator._sound_request_uuids = {"device-1": "uuid-ringing"}  # type: ignore[attr-defined]
+    coordinator.can_play_sound = lambda _device_id: True  # type: ignore[assignment]
+    transport_problems: list[bool] = []
+    coordinator._note_push_transport_problem = (  # type: ignore[attr-defined]
+        lambda: transport_problems.append(True)
+    )
+    coordinator._set_auth_state = lambda **kwargs: None  # type: ignore[attr-defined]
+
+    async def _async_play_sound(device_id: str) -> tuple[bool, str | None]:
+        # Ambiguous transient 5xx: not accepted (ok=False), fresh UUID present.
+        return False, "uuid-ambiguous-new"
+
+    coordinator.api = SimpleNamespace(async_play_sound=_async_play_sound)  # type: ignore[attr-defined]
+
+    result = await coordinator.async_play_sound("device-1")
+
+    assert result is False
+    # The known-good cancel key survives; the ambiguous UUID is discarded.
+    assert coordinator._sound_request_uuids == {"device-1": "uuid-ringing"}  # type: ignore[attr-defined]
+    assert transport_problems == [True]
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_play_keeps_fresh_tracked_cancel_key() -> None:
+    """A fresh, timestamp-tracked cancel key still survives an ambiguous Play.
+
+    The expiry-aware guard must only treat *aged* keys as absent. With a
+    recent timestamp present, the known-good key is younger than
+    SOUND_UUID_MAX_AGE_S, so an ambiguous ``(False, <new-uuid>)`` must not
+    clobber it (the still-ringing earlier play keeps its cancel handle).
+    """
+
+    coordinator = GoogleFindMyCoordinator.__new__(GoogleFindMyCoordinator)
+    coordinator._sound_request_uuids = {"device-1": "uuid-ringing"}  # type: ignore[attr-defined]
+    coordinator._sound_request_timestamps = {"device-1": time.time()}  # type: ignore[attr-defined]
+    coordinator.can_play_sound = lambda _device_id: True  # type: ignore[assignment]
+    coordinator._note_push_transport_problem = lambda: None  # type: ignore[attr-defined]
+    coordinator._set_auth_state = lambda **kwargs: None  # type: ignore[attr-defined]
+
+    async def _async_play_sound(device_id: str) -> tuple[bool, str | None]:
+        return False, "uuid-ambiguous-new"
+
+    coordinator.api = SimpleNamespace(async_play_sound=_async_play_sound)  # type: ignore[attr-defined]
+
+    result = await coordinator.async_play_sound("device-1")
+
+    assert result is False
+    assert coordinator._sound_request_uuids == {"device-1": "uuid-ringing"}  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_play_replaces_expired_cancel_key() -> None:
+    """An expired cancel key must not block caching a fresh ambiguous UUID.
+
+    Codex regression (PR #1106, follow-up 2): a prior Play key lingers past the
+    30-minute sound-UUID expiry, then a new Play hits a dispatch-ambiguous
+    failure returning ``(False, <new-uuid>)``. The reload filter would have
+    discarded the stale key, so the store-path guard must treat it as absent
+    and cache the new UUID — otherwise the only handle on the possibly-current
+    ring is dropped and the default Stop keeps targeting the expired request.
+    """
+
+    coordinator = GoogleFindMyCoordinator.__new__(GoogleFindMyCoordinator)
+    coordinator._sound_request_uuids = {"device-1": "uuid-expired"}  # type: ignore[attr-defined]
+    # Timestamp older than the max age: the load path would discard this key.
+    coordinator._sound_request_timestamps = {  # type: ignore[attr-defined]
+        "device-1": time.time() - (SOUND_UUID_MAX_AGE_S + 60)
+    }
+    coordinator.can_play_sound = lambda _device_id: True  # type: ignore[assignment]
+    transport_problems: list[bool] = []
+    coordinator._note_push_transport_problem = (  # type: ignore[attr-defined]
+        lambda: transport_problems.append(True)
+    )
+    coordinator._set_auth_state = lambda **kwargs: None  # type: ignore[attr-defined]
+
+    async def _async_play_sound(device_id: str) -> tuple[bool, str | None]:
+        return False, "uuid-fresh-ambiguous"
+
+    coordinator.api = SimpleNamespace(async_play_sound=_async_play_sound)  # type: ignore[attr-defined]
+
+    result = await coordinator.async_play_sound("device-1")
+
+    assert result is False
+    # The expired key is treated as absent, so the fresh handle is cached.
+    assert coordinator._sound_request_uuids == {"device-1": "uuid-fresh-ambiguous"}  # type: ignore[attr-defined]
+    assert transport_problems == [True]
+
+
+@pytest.mark.asyncio
+async def test_async_stop_sound_ignores_expired_cached_uuid() -> None:
+    """Stop must not target an expired cached UUID (sibling of the store guard).
+
+    A cached key older than SOUND_UUID_MAX_AGE_S refers to a ring that has long
+    auto-stopped; the reload filter would discard it. The default Stop path must
+    treat it as absent and stop without it rather than cancel a dead request.
+    """
+
+    coordinator = GoogleFindMyCoordinator.__new__(GoogleFindMyCoordinator)
+    coordinator._sound_request_uuids = {"device-1": "uuid-expired"}  # type: ignore[attr-defined]
+    coordinator._sound_request_timestamps = {  # type: ignore[attr-defined]
+        "device-1": time.time() - (SOUND_UUID_MAX_AGE_S + 60)
+    }
+    coordinator._note_push_transport_problem = lambda: None  # type: ignore[attr-defined]
+    coordinator._set_auth_state = lambda **kwargs: None  # type: ignore[attr-defined]
+    coordinator._api_push_ready = lambda: True  # type: ignore[attr-defined]
+
+    api_calls: list[tuple[str, str | None]] = []
+
+    async def _async_stop_sound(device_id: str, request_uuid: str | None) -> bool:
+        api_calls.append((device_id, request_uuid))
+        return True
+
+    coordinator.api = SimpleNamespace(async_stop_sound=_async_stop_sound)  # type: ignore[attr-defined]
+
+    result = await coordinator.async_stop_sound("device-1")
+
+    assert result is True
+    # The expired UUID is ignored; Stop is attempted without a request UUID.
+    assert api_calls == [("device-1", None)]
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_play_keeps_untracked_cancel_key() -> None:
+    """An untracked cancel key (no timestamp entry) is treated as fresh.
+
+    The staleness check must not crash or wrongly expire a key that lives in
+    ``_sound_request_uuids`` without a matching ``_sound_request_timestamps``
+    entry (a transient/anomalous state). Such a key cannot be proven aged, so
+    an ambiguous Play must leave it intact rather than drop the only handle.
+    """
+
+    coordinator = GoogleFindMyCoordinator.__new__(GoogleFindMyCoordinator)
+    coordinator._sound_request_uuids = {"device-1": "uuid-ringing"}  # type: ignore[attr-defined]
+    # Timestamp map exists but has no entry for this device.
+    coordinator._sound_request_timestamps = {}  # type: ignore[attr-defined]
+    coordinator.can_play_sound = lambda _device_id: True  # type: ignore[assignment]
+    coordinator._note_push_transport_problem = lambda: None  # type: ignore[attr-defined]
+    coordinator._set_auth_state = lambda **kwargs: None  # type: ignore[attr-defined]
+
+    async def _async_play_sound(device_id: str) -> tuple[bool, str | None]:
+        return False, "uuid-ambiguous-new"
+
+    coordinator.api = SimpleNamespace(async_play_sound=_async_play_sound)  # type: ignore[attr-defined]
+
+    result = await coordinator.async_play_sound("device-1")
+
+    assert result is False
+    assert coordinator._sound_request_uuids == {"device-1": "uuid-ringing"}  # type: ignore[attr-defined]
+
+
+def test_is_sound_uuid_expired_boundary() -> None:
+    """The shared expiry predicate is exclusive at the max-age boundary."""
+
+    now = 10_000.0
+    # Exactly at the boundary is not yet expired (strictly greater-than).
+    assert is_sound_uuid_expired(now - SOUND_UUID_MAX_AGE_S, now, SOUND_UUID_MAX_AGE_S) is False
+    # One second past the boundary is expired.
+    assert (
+        is_sound_uuid_expired(now - SOUND_UUID_MAX_AGE_S - 1, now, SOUND_UUID_MAX_AGE_S)
+        is True
+    )
+    # A just-stored key is fresh.
+    assert is_sound_uuid_expired(now, now, SOUND_UUID_MAX_AGE_S) is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_coordinator_sound_uuid.py
+++ b/tests/test_coordinator_sound_uuid.py
@@ -35,6 +35,111 @@ async def test_async_play_sound_stores_uuid() -> None:
 
 
 @pytest.mark.asyncio
+async def test_async_play_sound_skips_store_on_non_accepted_play() -> None:
+    """Do not cache a UUID when the command was not accepted.
+
+    Under the success-only contract api.async_play_sound returns ``(False, None)``
+    for *every* non-acceptance — a pre-dispatch guard (e.g. no FCM token), a
+    connection-setup error, or a server rejection (401/403/5xx). The play never
+    started a ring, so there is no cancel key to keep and the cache must stay
+    empty (while a push-transport problem is still flagged).
+    Regression for IRR-CA-CANCEL-KEY-ON-SUCCESS-ONLY.
+    """
+
+    coordinator = GoogleFindMyCoordinator.__new__(GoogleFindMyCoordinator)
+    coordinator._sound_request_uuids = {}  # type: ignore[attr-defined]
+    coordinator.can_play_sound = lambda _device_id: True  # type: ignore[assignment]
+    transport_problems: list[bool] = []
+    coordinator._note_push_transport_problem = (  # type: ignore[attr-defined]
+        lambda: transport_problems.append(True)
+    )
+    coordinator._set_auth_state = lambda **kwargs: None  # type: ignore[attr-defined]
+
+    async def _async_play_sound(device_id: str) -> tuple[bool, str | None]:
+        # Non-accepted play (pre-dispatch guard / rejection): no cancel key.
+        return False, None
+
+    coordinator.api = SimpleNamespace(async_play_sound=_async_play_sound)  # type: ignore[attr-defined]
+
+    result = await coordinator.async_play_sound("device-1")
+
+    assert result is False
+    assert coordinator._sound_request_uuids == {}  # type: ignore[attr-defined]
+    assert transport_problems == [True]
+
+
+@pytest.mark.asyncio
+async def test_non_accepted_play_keeps_existing_cancel_key() -> None:
+    """A non-accepted Play must not clobber an earlier, still-ringing play's key.
+
+    Codex regression (PR #1100, iter-4): a device is already ringing from an
+    earlier successful Play whose cancel key is cached. A *new* Play attempt is
+    not accepted — either it fails before reaching the wire OR the server rejects
+    it with 401/403/5xx. Under the success-only contract api.async_play_sound
+    returns ``(False, None)`` for *both* causes, so the coordinator keeps the
+    existing key intact. Overwriting it (the iter-4 bug: a rejected play used to
+    return its never-accepted UUID) would make the later Stop send a fresh,
+    non-correlating UUID and leave the device ringing.
+    """
+
+    coordinator = GoogleFindMyCoordinator.__new__(GoogleFindMyCoordinator)
+    # Earlier successful Play cached a valid cancel key for this device.
+    coordinator._sound_request_uuids = {"device-1": "uuid-ringing"}  # type: ignore[attr-defined]
+    coordinator.can_play_sound = lambda _device_id: True  # type: ignore[assignment]
+    coordinator._note_push_transport_problem = lambda: None  # type: ignore[attr-defined]
+    coordinator._set_auth_state = lambda **kwargs: None  # type: ignore[attr-defined]
+
+    async def _async_play_sound(device_id: str) -> tuple[bool, str | None]:
+        # New attempt not accepted (e.g. server 401/403, or pre-dispatch): the
+        # success-only contract yields (False, None) — no cancel key.
+        return False, None
+
+    coordinator.api = SimpleNamespace(async_play_sound=_async_play_sound)  # type: ignore[attr-defined]
+
+    result = await coordinator.async_play_sound("device-1")
+
+    assert result is False
+    # The previous, still-valid cancel key survives untouched.
+    assert coordinator._sound_request_uuids == {"device-1": "uuid-ringing"}  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_post_dispatch_ambiguous_play_caches_uuid() -> None:
+    """A dispatched-but-unconfirmed Play caches its key so Stop can still cancel.
+
+    Codex regression (PR #1100, iter-5): a network failure at/after the request
+    reached the wire (server disconnect, read timeout) may have started a ring
+    even without a 200. api.async_play_sound then returns ``(False, <uuid>)`` —
+    ``ok`` is False, but the cancel key is preserved. The coordinator caches every
+    non-null UUID, so it stores this key (letting a later Stop target the
+    possibly-active ring) while still flagging the push-transport problem.
+    """
+
+    coordinator = GoogleFindMyCoordinator.__new__(GoogleFindMyCoordinator)
+    coordinator._sound_request_uuids = {}  # type: ignore[attr-defined]
+    coordinator.can_play_sound = lambda _device_id: True  # type: ignore[assignment]
+    transport_problems: list[bool] = []
+    coordinator._note_push_transport_problem = (  # type: ignore[attr-defined]
+        lambda: transport_problems.append(True)
+    )
+    coordinator._set_auth_state = lambda **kwargs: None  # type: ignore[attr-defined]
+
+    async def _async_play_sound(device_id: str) -> tuple[bool, str | None]:
+        # Post-dispatch ambiguity: not confirmed (ok=False), but a ring may be
+        # active, so the cancel key is returned for caching.
+        return False, "uuid-postsend"
+
+    coordinator.api = SimpleNamespace(async_play_sound=_async_play_sound)  # type: ignore[attr-defined]
+
+    result = await coordinator.async_play_sound("device-1")
+
+    assert result is False
+    # The ambiguous-dispatch key is cached so a later Stop can target it.
+    assert coordinator._sound_request_uuids == {"device-1": "uuid-postsend"}  # type: ignore[attr-defined]
+    assert transport_problems == [True]
+
+
+@pytest.mark.asyncio
 async def test_async_stop_sound_uses_cached_uuid() -> None:
     """Stop sound should look up a cached UUID when none is provided."""
 

--- a/tests/test_coordinator_status.py
+++ b/tests/test_coordinator_status.py
@@ -13,6 +13,9 @@ import pytest
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import issue_registry as ir
 
+from custom_components.googlefindmy.Auth.fcm_receiver_ha import (
+    CRASH_LOOP_FATAL_PREFIX,
+)
 from custom_components.googlefindmy.binary_sensor import GoogleFindMyPollingSensor
 from custom_components.googlefindmy.const import (
     CONF_GOOGLE_EMAIL,
@@ -245,6 +248,91 @@ def test_global_fatal_error_ignored_for_clean_entry(
     assert result == []
     assert coordinator.auth_error_active is False
     assert coordinator.hass.bus.fired == []
+
+
+# --------------------------------------------------------------------------
+# AP7 / CA-6: re-auth-escalation dispatch wiring for the crash-loop fatal.
+#
+# cov-integ's ``test_coordinator_polling_fatal_channel.py`` only pins the
+# pure ``_classify_fcm_fatal`` function (RV-G3q scenarios a+b). It never
+# drives ``_async_update_data``, so a regression that re-wires the
+# CRASH_LOOP_EXCLUDED branch back into the re-auth path (the #1086
+# channel-confusion bug, RV-G3q) would not turn any cov-integ test red.
+# These two tests pin the consumer-branch wiring (RV-G3q scenarios c+d):
+#   (c) no ConfigEntryAuthFailed / no auth-error flip for a cap fatal;
+#   (d) a crash-loop fatal resets a stale transient auth-error count.
+# --------------------------------------------------------------------------
+
+
+def test_crash_loop_fatal_excluded_from_reauth_escalation(
+    coordinator: GoogleFindMyCoordinator, dummy_api: _DummyAPI
+) -> None:
+    """AP7/CA-6 (c): a supervisor short-run-cap fatal must NOT escalate to re-auth.
+
+    The FCM receiver's poison-message cap publishes its terminal state into
+    the same ``_fatal_errors`` map the re-auth escalation consumes. Polling
+    ``_async_update_data`` well past ``_FCM_ERROR_RETRY_THRESHOLD`` with a
+    ``CRASH_LOOP_FATAL_PREFIX`` fatal must never raise ConfigEntryAuthFailed
+    nor flip the auth-error state.
+    """
+    fatal_error = f"{CRASH_LOOP_FATAL_PREFIX} entry abc stopped after 10 short runs"
+
+    class _DummyFcm:
+        def __init__(self, message: str) -> None:
+            self._fatal_error = message
+            self._fatal_errors = {coordinator.config_entry.entry_id: message}
+
+    dummy_api.fcm = _DummyFcm(fatal_error)
+    dummy_api.device_list = [{"id": "dev-1", "name": "Device"}]
+    coordinator.config_entry.runtime_data = SimpleNamespace(
+        coordinator=coordinator, fcm_receiver=dummy_api.fcm
+    )
+    coordinator._is_fcm_ready_soft = lambda: False
+
+    loop = coordinator.hass.loop
+    # Five cycles is comfortably past the threshold (3); no escalation allowed.
+    for _ in range(5):
+        result = loop.run_until_complete(coordinator._async_update_data())
+        assert result == []
+
+    assert coordinator.auth_error_active is False
+    assert coordinator.hass.bus.fired == []
+    assert coordinator._fcm_error_count == 0
+
+
+def test_crash_loop_fatal_resets_stale_auth_error_count(
+    coordinator: GoogleFindMyCoordinator, dummy_api: _DummyAPI
+) -> None:
+    """AP7/CA-6 (d): a crash-loop fatal resets a stale transient auth-error count.
+
+    A partial count left over from earlier transient (non-cap) auth fatals
+    must not let a later real auth fatal inherit the crash-loop window's
+    count and escalate prematurely.
+    """
+    fatal_error = f"{CRASH_LOOP_FATAL_PREFIX} entry abc stopped after 10 short runs"
+
+    class _DummyFcm:
+        def __init__(self, message: str) -> None:
+            self._fatal_error = message
+            self._fatal_errors = {coordinator.config_entry.entry_id: message}
+
+    dummy_api.fcm = _DummyFcm(fatal_error)
+    dummy_api.device_list = [{"id": "dev-1", "name": "Device"}]
+    coordinator.config_entry.runtime_data = SimpleNamespace(
+        coordinator=coordinator, fcm_receiver=dummy_api.fcm
+    )
+    coordinator._is_fcm_ready_soft = lambda: False
+    # Simulate two prior transient (non-cap) auth-error cycles.
+    coordinator._fcm_error_count = 2
+    coordinator._fcm_last_error = "GCM Registration failed (401): transient"
+
+    loop = coordinator.hass.loop
+    result = loop.run_until_complete(coordinator._async_update_data())
+
+    assert result == []
+    assert coordinator._fcm_error_count == 0
+    assert coordinator._fcm_last_error is None
+    assert coordinator.auth_error_active is False
 
 
 def test_api_status_recovers_after_success(

--- a/tests/test_coordinator_status.py
+++ b/tests/test_coordinator_status.py
@@ -48,14 +48,18 @@ class _DummyBus:
 
 
 class _DummyConfigEntries:
-    """Stub Home Assistant config_entries manager."""
+    """Stub Home Assistant config_entries manager.
+
+    The real ``ConfigEntries`` manager exposes no ``async_start_reauth``
+    helper -- reauth is entry-scoped via ``ConfigEntry.async_start_reauth``.
+    The stub therefore deliberately omits it: a stray production call to
+    ``hass.config_entries.async_start_reauth(...)`` raises ``AttributeError``
+    here exactly as it would at runtime, instead of being silently recorded
+    by a fictional method.
+    """
 
     def __init__(self) -> None:
-        self.calls: list[object] = []
         self.setup_calls: list[str] = []
-
-    async def async_start_reauth(self, entry: object) -> None:
-        self.calls.append(entry)
 
     def async_get_subentries(self, _entry_id: str) -> list[Any]:
         return []
@@ -73,7 +77,10 @@ class _DummyEntry:
         self.data = {CONF_GOOGLE_EMAIL: "user@example.com"}
         self.reauth_calls = 0
 
-    async def async_start_reauth(self, hass) -> None:  # noqa: D401 - stub signature
+    def async_start_reauth(self, hass) -> None:  # noqa: D401 - stub signature
+        # Mirror the real ``ConfigEntry.async_start_reauth``: a synchronous
+        # ``@callback`` returning ``None`` (an async stub would mask a stray
+        # ``await`` in production code).
         self.reauth_calls += 1
 
 
@@ -185,8 +192,12 @@ def test_api_auth_error_preserves_fcm_status(
 
     assert coordinator.api_status.state == ApiStatus.REAUTH
     assert coordinator.fcm_status.state == FcmStatus.CONNECTED
+    # The coordinator must not start reauth manually; it relies on HA's
+    # automatic reauth triggered by raising ConfigEntryAuthFailed. Only the
+    # entry-level call exists in the real API, so that is what we guard. The
+    # manager has no async_start_reauth, so a stray manager call would raise
+    # AttributeError above instead of passing silently.
     assert coordinator.config_entry.reauth_calls == 0
-    assert coordinator.hass.config_entries.calls == []
     assert "Invalid" in (coordinator.api_status.reason or "")
 
 

--- a/tests/test_fcm_backoff_escalation.py
+++ b/tests/test_fcm_backoff_escalation.py
@@ -92,7 +92,7 @@ async def test_fcm_backoff_escalation_creates_and_clears_issue(
     monkeypatch.setattr(
         fcm_receiver_ha.ir,
         "IssueSeverity",
-        SimpleNamespace(WARNING="warning"),
+        SimpleNamespace(WARNING="warning", ERROR="error"),
     )
 
     await receiver._start_supervisor_for_entry(entry_id, None)
@@ -103,12 +103,19 @@ async def test_fcm_backoff_escalation_creates_and_clears_issue(
     assert create_issue.call_count == 6
     assert create_issue_attempts == [7, 8, 9, 10, 11, 12]
 
+    # The backoff path now escalates to the shared *fixable* reauth repair
+    # (same issue id / fix flow as the 404/401 give-up paths).
     for call in create_issue.call_args_list:
         assert call.args[0] is hass
         assert call.args[1] == DOMAIN
-        assert call.args[2] == f"fcm_stuck_{entry_id}"
-        assert call.kwargs["is_fixable"] is False
-        assert call.kwargs["severity"] == fcm_receiver_ha.ir.IssueSeverity.WARNING
-        assert call.kwargs["translation_key"] == "fcm_connection_stuck"
+        assert call.args[2] == f"fcm_reauth_required_{entry_id}"
+        assert call.kwargs["is_fixable"] is True
+        assert call.kwargs["severity"] == fcm_receiver_ha.ir.IssueSeverity.ERROR
+        assert call.kwargs["translation_key"] == "fcm_reauth_required"
+        assert call.kwargs["data"]["entry_id"] == entry_id
+        assert call.kwargs["data"]["reason"] == "registration_backoff"
 
-    delete_issue.assert_called_once_with(hass, DOMAIN, f"fcm_stuck_{entry_id}")
+    # Recovery deletes the fixable issue and cleans up any legacy
+    # ``fcm_stuck`` issue from before the key rename.
+    delete_issue.assert_any_call(hass, DOMAIN, f"fcm_reauth_required_{entry_id}")
+    delete_issue.assert_any_call(hass, DOMAIN, f"fcm_stuck_{entry_id}")

--- a/tests/test_fcm_receiver.py
+++ b/tests/test_fcm_receiver.py
@@ -6,9 +6,11 @@ import importlib
 from collections.abc import Callable
 from types import SimpleNamespace
 from typing import Any, cast
+from unittest.mock import AsyncMock
 
 import pytest
 
+from custom_components.googlefindmy.Auth import fcm_receiver_ha
 from custom_components.googlefindmy.Auth.fcm_receiver_ha import FcmReceiverHA
 from custom_components.googlefindmy.Auth.firebase_messaging.fcmregister import (
     FcmRegisterHTTPError,
@@ -438,3 +440,269 @@ async def test_register_keeps_transient_runtime_error_transient() -> None:
 
     assert result is False
     assert entry_id not in receiver._fatal_errors
+
+
+# --------------------------------------------------------------------------
+# PR B — stop-event lifecycle (AP5) + exception classification (AP6)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_supervisor_restart_installs_fresh_stop_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AP5 (finding 4b): a re-setup must not inherit a leftover *set* stop event.
+
+    ``request_stop`` sets the entry's event without installing a fresh one. The
+    old ``setdefault`` in ``_start_supervisor_for_entry`` then handed that set
+    event to the new supervisor, whose ``while not stop_evt.is_set()`` exited
+    immediately (wedged restart). The fix installs a fresh, unset event so the
+    supervisor body actually runs.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-wedge"
+    stale = asyncio.Event()
+    stale.set()  # leftover from a prior request_stop
+    receiver._stop_evts[entry_id] = stale
+
+    ran = asyncio.Event()
+
+    async def _ensure(eid: str, _cache: Any) -> None:
+        ran.set()
+        # Terminate the loop deterministically after one body execution.
+        receiver._stop_evts[eid].set()
+
+    monkeypatch.setattr(receiver, "_ensure_client_for_entry", _ensure)
+    monkeypatch.setattr(fcm_receiver_ha.asyncio, "sleep", AsyncMock())
+
+    real_wait_for = asyncio.wait_for
+
+    async def _instant_wait_for(fut: Any, *, timeout: Any = None) -> Any:
+        # Make the supervisor's nudge-sleep return immediately.
+        coro_name = getattr(getattr(fut, "cr_code", None), "co_name", "")
+        if coro_name == "wait":
+            if asyncio.iscoroutine(fut):
+                fut.close()
+            raise TimeoutError
+        return await real_wait_for(fut, timeout=timeout)
+
+    monkeypatch.setattr(fcm_receiver_ha.asyncio, "wait_for", _instant_wait_for)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await real_wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert ran.is_set()  # body executed -> a fresh, unset event was installed
+    assert receiver._stop_evts[entry_id] is not stale  # stale event replaced
+
+
+@pytest.mark.asyncio
+async def test_register_invalidates_tokens_on_corrupt_creds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AP6 (finding 3a): a KeyError (corrupt creds) escalates via token invalidation."""
+    receiver = FcmReceiverHA()
+    entry_id = "entry-corrupt"
+
+    class _PcKeyError:
+        async def checkin_or_register(self) -> dict[str, str]:
+            raise KeyError("gcm")
+
+    receiver.pcs[entry_id] = _PcKeyError()
+
+    invalidated: list[str] = []
+
+    async def _inv(eid: str) -> None:
+        invalidated.append(eid)
+
+    monkeypatch.setattr(receiver, "_invalidate_fcm_tokens", _inv)
+
+    result = await receiver._register_for_fcm_entry(entry_id)
+
+    assert result is False
+    assert invalidated == [entry_id]
+
+
+@pytest.mark.asyncio
+async def test_invalidate_fcm_tokens_preserves_complete_gcm_identity() -> None:
+    """A complete GCM identity survives an FCM-token invalidation.
+
+    Positive control for the corrupt-identity drop: when android_id AND
+    security_token are present, only the renewable FCM parts (fcm, keys, the
+    gcm token/app_id) are stripped, so ``reregister_keeping_identity()`` can
+    take the fast path on the next attempt.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-complete-identity"
+    receiver.creds[entry_id] = {
+        "gcm": {
+            # Both fields are int()-convertible (an int and a numeric string),
+            # exactly what reregister_keeping_identity() can consume.
+            "android_id": 1234567890123456,
+            "security_token": "9876543210987654",
+            "token": "gcm-tok",
+            "app_id": "app-1",
+        },
+        "fcm": {"registration": {"token": "fcm-tok"}},
+        "keys": {"private": "x"},
+    }
+
+    await receiver._invalidate_fcm_tokens(entry_id)
+
+    creds = receiver.creds[entry_id]
+    assert "fcm" not in creds
+    assert "keys" not in creds
+    gcm = creds["gcm"]
+    assert gcm["android_id"] == 1234567890123456
+    assert gcm["security_token"] == "9876543210987654"
+    assert "token" not in gcm  # renewable gcm token stripped
+    assert "app_id" not in gcm
+
+
+@pytest.mark.asyncio
+async def test_invalidate_fcm_tokens_drops_corrupt_gcm_identity() -> None:
+    """A partial GCM identity is dropped to break the KeyError retry loop.
+
+    Regression for the Codex follow-up on AP6: ``reregister_keeping_identity()``
+    subscripts ``credentials["gcm"]["security_token"]`` unguarded and only falls
+    back to a full register when ``gcm`` is entirely absent. A block with an
+    ``android_id`` but no ``security_token`` therefore raises ``KeyError`` on
+    every retry. The invalidation must drop the whole ``gcm`` block so
+    ``_register_for_fcm_entry`` takes the full ``checkin_or_register()``
+    handshake instead of replaying the same broken identity forever.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-corrupt-identity"
+    receiver.creds[entry_id] = {
+        "gcm": {"android_id": 1234567890123456},  # security_token missing
+        "fcm": {"registration": {"token": "fcm-tok"}},
+        "keys": {"private": "x"},
+    }
+
+    await receiver._invalidate_fcm_tokens(entry_id)
+
+    creds = receiver.creds[entry_id]
+    # Whole gcm block gone -> next _register_for_fcm_entry uses checkin_or_register.
+    assert "gcm" not in creds
+    assert "fcm" not in creds
+    assert "keys" not in creds
+    # And the predicate that drives the decision is honest about both shapes:
+    # a missing field is incomplete; both int()-convertible fields are complete.
+    assert FcmReceiverHA._gcm_identity_is_complete({"android_id": 1}) is False
+    assert (
+        FcmReceiverHA._gcm_identity_is_complete(
+            {"android_id": 1, "security_token": "2"}
+        )
+        is True
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bad_security_token",
+    ["sec-tok", ["1", "2"], {"x": 1}, True, float("inf"), float("-inf")],
+    ids=["non-numeric-str", "list", "dict", "bool", "inf", "-inf"],
+)
+async def test_invalidate_fcm_tokens_drops_malformed_gcm_identity(
+    bad_security_token: object,
+) -> None:
+    """A truthy-but-non-numeric GCM identity is dropped, not preserved.
+
+    Regression for the Codex follow-up: ``reregister_keeping_identity()`` runs
+    ``int(security_token)`` only after a truthiness gate, so a truthy value that
+    is not ``int()``-convertible passes the gate but raises on every retry —
+    ``ValueError``/``TypeError`` for a non-numeric string, list, dict or bool,
+    and ``OverflowError`` for a float infinity (JSON ``1e309`` / ``Infinity``).
+    The earlier predicate preserved such a block and the supervisor looped
+    forever (or, for infinity, ``_invalidate_fcm_tokens`` itself raised and
+    stopped the supervisor). The hardened predicate now drops the whole ``gcm``
+    block so the next attempt does a full ``checkin_or_register()``.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-malformed-identity"
+    receiver.creds[entry_id] = {
+        "gcm": {
+            "android_id": 1234567890123456,
+            "security_token": bad_security_token,
+        },
+        "fcm": {"registration": {"token": "fcm-tok"}},
+        "keys": {"private": "x"},
+    }
+
+    await receiver._invalidate_fcm_tokens(entry_id)
+
+    creds = receiver.creds[entry_id]
+    # Malformed identity cannot be re-registered -> whole block must be dropped.
+    assert "gcm" not in creds
+    assert "fcm" not in creds
+    assert "keys" not in creds
+    # The predicate is the single source of that decision.
+    assert (
+        FcmReceiverHA._gcm_identity_is_complete(
+            {"android_id": 1234567890123456, "security_token": bad_security_token}
+        )
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_register_unexpected_error_is_non_fatal_without_invalidate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AP6 (finding 3a): an unexpected error stays non-fatal and does NOT invalidate."""
+    receiver = FcmReceiverHA()
+    entry_id = "entry-weird"
+
+    class _WeirdError(Exception):
+        pass
+
+    class _PcWeird:
+        async def checkin_or_register(self) -> dict[str, str]:
+            raise _WeirdError("boom")
+
+    receiver.pcs[entry_id] = _PcWeird()
+
+    invalidated: list[str] = []
+
+    async def _inv(eid: str) -> None:
+        invalidated.append(eid)
+
+    monkeypatch.setattr(receiver, "_invalidate_fcm_tokens", _inv)
+
+    result = await receiver._register_for_fcm_entry(entry_id)
+
+    assert result is False
+    assert invalidated == []  # unexpected path must not invalidate
+
+
+@pytest.mark.asyncio
+async def test_classify_registration_exception_branches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AP6 (finding 3a): the classification helper routes each error class."""
+    receiver = FcmReceiverHA()
+    entry_id = "entry-classify"
+
+    calls: list[str] = []
+
+    async def _inv(eid: str) -> None:
+        calls.append(eid)
+
+    monkeypatch.setattr(receiver, "_invalidate_fcm_tokens", _inv)
+
+    # Transient: no invalidation.
+    await receiver._classify_registration_exception(entry_id, RuntimeError("x"))
+    await receiver._classify_registration_exception(entry_id, TimeoutError())
+    assert calls == []
+
+    # Structural corruption: invalidate each time.
+    await receiver._classify_registration_exception(entry_id, KeyError("gcm"))
+    await receiver._classify_registration_exception(entry_id, ValueError("bad"))
+    await receiver._classify_registration_exception(entry_id, TypeError("bad"))
+    assert calls == [entry_id, entry_id, entry_id]
+
+    # Unexpected: no invalidation.
+    class _WeirdError(Exception):
+        pass
+
+    await receiver._classify_registration_exception(entry_id, _WeirdError())
+    assert calls == [entry_id, entry_id, entry_id]

--- a/tests/test_fcm_receiver.py
+++ b/tests/test_fcm_receiver.py
@@ -333,6 +333,361 @@ async def test_register_clears_latched_fatal_error(
 
 
 @pytest.mark.asyncio
+async def test_register_success_skips_routing_writes_for_tombstoned_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A registration attempt that finishes after the entry was torn down must
+    not resurrect token routing for the tombstoned entry (AP4 teardown race).
+
+    The routing writes RE-CREATE the per-entry state ``_purge_entry_tokens``
+    just removed, so they must be skipped while the entry is tombstoned. The
+    fatal/repair clears only REMOVE state, so they stay teardown-safe and still
+    run, and the attempt still reports success.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-tombstoned"
+    receiver._fatal_errors[entry_id] = "BadAuthentication"
+    receiver._fatal_error = "BadAuthentication"
+    # The synchronous teardown purged this entry while this in-flight
+    # registration was still running.
+    receiver._unregistered.add(entry_id)
+
+    class _DummyPc:
+        async def checkin_or_register(self) -> dict[str, str]:
+            return {"ok": "true"}
+
+    receiver.pcs[entry_id] = _DummyPc()
+
+    token_routes: list[tuple[str, set[str]]] = []
+    monkeypatch.setattr(
+        receiver,
+        "_update_token_routing",
+        lambda token, entries: token_routes.append((token, set(entries))),
+    )
+
+    persisted_tokens: list[tuple[str, str]] = []
+
+    async def _persist(entry_arg: str, token_arg: str) -> None:
+        persisted_tokens.append((entry_arg, token_arg))
+
+    monkeypatch.setattr(receiver, "_persist_routing_token", _persist)
+    monkeypatch.setattr(receiver, "get_fcm_token", lambda _entry_id=None: "token-123")
+
+    result = await receiver._register_for_fcm_entry(entry_id)
+
+    assert result is True
+    # Routing writes are suppressed for the tombstoned entry...
+    assert token_routes == []
+    assert persisted_tokens == []
+    # ...but the teardown-safe clears still run.
+    assert entry_id not in receiver._fatal_errors
+    assert receiver._fatal_error is None
+
+
+@pytest.mark.asyncio
+async def test_register_success_skips_clears_for_superseded_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A success finishing under a SUPERSEDED generation must not clear the
+    LIVE generation's diagnostics (Codex: guard all stale success side effects).
+
+    Distinct from the pure-tombstone case: here the entry is NOT tombstoned (a
+    fast reload already cleared the tombstone and bumped the generation), so the
+    old generation's success would otherwise wipe the new incarnation's fatal
+    latch and retry counters. Both the routing writes AND the clears must be
+    skipped for the stale generation, while the attempt still reports success.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-superseded"
+    # State owned by the LIVE (new) generation after a fast reload.
+    receiver._fatal_errors[entry_id] = "BadAuthentication"
+    receiver._fatal_error = "BadAuthentication"
+    receiver._fatal_retry_counts[f"{entry_id}:auth"] = 2
+    # The new incarnation bumped the generation; this in-flight attempt still
+    # carries the old (now superseded) snapshot. No tombstone is set.
+    receiver._entry_generation[entry_id] = 5
+    stale_generation = 4
+
+    class _DummyPc:
+        async def checkin_or_register(self) -> dict[str, str]:
+            return {"ok": "true"}
+
+    receiver.pcs[entry_id] = _DummyPc()
+
+    token_routes: list[tuple[str, set[str]]] = []
+    monkeypatch.setattr(
+        receiver,
+        "_update_token_routing",
+        lambda token, entries: token_routes.append((token, set(entries))),
+    )
+
+    persisted_tokens: list[tuple[str, str]] = []
+
+    async def _persist(entry_arg: str, token_arg: str) -> None:
+        persisted_tokens.append((entry_arg, token_arg))
+
+    monkeypatch.setattr(receiver, "_persist_routing_token", _persist)
+    monkeypatch.setattr(receiver, "get_fcm_token", lambda _entry_id=None: "token-123")
+
+    result = await receiver._register_for_fcm_entry(entry_id, stale_generation)
+
+    assert result is True
+    # Routing writes stay suppressed for the superseded generation...
+    assert token_routes == []
+    assert persisted_tokens == []
+    # ...and so do the clears: the LIVE generation's diagnostics survive.
+    assert receiver._fatal_errors[entry_id] == "BadAuthentication"
+    assert receiver._fatal_error == "BadAuthentication"
+    assert receiver._fatal_retry_counts[f"{entry_id}:auth"] == 2
+
+
+@pytest.mark.asyncio
+async def test_supervisor_bails_out_for_superseded_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A supervisor whose generation is superseded mid-flight must terminate,
+    not run the caller-level success path (Codex: stale registration success).
+
+    ``_register_for_fcm_entry`` already guards its in-method writes, but its
+    boolean return cannot signal the caller that the generation was superseded.
+    Here a fast reload bumps the generation while registration is in flight, so
+    the (now stale) supervisor must NOT delete the live reauth issue, bump start
+    metrics or (re)start + monitor the old client; it stops the client and exits.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-sup-superseded"
+    # Generation captured by the supervisor at start.
+    receiver._entry_generation[entry_id] = 1
+
+    fake_pc = SimpleNamespace(
+        start=AsyncMock(),
+        stop=AsyncMock(),
+        run_state=None,
+        do_listen=False,
+    )
+
+    async def _ensure(
+        _entry_id: str, _cache: object, _generation: int | None = None
+    ) -> object:
+        return fake_pc
+
+    monkeypatch.setattr(receiver, "_ensure_client_for_entry", _ensure)
+
+    async def _register(_entry_id: str, _generation: int | None = None) -> bool:
+        # A live incarnation took over (fast reload) while this attempt ran.
+        receiver._entry_generation[_entry_id] = 2
+        return True
+
+    monkeypatch.setattr(receiver, "_register_for_fcm_entry", _register)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    task = receiver.supervisors[entry_id]
+    # The bail-out terminates the supervisor; without it the stale supervisor
+    # would enter the monitor loop and never finish (so the timeout also pins
+    # the regression).
+    await asyncio.wait_for(task, timeout=2)
+
+    # Caller-level success side effects must NOT have run for the stale gen.
+    fake_pc.start.assert_not_awaited()
+    assert receiver.start_count == 0
+    # The stale client is stopped and dropped on bail-out.
+    fake_pc.stop.assert_awaited()
+    assert entry_id not in receiver.pcs
+
+
+@pytest.mark.asyncio
+async def test_discard_own_client_spares_live_client_after_reload() -> None:
+    """``_discard_own_client`` evicts only the client it was handed.
+
+    Every supervisor cleanup path funnels its ``pcs`` removal through this
+    helper. A fast reload can install a fresh client under the same
+    ``entry_id`` while a stale supervisor reaches its cleanup; an identity-blind
+    ``pcs.pop`` would evict the LIVE client and leave the new generation without
+    an FCM client. The helper compares by identity, so the live client survives
+    and a supervisor only removes the client it owns.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-discard"
+    stale_pc = SimpleNamespace(label="stale")
+    live_pc = SimpleNamespace(label="live")
+
+    # The live incarnation already owns the slot; the stale supervisor cleans up
+    # with its own (superseded) client object -> the live client must survive.
+    receiver.pcs[entry_id] = live_pc
+    receiver._discard_own_client(entry_id, stale_pc)
+    assert receiver.pcs[entry_id] is live_pc
+
+    # When the stored client IS the caller's own client, it is removed.
+    receiver._discard_own_client(entry_id, live_pc)
+    assert entry_id not in receiver.pcs
+
+
+@pytest.mark.asyncio
+async def test_ensure_client_skips_build_for_suppressed_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_ensure_client_for_entry`` must not re-create state for a suppressed entry.
+
+    ``register_coordinator`` dispatches the supervisor asynchronously. If
+    ``unregister_coordinator`` tombstones the entry before that queued coroutine
+    runs (unload-before-dispatch), the supervisor's first iteration would
+    otherwise revive the torn-down entry's ``self.pcs``/``self.creds`` -- the
+    generation guard in ``_register_for_fcm_entry`` fires one step too late
+    (after the client is already stored). The build chokepoint gates on
+    ``_entry_writes_suppressed`` so a suppressed entry returns ``None`` and
+    writes nothing (Codex finding 5).
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-build-suppressed"
+
+    built: list[object] = []
+
+    class DummyPushClient:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            built.append(self)
+            self.run_state = None
+            self.do_listen = False
+
+    monkeypatch.setattr(fcm_receiver_ha, "FcmPushClient", DummyPushClient)
+    monkeypatch.setattr(fcm_receiver_ha, "HAVE_FCM_PUSH_CLIENT", True)
+
+    # Positive control: a live entry (no tombstone, matching generation) builds
+    # and stores a client. This proves the suppression branch -- not some
+    # unrelated early return -- is what blocks the two cases below.
+    receiver._entry_generation[entry_id] = 3
+    live = await receiver._ensure_client_for_entry(entry_id, None, 3)
+    assert isinstance(live, DummyPushClient)
+    assert receiver.pcs[entry_id] is live
+    assert len(built) == 1
+
+    # Tombstone path: a torn-down entry must not be revived. Clear the stored
+    # client/creds first so only a fresh build could repopulate the maps.
+    receiver.pcs.clear()
+    receiver.creds.clear()
+    receiver._unregistered.add(entry_id)
+    suppressed = await receiver._ensure_client_for_entry(entry_id, None, 3)
+    assert suppressed is None
+    assert entry_id not in receiver.pcs
+    assert entry_id not in receiver.creds
+    assert len(built) == 1  # no new client constructed
+
+    # Superseded-generation path: the tombstone is cleared (a new incarnation
+    # is set up) but a stale supervisor holding an old generation snapshot must
+    # still be blocked from clobbering the live generation's state.
+    receiver._unregistered.discard(entry_id)
+    receiver._entry_generation[entry_id] = 4  # live incarnation moved on
+    stale = await receiver._ensure_client_for_entry(entry_id, None, 3)
+    assert stale is None
+    assert entry_id not in receiver.pcs
+    assert len(built) == 1
+
+
+@pytest.mark.asyncio
+async def test_ensure_client_does_not_hand_live_client_to_stale_supervisor() -> None:
+    """A stale supervisor must never receive the live incarnation's client.
+
+    Fast-reload race (Codex finding 6): the new incarnation already installed a
+    fresh client under ``entry_id`` (live generation 4). A stale supervisor that
+    captured generation 3 then calls in here. If the existing-client fast path
+    ran before the suppression guard it would hand that stale supervisor the LIVE
+    client, which it later stops + discards on its own suppression branch --
+    ``_discard_own_client`` compares by identity, but the handle IS the live
+    client, so the identity guard cannot save it and the new incarnation loses
+    its client. The build chokepoint therefore gates on
+    ``_entry_writes_suppressed`` BEFORE the existing-client return: the stale
+    supervisor gets ``None`` and the live client stays untouched.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-stale-handover"
+    live_pc = SimpleNamespace(label="live")
+
+    # New incarnation owns the slot at the current (live) generation.
+    receiver.pcs[entry_id] = live_pc
+    receiver._entry_generation[entry_id] = 4
+
+    # Stale supervisor (captured generation 3) must NOT be handed the live client.
+    stale = await receiver._ensure_client_for_entry(entry_id, None, 3)
+    assert stale is None
+    assert receiver.pcs[entry_id] is live_pc  # live client untouched
+
+    # Idempotent read still works for the live, current generation: a matching
+    # caller receives the existing client as-is (no re-creation, no None).
+    current = await receiver._ensure_client_for_entry(entry_id, None, 4)
+    assert current is live_pc
+    assert receiver.pcs[entry_id] is live_pc
+
+
+@pytest.mark.asyncio
+async def test_ensure_client_drops_handover_on_teardown_during_cache_await(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A teardown during the credential-load await must not resurrect state.
+
+    Slow-cache race (Codex finding 7): ``_ensure_client_for_entry`` holds the
+    asyncio ``self._lock``, but ``unregister_coordinator`` is synchronous and
+    takes no lock, so it runs to completion while this method is suspended on
+    ``await cache.get("fcm_credentials")``. The single suppression check before
+    that await is stale on resume; committing the per-entry stores afterwards
+    would re-create exactly the ``self.pcs``/``self.creds`` state the teardown
+    purged. The post-await re-check drops the handover instead, while the
+    no-teardown path still performs every store the inline writes used to.
+    """
+    built: list[object] = []
+
+    class DummyPushClient:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            built.append(self)
+            self.run_state = None
+            self.do_listen = False
+
+    monkeypatch.setattr(fcm_receiver_ha, "FcmPushClient", DummyPushClient)
+    monkeypatch.setattr(fcm_receiver_ha, "HAVE_FCM_PUSH_CLIENT", True)
+
+    receiver = FcmReceiverHA()
+    entry_id = "entry-slow-cache-teardown"
+    creds_payload = {"fcm": {"registration": {"token": "creds-from-cache"}}}
+
+    class _TeardownDuringGetCache:
+        """A cache whose awaited ``get`` lets a sync teardown land mid-flight."""
+
+        def __init__(self, *, tombstone: bool) -> None:
+            self.entry_id = entry_id
+            self._tombstone = tombstone
+
+        async def get(self, _key: str) -> dict[str, object]:
+            if self._tombstone:
+                # The synchronous async_on_unload teardown running while this
+                # coroutine is suspended: tombstone the entry exactly as
+                # ``unregister_coordinator`` does before it purges.
+                receiver._unregistered.add(entry_id)
+            return dict(creds_payload)
+
+    # Negative case: teardown lands during the await -> handover dropped, no
+    # per-entry state resurrected, build never reached.
+    receiver._pending_creds[entry_id] = {"stale": "pending"}
+    dropped = await receiver._ensure_client_for_entry(
+        entry_id, _TeardownDuringGetCache(tombstone=True), None
+    )
+    assert dropped is None
+    assert entry_id not in receiver.pcs
+    assert entry_id not in receiver.creds
+    assert built == []  # no client constructed for a torn-down entry
+
+    # Positive control: no teardown -> client built, creds committed from the
+    # cache load, and the consumed pending-creds entry popped. This proves the
+    # deferred single commit still performs every store the inline writes did.
+    receiver._unregistered.discard(entry_id)
+    live = await receiver._ensure_client_for_entry(
+        entry_id, _TeardownDuringGetCache(tombstone=False), None
+    )
+    assert isinstance(live, DummyPushClient)
+    assert receiver.pcs[entry_id] is live
+    assert receiver.creds[entry_id] == creds_payload
+    assert entry_id not in receiver._pending_creds  # loaded_from_cache popped it
+    assert len(built) == 1
+
+
+@pytest.mark.asyncio
 async def test_credentials_update_clears_latched_fatal_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -442,6 +797,179 @@ async def test_register_keeps_transient_runtime_error_transient() -> None:
     assert entry_id not in receiver._fatal_errors
 
 
+def test_entry_writes_suppressed_generation_and_tombstone() -> None:
+    """``_entry_writes_suppressed`` combines the boolean tombstone with the
+    per-entry generation (finding 4b).
+
+    The tombstone suppresses regardless of generation; a mismatched generation
+    suppresses even without a tombstone; ``None`` falls back to tombstone-only.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-gen"
+
+    # Fresh entry: generation 0 matches, no tombstone -> writes allowed.
+    assert receiver._entry_writes_suppressed(entry_id, 0) is False
+
+    # The tombstone suppresses regardless of the supplied generation.
+    receiver._unregistered.add(entry_id)
+    assert receiver._entry_writes_suppressed(entry_id, 0) is True
+    receiver._unregistered.discard(entry_id)
+
+    # A teardown bumped the generation; a stale supervisor (captured 0) is
+    # suppressed even though the tombstone was cleared by the reload.
+    receiver._entry_generation[entry_id] = 1
+    assert receiver._entry_writes_suppressed(entry_id, 0) is True
+    # The current incarnation (captured 1) writes again.
+    assert receiver._entry_writes_suppressed(entry_id, 1) is False
+    # Callers without a captured generation get tombstone-only behaviour.
+    assert receiver._entry_writes_suppressed(entry_id, None) is False
+
+
+@pytest.mark.asyncio
+async def test_register_success_skips_routing_writes_for_superseded_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A registration attempt from a superseded supervisor must not resurrect
+    routing even after the boolean tombstone was cleared by a reload (finding 4b).
+
+    This is the gap left by the tombstone-only guard: ``request_stop`` cancels
+    the old supervisor without awaiting it, and ``register_coordinator`` clears
+    ``_unregistered`` for the new incarnation, so only the generation keeps the
+    stale supervisor's success-path writes suppressed.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-superseded"
+    # Teardown bumped the generation; the reload then cleared the tombstone.
+    receiver._entry_generation[entry_id] = 1
+    assert entry_id not in receiver._unregistered
+
+    class _DummyPc:
+        async def checkin_or_register(self) -> dict[str, str]:
+            return {"ok": "true"}
+
+    receiver.pcs[entry_id] = _DummyPc()
+
+    token_routes: list[tuple[str, set[str]]] = []
+    monkeypatch.setattr(
+        receiver,
+        "_update_token_routing",
+        lambda token, entries: token_routes.append((token, set(entries))),
+    )
+
+    persisted_tokens: list[tuple[str, str]] = []
+
+    async def _persist(entry_arg: str, token_arg: str) -> None:
+        persisted_tokens.append((entry_arg, token_arg))
+
+    monkeypatch.setattr(receiver, "_persist_routing_token", _persist)
+    monkeypatch.setattr(receiver, "get_fcm_token", lambda _entry_id=None: "token-123")
+
+    # Stale supervisor captured generation 0; current is 1 -> writes suppressed.
+    result = await receiver._register_for_fcm_entry(entry_id, 0)
+    assert result is True
+    assert token_routes == []
+    assert persisted_tokens == []
+
+    # The current incarnation (generation 1) still writes routing.
+    result_current = await receiver._register_for_fcm_entry(entry_id, 1)
+    assert result_current is True
+    assert token_routes == [("token-123", {entry_id})]
+    assert persisted_tokens == [(entry_id, "token-123")]
+
+
+def test_unregister_bumps_generation_and_suppresses_old_supervisor() -> None:
+    """A real removal bumps the entry generation so a supervisor that captured
+    the prior value stays suppressed once the tombstone is cleared (finding 4b).
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-bumped"
+    coordinator = SimpleNamespace(
+        config_entry=make_config_entry(entry_id=entry_id), cache=None
+    )
+    receiver.coordinators.append(coordinator)
+
+    # A supervisor for this entry captured generation 0 before the teardown.
+    assert receiver._entry_generation.get(entry_id, 0) == 0
+
+    receiver.unregister_coordinator(coordinator)
+
+    # Teardown tombstoned the entry and bumped the generation.
+    assert entry_id in receiver._unregistered
+    assert receiver._entry_generation[entry_id] == 1
+    # Simulate the reload clearing the tombstone; the old supervisor (gen 0)
+    # must remain suppressed purely by generation.
+    receiver._unregistered.discard(entry_id)
+    assert receiver._entry_writes_suppressed(entry_id, 0) is True
+    assert receiver._entry_writes_suppressed(entry_id, 1) is False
+
+
+def test_purge_entry_debounce_drops_entry_from_foreign_target_set() -> None:
+    """A flush keyed by another source entry that also targets the purged entry
+    must drop the purged entry from its target set while keeping the flush for
+    the remaining recipients (Codex follow-up, finding for shared targets).
+    """
+    receiver = FcmReceiverHA()
+    source = "entry-source"
+    victim = "entry-victim"
+    other = "entry-other"
+    key = (source, "device-1")
+    receiver._pending[key] = {"latitude": 1.0}
+    receiver._pending_targets[key] = {source, victim, other}
+
+    receiver._purge_entry_debounce(victim)
+
+    # Victim removed from the foreign target set; flush kept for the rest.
+    assert receiver._pending_targets[key] == {source, other}
+    assert key in receiver._pending
+
+
+@pytest.mark.asyncio
+async def test_purge_entry_debounce_cancels_orphaned_flush_when_targets_empty() -> None:
+    """When the purged entry is the sole recipient of a foreign-keyed flush, the
+    whole flush is cancelled and dropped (an empty target set would otherwise
+    fan out to no one and leak).
+    """
+    receiver = FcmReceiverHA()
+    source = "entry-source"
+    victim = "entry-victim"
+    key = (source, "device-1")
+    receiver._pending[key] = {"latitude": 1.0}
+    receiver._pending_targets[key] = {victim}
+
+    async def _never() -> None:
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(_never())
+    receiver._flush_tasks[key] = task
+
+    receiver._purge_entry_debounce(victim)
+
+    assert key not in receiver._pending_targets
+    assert key not in receiver._pending
+    assert key not in receiver._flush_tasks
+    # Let the cancellation settle, then confirm the orphaned flush was cancelled.
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert task.cancelled()
+
+
+def test_purge_entry_debounce_leaves_broadcast_targets() -> None:
+    """Broadcast fallbacks (target set is ``None``) are device-scoped, not
+    entry-scoped, so a purge must leave them untouched.
+    """
+    receiver = FcmReceiverHA()
+    source = "entry-source"
+    victim = "entry-victim"
+    key = (source, "device-1")
+    receiver._pending[key] = {"latitude": 1.0}
+    receiver._pending_targets[key] = None
+
+    receiver._purge_entry_debounce(victim)
+
+    assert key in receiver._pending_targets
+    assert receiver._pending_targets[key] is None
+
+
 # --------------------------------------------------------------------------
 # PR B — stop-event lifecycle (AP5) + exception classification (AP6)
 # --------------------------------------------------------------------------
@@ -467,7 +995,7 @@ async def test_supervisor_restart_installs_fresh_stop_event(
 
     ran = asyncio.Event()
 
-    async def _ensure(eid: str, _cache: Any) -> None:
+    async def _ensure(eid: str, _cache: Any, _generation: int | None = None) -> None:
         ran.set()
         # Terminate the loop deterministically after one body execution.
         receiver._stop_evts[eid].set()
@@ -511,7 +1039,7 @@ async def test_register_invalidates_tokens_on_corrupt_creds(
 
     invalidated: list[str] = []
 
-    async def _inv(eid: str) -> None:
+    async def _inv(eid: str, generation: int | None = None) -> None:
         invalidated.append(eid)
 
     monkeypatch.setattr(receiver, "_invalidate_fcm_tokens", _inv)
@@ -663,7 +1191,7 @@ async def test_register_unexpected_error_is_non_fatal_without_invalidate(
 
     invalidated: list[str] = []
 
-    async def _inv(eid: str) -> None:
+    async def _inv(eid: str, generation: int | None = None) -> None:
         invalidated.append(eid)
 
     monkeypatch.setattr(receiver, "_invalidate_fcm_tokens", _inv)
@@ -684,7 +1212,7 @@ async def test_classify_registration_exception_branches(
 
     calls: list[str] = []
 
-    async def _inv(eid: str) -> None:
+    async def _inv(eid: str, generation: int | None = None) -> None:
         calls.append(eid)
 
     monkeypatch.setattr(receiver, "_invalidate_fcm_tokens", _inv)
@@ -706,3 +1234,32 @@ async def test_classify_registration_exception_branches(
 
     await receiver._classify_registration_exception(entry_id, _WeirdError())
     assert calls == [entry_id, entry_id, entry_id]
+
+
+@pytest.mark.asyncio
+async def test_classify_registration_exception_forwards_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Merge guard (AP4 x AP6): the supervisor's captured generation reaches
+    ``_invalidate_fcm_tokens`` through the classification helper.
+
+    The AP6 extract-method refactor (#1108) split the corrupt-creds escalation
+    into ``_classify_registration_exception``; the AP4 generation guard (#1107)
+    must keep flowing through it, or a superseded supervisor could strip the
+    creds of the next incarnation despite the tombstone already being cleared.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-classify-gen"
+
+    seen: list[int | None] = []
+
+    async def _inv(eid: str, generation: int | None = None) -> None:
+        seen.append(generation)
+
+    monkeypatch.setattr(receiver, "_invalidate_fcm_tokens", _inv)
+
+    await receiver._classify_registration_exception(
+        entry_id, KeyError("gcm"), generation=7
+    )
+
+    assert seen == [7]

--- a/tests/test_fcm_receiver_ha_short_run_cap.py
+++ b/tests/test_fcm_receiver_ha_short_run_cap.py
@@ -24,6 +24,7 @@ from custom_components.googlefindmy.Auth.fcm_receiver_ha import (
     DOMAIN,
     FcmReceiverHA,
 )
+from tests.helpers.config_entries_stub import make_config_entry
 
 
 class _MonoClock:
@@ -163,7 +164,7 @@ def _install_supervisor_mocks(
 
     ensure_iter = iter(ensure_clients)
 
-    async def _ensure(entry_id: str, cache):  # noqa: ARG001
+    async def _ensure(entry_id: str, cache, generation=None):  # noqa: ARG001
         # Codex Iter-7 (PR #1086): modelling exhaustion as ``None`` mirrors
         # production's ``if not pc`` path, which is designed to back off and
         # retry **forever**. The non-cap tests (long-run reset,
@@ -293,7 +294,10 @@ async def test_credential_error_invalidates_tokens_and_bypasses_cap(
 
     # Every credential-error run escalated to re-registration ...
     assert invalidate_mock.await_count == _MAX_CONSECUTIVE_SHORT_RUNS + 2
-    invalidate_mock.assert_awaited_with(entry_id)
+    # AP4 (finding 4b): the supervisor passes its captured generation (0 here,
+    # no teardown occurred) so a superseded run cannot write back invalidated
+    # creds after the tombstone is cleared.
+    invalidate_mock.assert_awaited_with(entry_id, 0)
     # ... and NONE of them tripped the short-run crash cap.
     assert create_issue.call_count == 0
     assert entry_id not in receiver._fatal_errors
@@ -1178,7 +1182,7 @@ async def test_cap_fire_terminates_outer_loop_without_helper_safety_net(
     ensure_iter = iter(clients)
     ensure_call_count = 0
 
-    async def _ensure(entry_id_inner: str, cache):  # noqa: ARG001
+    async def _ensure(entry_id_inner: str, cache, generation=None):  # noqa: ARG001
         # NOTE: no StopIteration->stop_evt.set() escape hatch here. If the
         # production cap fails to terminate the supervisor, this returns the
         # 11th client and we explicitly fail the test below.
@@ -1711,3 +1715,421 @@ def test_factory_honours_monkeypatched_fcm_push_client_symbol(
         assert not isinstance(pc, fcm_receiver_ha._ObservableFcmPushClientCls)
     assert captured["args"][0] == "callback"
     assert captured["kwargs"]["http_client_session"] == "session"
+
+
+# --------------------------------------------------------------------------
+# PR A — entry-state purge symmetry (AP1/AP2/AP3/AP7) + race tombstone (AP4)
+# --------------------------------------------------------------------------
+
+
+def test_purge_entry_tokens_clears_fatal_retry_counts() -> None:
+    """AP1 (finding 2a): the teardown purge drops both fatal-retry counters."""
+    receiver = FcmReceiverHA()
+    eid = "entry-purge-counts"
+    receiver._fatal_retry_counts[f"{eid}:auth"] = 4
+    receiver._fatal_retry_counts[f"{eid}:endpoint"] = 2
+    receiver._fatal_retry_counts["other:auth"] = 1  # foreign entry untouched
+
+    receiver._purge_entry_tokens(eid)
+
+    assert f"{eid}:auth" not in receiver._fatal_retry_counts
+    assert f"{eid}:endpoint" not in receiver._fatal_retry_counts
+    assert receiver._fatal_retry_counts["other:auth"] == 1
+
+
+def test_purge_entry_tokens_clears_entry_health() -> None:
+    """AP2 (finding 2b): per-entry health snapshots are purged on teardown."""
+    receiver = FcmReceiverHA()
+    eid = "entry-purge-health"
+    receiver._entry_health[eid] = True
+    receiver._entry_last_connected_wall[eid] = 123.0
+
+    receiver._purge_entry_tokens(eid)
+
+    assert eid not in receiver._entry_health
+    assert eid not in receiver._entry_last_connected_wall
+
+
+def test_purge_entry_tokens_clears_creds() -> None:
+    """AP3 (finding 2c): in-memory creds + pending creds are purged on teardown."""
+    receiver = FcmReceiverHA()
+    eid = "entry-purge-creds"
+    receiver.creds[eid] = {"gcm": {"token": "x"}}
+    receiver._pending_creds[eid] = {"gcm": {"token": "y"}}
+
+    receiver._purge_entry_tokens(eid)
+
+    assert eid not in receiver.creds
+    assert eid not in receiver._pending_creds
+
+
+@pytest.mark.asyncio
+async def test_reregister_returns_false_after_purge() -> None:
+    """AP3 behaviour: a purged entry can no longer be revived via reregister.
+
+    Before the creds purge, ``async_reregister_fcm``'s guard
+    (``entry_id in self.creds``) stayed True after teardown and could restart a
+    zombie supervisor for a dead entry. With the creds purged the guard now
+    correctly rejects the revival.
+    """
+    receiver = FcmReceiverHA()
+    eid = "entry-zombie"
+    receiver.creds[eid] = {"gcm": {"token": "x"}}
+    # pcs is empty (teardown stopped the client); only creds kept the guard True.
+
+    receiver._purge_entry_tokens(eid)
+
+    assert await receiver.async_reregister_fcm(eid) is False
+
+
+@pytest.mark.asyncio
+async def test_reregister_returns_false_when_tombstoned_with_residual_client() -> None:
+    """Codex follow-up to AP3: a tombstoned entry whose live client still lingers.
+
+    unregister_coordinator runs synchronously and cannot await ``pc.stop()``, so the
+    client survives in ``self.pcs`` until the cancelled supervisor (or async_stop)
+    drains it. The creds purge alone left the ``entry_id in self.pcs`` half of the
+    reregister guard open, so a reregister in that window restarted a zombie
+    supervisor for an entry mid-teardown. The tombstone (``_unregistered``) is the
+    single source of truth for "torn down" and now blocks the revival.
+
+    Distinct from a tombstoned supervisor that is *already running*: that one is
+    allowed to terminate with its writes suppressed (see
+    ``test_tombstone_suppresses_cap_latch``). Only the external revival path
+    (``async_reregister_fcm``) is refused here.
+    """
+    receiver = FcmReceiverHA()
+    eid = "entry-zombie-residual"
+    # Post-unregister_coordinator state: creds purged, tombstone set, but the live
+    # client still lingers in self.pcs (sync teardown could not await pc.stop()).
+    receiver._unregistered.add(eid)
+    receiver.pcs[eid] = object()  # residual client; must not be revived
+
+    assert await receiver.async_reregister_fcm(eid) is False
+    # The residual client is left untouched for the running supervisor / async_stop
+    # to drain; the revival path must not have started reconstructing it.
+    assert eid not in receiver.supervisors
+
+
+@pytest.mark.asyncio
+async def test_purge_cancels_pending_debounce_flush_tasks() -> None:
+    """AP7 (finding 2d): pending flush tasks are cancelled and the trias dropped."""
+    receiver = FcmReceiverHA()
+    eid = "entry-debounce"
+    key = (eid, "device-1")
+    foreign = ("other-entry", "device-9")
+
+    async def _never() -> None:
+        await asyncio.sleep(60)
+
+    task = asyncio.create_task(_never())
+    foreign_task = asyncio.create_task(_never())
+    receiver._flush_tasks[key] = task
+    receiver._flush_tasks[foreign] = foreign_task
+    receiver._pending[key] = {"payload": 1}
+    receiver._pending_targets[key] = {"target"}
+    receiver._pending[foreign] = {"payload": 2}
+
+    try:
+        receiver._purge_entry_tokens(eid)
+
+        assert key not in receiver._flush_tasks
+        assert key not in receiver._pending
+        assert key not in receiver._pending_targets
+        assert task.cancelled() or task.cancelling()
+        # Foreign entry's debounce state is untouched.
+        assert foreign in receiver._flush_tasks
+        assert foreign in receiver._pending
+    finally:
+        foreign_task.cancel()
+        for t in (task, foreign_task):
+            try:
+                await t
+            except asyncio.CancelledError:
+                pass
+
+
+def test_unregister_coordinator_tombstones_and_purges() -> None:
+    """AP4 (finding 4a): unregister tombstones the entry and purges its state."""
+    receiver = FcmReceiverHA()
+    eid = "entry-unreg-tombstone"
+    coord = SimpleNamespace(
+        config_entry=make_config_entry(entry_id=eid), cache=None
+    )
+    receiver._fatal_retry_counts[f"{eid}:auth"] = 3
+    receiver._entry_health[eid] = True
+    receiver.creds[eid] = {"gcm": {}}
+
+    receiver.unregister_coordinator(coord)
+
+    assert eid in receiver._unregistered
+    assert f"{eid}:auth" not in receiver._fatal_retry_counts
+    assert eid not in receiver._entry_health
+    assert eid not in receiver.creds
+
+
+def test_register_coordinator_clears_tombstone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AP4 (finding 4a, guard B): a setup un-tombstones the entry."""
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+    eid = "entry-reload"
+    receiver._unregistered.add(eid)
+    coord = SimpleNamespace(
+        config_entry=make_config_entry(entry_id=eid), cache=None
+    )
+
+    # The supervisor dispatch is irrelevant here; neutralise it so the test
+    # does not leak an un-awaited coroutine.
+    def _consume(coro: object, *, label: str | None = None) -> None:
+        if asyncio.iscoroutine(coro):
+            coro.close()
+
+    monkeypatch.setattr(receiver, "_dispatch_to_hass_loop", _consume)
+
+    receiver.register_coordinator(coord)
+
+    assert eid not in receiver._unregistered
+    assert receiver._entry_writes_suppressed(eid) is False
+
+
+@pytest.mark.asyncio
+async def test_invalidate_fcm_tokens_skipped_when_tombstoned() -> None:
+    """AP4 (finding 4a): _invalidate_fcm_tokens does not persist for a dead entry."""
+    receiver = FcmReceiverHA()
+    eid = "entry-invalidate"
+    creds = {"gcm": {"token": "keep"}, "fcm": {"x": 1}}
+    receiver.creds[eid] = creds
+    receiver._unregistered.add(eid)
+
+    await receiver._invalidate_fcm_tokens(eid)
+
+    # Suppressed: creds dict is left exactly as-is (fcm not stripped).
+    assert receiver.creds[eid]["fcm"] == {"x": 1}
+
+
+def test_credentials_callback_suppressed_when_tombstoned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AP4 (finding 4a, Codex follow-up): a late creds callback cannot resurrect.
+
+    The old FCM client is not awaited during ``unregister_coordinator``'s
+    synchronous teardown, so it can still fire ``_on_credentials_updated_for_entry``
+    after ``_purge_entry_tokens`` cleared the entry. While tombstoned the callback
+    must not re-write ``self.creds[entry_id]``, restore routing or queue
+    persistence — otherwise the removed entry looks known to ``async_reregister_fcm``
+    again. Once the tombstone is cleared (a real reload), fresh creds are accepted.
+    """
+    receiver = FcmReceiverHA()
+    eid = "entry-creds-callback"
+
+    dispatched: list[str | None] = []
+
+    def _capture(coro: object, *, label: str | None = None) -> None:
+        if asyncio.iscoroutine(coro):
+            coro.close()
+        dispatched.append(label)
+
+    monkeypatch.setattr(receiver, "_dispatch_to_hass_loop", _capture)
+
+    # Tombstoned: the late callback is dropped wholesale.
+    receiver._unregistered.add(eid)
+    receiver._on_credentials_updated_for_entry(eid, {"fcm": {"token": "late"}})
+
+    assert eid not in receiver.creds
+    assert eid not in receiver._pending_creds
+    assert dispatched == []  # no routing/persistence dispatch happened
+
+    # Real reload clears the tombstone; the next callback is honoured again.
+    receiver._unregistered.discard(eid)
+    receiver._on_credentials_updated_for_entry(eid, {"fcm": {"token": "fresh"}})
+
+    assert receiver.creds[eid] == {"fcm": {"token": "fresh"}}
+
+
+def test_credentials_callback_gates_on_driving_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AP4 (finding 4c): a superseded supervisor's mid-handshake callback is dropped.
+
+    On a fast reload ``unregister_coordinator`` bumps the generation but does NOT
+    pop the reused client, and ``register_coordinator`` clears the tombstone for
+    the new incarnation. A cancelled-but-unwinding supervisor still inside
+    ``checkin_or_register`` fires the synchronous credentials callback; the
+    tombstone is already gone, so a tombstone-only gate would let it clobber the
+    LIVE generation's creds and fatal latch. The callback must instead gate on
+    the *driving* generation published by the supervisor for the handshake: a
+    superseded generation is suppressed, the matching live generation writes.
+    """
+    receiver = FcmReceiverHA()
+    eid = "entry-driving-gen"
+
+    dispatched: list[str | None] = []
+
+    def _capture(coro: object, *, label: str | None = None) -> None:
+        if asyncio.iscoroutine(coro):
+            coro.close()
+        dispatched.append(label)
+
+    monkeypatch.setattr(receiver, "_dispatch_to_hass_loop", _capture)
+    # Isolate the callback's own effects from the supervisor routing block.
+    monkeypatch.setattr(receiver, "get_fcm_token", lambda _eid=None: None)
+
+    # Live incarnation: tombstone cleared, generation bumped to 1, fatal latched.
+    receiver._unregistered.discard(eid)
+    receiver._entry_generation[eid] = 1
+    receiver._fatal_errors[eid] = "BadAuthentication"
+    receiver._fatal_error = "BadAuthentication"
+
+    # A superseded supervisor (captured generation 0) drives the handshake.
+    with receiver._driving_generation_scope(eid, 0):
+        receiver._on_credentials_updated_for_entry(eid, {"fcm": {"token": "stale"}})
+
+    # Dropped wholesale: no creds resurrection, no dispatch, LIVE latch survives.
+    assert eid not in receiver.creds
+    assert eid not in receiver._pending_creds
+    assert dispatched == []
+    assert receiver._fatal_errors[eid] == "BadAuthentication"
+    assert receiver._fatal_error == "BadAuthentication"
+
+    # The live supervisor (matching generation 1) is honoured: creds written,
+    # latch cleared, persistence dispatched.
+    with receiver._driving_generation_scope(eid, 1):
+        receiver._on_credentials_updated_for_entry(eid, {"fcm": {"token": "live"}})
+
+    assert receiver.creds[eid] == {"fcm": {"token": "live"}}
+    assert eid not in receiver._fatal_errors
+    assert receiver._fatal_error is None
+    assert dispatched  # save_credentials dispatch happened
+
+
+@pytest.mark.asyncio
+async def test_register_handshake_publishes_generation_for_callback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AP4 (finding 4c): the handshake publishes its generation end to end.
+
+    ``firebase_messaging`` fires the credentials callback synchronously from
+    inside ``checkin_or_register``. This pins the wiring: a superseded supervisor
+    running ``_register_for_fcm_entry`` must suppress that mid-handshake callback,
+    while a live supervisor's identical callback writes. A plain instance
+    attribute could not survive firebase's internal awaits without a concurrent
+    task clobbering it; the task-local ContextVar is what makes this hold.
+    """
+    eid = "entry-handshake-gen"
+
+    def _build_receiver() -> FcmReceiverHA:
+        receiver = FcmReceiverHA()
+        monkeypatch.setattr(receiver, "get_fcm_token", lambda _eid=None: None)
+
+        def _capture(coro: object, *, label: str | None = None) -> None:
+            if asyncio.iscoroutine(coro):
+                coro.close()
+
+        monkeypatch.setattr(receiver, "_dispatch_to_hass_loop", _capture)
+        receiver._unregistered.discard(eid)
+        return receiver
+
+    class _FakePc:
+        """Mimics firebase firing the creds callback synchronously mid-checkin."""
+
+        credentials = {"gcm": {"t": 1}, "fcm": {"t": 2}}  # not a re-register path
+
+        def __init__(self, receiver: FcmReceiverHA) -> None:
+            self._receiver = receiver
+
+        async def checkin_or_register(self) -> dict[str, dict[str, str]]:
+            # Yield like the real client so the ContextVar must survive an await.
+            await asyncio.sleep(0)
+            self._receiver._on_credentials_updated_for_entry(
+                eid, {"fcm": {"token": "from-handshake"}}
+            )
+            return {"fcm": {"token": "from-handshake"}}
+
+    # Superseded supervisor (captured generation 0; a reload bumped it to 1).
+    superseded = _build_receiver()
+    superseded._entry_generation[eid] = 1
+    superseded.pcs[eid] = _FakePc(superseded)
+    assert await superseded._register_for_fcm_entry(eid, generation=0) is True
+    assert eid not in superseded.creds  # mid-handshake callback was suppressed
+
+    # Live supervisor (captured generation matches current).
+    live = _build_receiver()
+    live._entry_generation[eid] = 0
+    live.pcs[eid] = _FakePc(live)
+    assert await live._register_for_fcm_entry(eid, generation=0) is True
+    assert live.creds[eid] == {"fcm": {"token": "from-handshake"}}
+
+
+@pytest.mark.asyncio
+async def test_tombstone_suppresses_cap_latch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AP4 (finding 4a, guard A): a post-unregister supervisor write is dropped.
+
+    The short-run cap fires while the entry is tombstoned (it was torn down
+    mid-flight). The cap latch, the fatal-error map and the Repairs issue must
+    NOT be (re-)created; the supervisor still terminates.
+    """
+    entry_id = "entry-cap-tombstoned"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+    receiver._unregistered.add(entry_id)  # tombstoned before the cap fires
+
+    clock = _MonoClock(step=0.001)
+    clients = [
+        _SupervisorPushClientStub(clock=clock)
+        for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS)
+    ]
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    create_issue, _ = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert create_issue.call_count == 0
+    assert entry_id not in receiver._short_run_cap_latched
+    assert entry_id not in receiver._fatal_errors
+    assert entry_id not in receiver._short_run_cap_messages
+
+
+@pytest.mark.asyncio
+async def test_tombstone_suppresses_fatal_retry_counts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AP4 (finding 4a, guard A): the fatal-retry counter is not re-created.
+
+    A tombstoned entry hitting the endpoint-404 fatal path must not repopulate
+    ``_fatal_retry_counts`` (which the teardown just purged).
+    """
+    from custom_components.googlefindmy.exceptions import FatalRegistrationError
+
+    entry_id = "entry-fatal-tombstoned"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+    receiver._unregistered.add(entry_id)
+
+    clock = _MonoClock(step=0.001)
+    clients = [_SupervisorPushClientStub(clock=clock) for _ in range(4)]
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    _install_ir_capture(monkeypatch)
+
+    err = FatalRegistrationError("registration failed")
+    err.is_auth_error = False  # endpoint path
+    register_mock = AsyncMock(side_effect=[err] * 4)
+    monkeypatch.setattr(receiver, "_register_for_fcm_entry", register_mock)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    try:
+        await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+    except TimeoutError:  # pragma: no cover - bounded fallback
+        receiver._stop_evts[entry_id].set()
+        await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert f"{entry_id}:endpoint" not in receiver._fatal_retry_counts
+    assert f"{entry_id}:auth" not in receiver._fatal_retry_counts

--- a/tests/test_fcm_receiver_ha_short_run_cap.py
+++ b/tests/test_fcm_receiver_ha_short_run_cap.py
@@ -1,0 +1,1637 @@
+# tests/test_fcm_receiver_ha_short_run_cap.py
+"""Defense-2 regression tests for the FCM supervisor short-run crash cap.
+
+Covers PLAN_HOTFIX_FCM_CASCADING_FAILURE AP-2 (`fcm_receiver_ha.py`):
+- 7 building-block tests (threshold trigger, break, reset, re-registration,
+  per-entry independence, orthogonality to `_fatal_retry_counts`, unload-cleanup)
+- 1 boundary test that pins `<` vs. `<=` drift on `_SHORT_RUN_THRESHOLD_S`
+- 1 cross-locale symmetry test for the `fcm_short_run_crash_loop` translation key
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.Auth import fcm_receiver_ha
+from custom_components.googlefindmy.Auth.fcm_receiver_ha import (
+    _MAX_CONSECUTIVE_SHORT_RUNS,
+    _SHORT_RUN_THRESHOLD_S,
+    DOMAIN,
+    FcmReceiverHA,
+)
+
+
+class _MonoClock:
+    """Stateful auto-increment monotonic clock for deterministic run-duration math.
+
+    Each call returns ``value`` then advances by ``step``. ``jump(seconds)``
+    skips ahead without consuming a call slot (used to simulate a long run
+    between ``entry_start`` and the run-duration check).
+    """
+
+    def __init__(self, step: float = 0.01) -> None:
+        self.value = 0.0
+        self.step = step
+
+    def __call__(self) -> float:
+        v = self.value
+        self.value += self.step
+        return v
+
+    def jump(self, seconds: float) -> None:
+        self.value += seconds
+
+
+class _SupervisorPushClientStub:
+    """Lightweight ``FcmPushClient`` substitute for supervisor-loop tests.
+
+    Mirrors only the surface the supervisor reads/writes (``start``, ``stop``,
+    ``run_state``, ``do_listen``, ``_observe_counter``).
+
+    Two clock-injection hooks model the supervisor's snapshot boundary
+    correctly:
+
+    * ``jump_on_start`` advances the clock inside ``start()`` BEFORE the
+      supervisor takes the ``entry_start`` snapshot (Z. 960). It models
+      pre-monitor elapsed time and does NOT influence ``run_duration``.
+    * ``jump_on_run_state_read`` advances the clock on the first
+      ``pc.run_state`` access INSIDE the monitor loop (Z. 964), which is
+      AFTER the ``entry_start`` snapshot. It is the only correct way to
+      inject elapsed-run time that ``run_duration = time.monotonic() -
+      entry_start`` actually observes. Use this for boundary math.
+
+    Iter-11 ``become_started``: defaults to ``True`` so the first
+    ``run_state`` read returns ``FcmPushClientRunState.STARTED`` (setting
+    the supervisor's per-run ``became_started`` latch) and the second
+    read returns ``None`` (forcing the ``state is None`` break path on
+    the next iteration with ``last_activity is None``). This mirrors the
+    poison-message scenario the cap is designed to catch: client
+    connects, decodes, dies, repeat. Set ``become_started=False`` to
+    model a pre-start failure (MCS unreachable / login failed) where the
+    client NEVER reaches ``STARTED`` and the cap MUST NOT advance the
+    counter.
+    """
+
+    def __init__(
+        self,
+        *,
+        clock: _MonoClock | None = None,
+        jump_on_start: float = 0.0,
+        jump_on_run_state_read: float = 0.0,
+        become_started: bool = True,
+        has_been_started: bool | None = None,
+        credential_error: object | None = None,
+    ) -> None:
+        self.clock = clock
+        self.jump_on_start = jump_on_start
+        self.jump_on_run_state_read = jump_on_run_state_read
+        self.become_started = become_started
+        # Finding 1: mirror the production ``credential_error`` signal the
+        # supervisor reads after the monitor loop ends to escalate corrupt
+        # FCM key material to ``_invalidate_fcm_tokens`` + re-registration.
+        self.credential_error = credential_error
+        # Iter-12 ``has_been_started``: mirrors the production subclass'
+        # ``_has_been_started`` latch which is set by the vendored
+        # library the moment ``run_state = STARTED`` is assigned,
+        # independent of polling cadence. Default mirrors
+        # ``become_started`` so existing tests behave as before; pass
+        # explicitly to model the micro-window crash scenario
+        # (``become_started=False, has_been_started=True``: client
+        # reached STARTED and crashed before the first monitor poll)
+        # or a true pre-start failure
+        # (``become_started=False, has_been_started=False``: client
+        # never reached STARTED at all).
+        if has_been_started is None:
+            has_been_started = become_started
+        self._has_been_started = has_been_started
+        self.do_listen = True
+        self.start_calls = 0
+        self.stop_calls = 0
+        self._observed_short_run_counter: int | None = None
+        self._run_state_reads = 0
+
+    @property
+    def run_state(self):  # noqa: D401 - mirror attribute access
+        self._run_state_reads += 1
+        if (
+            self._run_state_reads == 1
+            and self.clock is not None
+            and self.jump_on_run_state_read
+        ):
+            self.clock.jump(self.jump_on_run_state_read)
+        if self.become_started and self._run_state_reads == 1:
+            from custom_components.googlefindmy.Auth.firebase_messaging import (
+                FcmPushClientRunState,
+            )
+
+            return FcmPushClientRunState.STARTED
+        # Implicit ``None`` return forces the ``state is None`` break path
+        # in the supervisor monitor loop on the next iteration. With
+        # ``become_started=True`` this also gives ``last_activity is
+        # None`` break exactly one iteration AFTER ``STARTED`` was
+        # observed, which is the poison-message run shape (client
+        # connects, no message processed, restart).
+
+    async def start(self) -> None:
+        self.start_calls += 1
+        if self.clock is not None and self.jump_on_start:
+            self.clock.jump(self.jump_on_start)
+
+    async def stop(self) -> None:
+        self.stop_calls += 1
+
+    def _observe_counter(self, counter: int) -> None:
+        # Last writer wins so tests observe the most recent supervisor pass.
+        self._observed_short_run_counter = counter
+
+
+def _install_supervisor_mocks(
+    monkeypatch: pytest.MonkeyPatch,
+    receiver: FcmReceiverHA,
+    *,
+    clock: _MonoClock,
+    ensure_clients: list,
+) -> AsyncMock:
+    """Wire the common supervisor-loop mock surface and return the register mock."""
+
+    monkeypatch.setattr(fcm_receiver_ha.time, "monotonic", clock)
+
+    ensure_iter = iter(ensure_clients)
+
+    async def _ensure(entry_id: str, cache):  # noqa: ARG001
+        # Codex Iter-7 (PR #1086): modelling exhaustion as ``None`` mirrors
+        # production's ``if not pc`` path, which is designed to back off and
+        # retry **forever**. The non-cap tests (long-run reset,
+        # re-registration, entry-B independence, 30s boundary) all rely on
+        # natural supervisor completion after the configured client list is
+        # exhausted, so we MUST stop the supervisor explicitly here instead
+        # of falling into the retry-forever branch (CA-TEST-TERMINATION-001).
+        try:
+            return next(ensure_iter)
+        except StopIteration:
+            stop_evt = receiver._stop_evts.get(entry_id)
+            if stop_evt is not None:
+                stop_evt.set()
+            return None
+
+    monkeypatch.setattr(receiver, "_ensure_client_for_entry", _ensure)
+
+    register_mock = AsyncMock(return_value=True)
+    monkeypatch.setattr(receiver, "_register_for_fcm_entry", register_mock)
+
+    monkeypatch.setattr(fcm_receiver_ha.asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(
+        fcm_receiver_ha.random, "uniform", lambda *_a, **_kw: 0.0
+    )
+
+    real_wait_for = asyncio.wait_for
+
+    async def _instant_wait_for(fut, *, timeout=None):
+        if timeout is not None and timeout > 0:
+            coro_name = getattr(fut, "__name__", "") or getattr(
+                getattr(fut, "cr_code", None), "co_name", ""
+            )
+            if coro_name == "wait":
+                if asyncio.iscoroutine(fut):
+                    fut.close()
+                raise TimeoutError
+        return await real_wait_for(fut, timeout=timeout)
+
+    monkeypatch.setattr(fcm_receiver_ha.asyncio, "wait_for", _instant_wait_for)
+    return register_mock
+
+
+def _install_ir_capture(monkeypatch: pytest.MonkeyPatch) -> tuple[MagicMock, MagicMock]:
+    """Capture ``ir.async_create_issue`` and ``ir.async_delete_issue`` calls."""
+
+    create_issue = MagicMock()
+    delete_issue = MagicMock()
+    monkeypatch.setattr(fcm_receiver_ha.ir, "async_create_issue", create_issue)
+    monkeypatch.setattr(fcm_receiver_ha.ir, "async_delete_issue", delete_issue)
+    monkeypatch.setattr(
+        fcm_receiver_ha.ir,
+        "IssueSeverity",
+        SimpleNamespace(WARNING="warning", ERROR="error"),
+    )
+    return create_issue, delete_issue
+
+
+# --------------------------------------------------------------------------
+# Building blocks
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_short_run_triggers_repair_issue_after_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """10 short runs in one supervisor pass produce exactly one ERROR repair issue."""
+    entry_id = "entry-trigger"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)  # 1ms per call -> every run is short
+    clients = [_SupervisorPushClientStub(clock=clock) for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS)]
+    register_mock = _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    create_issue, _delete_issue = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert register_mock.await_count == _MAX_CONSECUTIVE_SHORT_RUNS
+    assert create_issue.call_count == 1
+    call = create_issue.call_args
+    assert call.args[1] == DOMAIN
+    assert call.args[2] == f"fcm_short_run_crash_loop_{entry_id}"
+    assert call.kwargs["is_fixable"] is False
+    assert call.kwargs["severity"] == fcm_receiver_ha.ir.IssueSeverity.ERROR
+    assert call.kwargs["translation_key"] == "fcm_short_run_crash_loop"
+    assert receiver._fatal_errors[entry_id].startswith("FCM short-run crash loop")
+
+
+@pytest.mark.asyncio
+async def test_credential_error_invalidates_tokens_and_bypasses_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A listener ``credential_error`` escalates to re-registration, not the cap.
+
+    Codex Finding 1: when the listener reports corrupt FCM key material via
+    ``pc.credential_error``, the supervisor must invalidate the bad tokens
+    (forcing re-registration with the device identity preserved) instead of
+    charging the short run to the crash cap. Even
+    ``_MAX_CONSECUTIVE_SHORT_RUNS + 2`` such runs must NOT fire the cap
+    repair issue -- corrective action is being taken, this is not a
+    poison-message loop.
+    """
+    entry_id = "entry-cred"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)  # every run is short
+    cred_err = ValueError("Credentials key material failed base64 decode")
+    clients = [
+        _SupervisorPushClientStub(clock=clock, credential_error=cred_err)
+        for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS + 2)
+    ]
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    create_issue, _delete_issue = _install_ir_capture(monkeypatch)
+
+    invalidate_mock = AsyncMock()
+    monkeypatch.setattr(receiver, "_invalidate_fcm_tokens", invalidate_mock)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # Every credential-error run escalated to re-registration ...
+    assert invalidate_mock.await_count == _MAX_CONSECUTIVE_SHORT_RUNS + 2
+    invalidate_mock.assert_awaited_with(entry_id)
+    # ... and NONE of them tripped the short-run crash cap.
+    assert create_issue.call_count == 0
+    assert entry_id not in receiver._fatal_errors
+
+
+@pytest.mark.asyncio
+async def test_short_run_break_after_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The supervisor task completes after the 10th short run (no further iters)."""
+    entry_id = "entry-break"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    # Provide more clients than the threshold to detect "loop kept going".
+    clients = [
+        _SupervisorPushClientStub(clock=clock)
+        for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS + 5)
+    ]
+    register_mock = _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert receiver.supervisors[entry_id].done()
+    assert register_mock.await_count == _MAX_CONSECUTIVE_SHORT_RUNS
+
+
+@pytest.mark.asyncio
+async def test_long_run_resets_closure_counter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """9 short + 1 long + 9 short runs must not trigger the threshold."""
+    entry_id = "entry-reset"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    # Build 19 clients: short, short, ..., LONG at index 9, short, short, ...
+    # The LONG run must use ``jump_on_run_state_read`` (not ``jump_on_start``)
+    # so the 60s elapse AFTER the supervisor captures ``entry_start`` at
+    # Z. 960; otherwise the jump is consumed by the snapshot itself and
+    # ``run_duration`` collapses to ~0, making this run count as short.
+    clients = []
+    for idx in range(19):
+        if idx == 9:
+            clients.append(
+                _SupervisorPushClientStub(
+                    clock=clock, jump_on_run_state_read=60.0
+                )
+            )
+        else:
+            clients.append(_SupervisorPushClientStub(clock=clock))
+    register_mock = _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    create_issue, _delete_issue = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # No repair issue: the long run at index 9 resets the counter, so the
+    # remaining 9 short runs never reach the threshold of 10.
+    assert create_issue.call_count == 0
+    assert entry_id not in receiver._fatal_errors
+    assert register_mock.await_count == 19
+
+
+@pytest.mark.asyncio
+async def test_re_registration_does_not_inherit_old_counter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cancelled supervisor's counter must not bleed into a fresh supervisor."""
+    entry_id = "entry-rereg"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    # First supervisor: 9 short runs then we cancel.
+    clients_first = [
+        _SupervisorPushClientStub(clock=clock)
+        for _ in range(9)
+    ]
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients_first
+    )
+    create_issue, _delete_issue = _install_ir_capture(monkeypatch)
+
+    # Run the first supervisor to natural completion (runs out of clients).
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+    # Pre-condition: 9 short runs did NOT trigger the cap.
+    assert create_issue.call_count == 0
+    assert entry_id not in receiver._fatal_errors
+
+    # Remove the spent stop_evt so a fresh supervisor can start.
+    receiver._stop_evts.pop(entry_id, None)
+    receiver.supervisors.pop(entry_id, None)
+
+    # Second supervisor: 9 more short runs. If the counter were shared, the
+    # combined 18 runs would have crossed the threshold and re-fired.
+    clients_second = [
+        _SupervisorPushClientStub(clock=clock)
+        for _ in range(9)
+    ]
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients_second
+    )
+    create_issue_b, _ = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert create_issue_b.call_count == 0
+    assert entry_id not in receiver._fatal_errors
+
+
+@pytest.mark.asyncio
+async def test_per_entry_supervisors_independent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Entry A crash-loops, entry B stays healthy: only A produces a repair issue."""
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock_a = _MonoClock(step=0.001)
+    clock_b = _MonoClock(step=0.001)
+    # Entry A: 10 short runs (will trip the cap).
+    clients_a = [_SupervisorPushClientStub(clock=clock_a) for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS)]
+    # Entry B: 5 healthy long runs (well above threshold).
+    # ``jump_on_run_state_read`` (not ``jump_on_start``) is required so the
+    # 60s elapse AFTER ``entry_start`` snapshot at Z. 960 and actually mark
+    # each run as a long run; otherwise the test passes only by accident
+    # because 5 short runs also stay below the cap of 10.
+    clients_b = [
+        _SupervisorPushClientStub(clock=clock_b, jump_on_run_state_read=60.0)
+        for _ in range(5)
+    ]
+
+    # Single shared monkeypatch fixture but per-receiver wiring.
+    # We can't run both supervisors against the same monkeypatched function,
+    # so we sequence A then B.
+    register_a = _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock_a, ensure_clients=clients_a
+    )
+    create_issue, _ = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry("entry-a", None)
+    await asyncio.wait_for(receiver.supervisors["entry-a"], timeout=5.0)
+
+    register_b = _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock_b, ensure_clients=clients_b
+    )
+    await receiver._start_supervisor_for_entry("entry-b", None)
+    await asyncio.wait_for(receiver.supervisors["entry-b"], timeout=5.0)
+
+    # Exactly one issue was raised, and it targets entry A.
+    assert create_issue.call_count == 1
+    assert create_issue.call_args.args[2] == "fcm_short_run_crash_loop_entry-a"
+    assert receiver._fatal_errors.get("entry-a", "").startswith(
+        "FCM short-run crash loop"
+    )
+    assert "entry-b" not in receiver._fatal_errors
+    assert register_a.await_count == _MAX_CONSECUTIVE_SHORT_RUNS
+    assert register_b.await_count == 5
+
+
+@pytest.mark.asyncio
+async def test_fatal_retry_counts_orthogonal_to_short_run_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`_fatal_retry_counts` and the closure-counter advance independently.
+
+    A short run pumps the closure counter; a `FatalRegistrationError` from
+    the registration path pumps `_fatal_retry_counts`. They share no state
+    and must not double-fire the short-run repair issue.
+    """
+    from custom_components.googlefindmy.exceptions import FatalRegistrationError
+
+    entry_id = "entry-orthogonal"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    clients = [_SupervisorPushClientStub(clock=clock) for _ in range(6)]
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    create_issue, _ = _install_ir_capture(monkeypatch)
+
+    # Override register: first 5 successes (short runs), 6th raises fatal endpoint.
+    side_effects: list = [True, True, True, True, True]
+    err = FatalRegistrationError("registration failed")
+    err.is_auth_error = False  # endpoint path, not auth
+    side_effects.append(err)
+    register_mock = AsyncMock(side_effect=side_effects)
+    monkeypatch.setattr(receiver, "_register_for_fcm_entry", register_mock)
+
+    # 6th iteration's FatalRegistrationError triggers endpoint path
+    # which retries up to _MAX_FATAL_ENDPOINT_RETRIES (7) before giving up.
+    # Refill register with the same error so the endpoint counter exhausts.
+    side_effects.extend([err] * 6)
+
+    # Bounded run via wait_for to avoid hanging on register-retry backoff.
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    try:
+        await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+    except TimeoutError:  # noqa: PERF203 - test bounded fallback
+        receiver._stop_evts[entry_id].set()
+        await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # The short-run counter reached 5 (< 10), so no short-run issue.
+    short_run_calls = [
+        c for c in create_issue.call_args_list
+        if c.args[2].startswith("fcm_short_run_crash_loop_")
+    ]
+    assert len(short_run_calls) == 0
+    # _fatal_retry_counts was incremented at least once by the endpoint path.
+    counter_key = f"{entry_id}:endpoint"
+    assert receiver._fatal_retry_counts.get(counter_key, 0) >= 1
+
+
+def test_unload_clears_fatal_errors_via_force() -> None:
+    """`_clear_fatal_error_for_entry(force=True)` (unload path) releases the latch.
+
+    Defense 2 iter-8: the unregister path must clear the cap latch alongside
+    the fatal-error map because the entry itself goes away. Without ``force``
+    the clear-path is a no-op while the latch is set (Codex second finding).
+    """
+    receiver = FcmReceiverHA()
+    receiver._fatal_errors["entry-unload"] = "FCM short-run crash loop: ..."
+    receiver._fatal_error = "FCM short-run crash loop: ..."
+    receiver._short_run_cap_latched.add("entry-unload")
+
+    receiver._clear_fatal_error_for_entry(
+        "entry-unload", reason="Entry unregistered", force=True
+    )
+
+    assert "entry-unload" not in receiver._fatal_errors
+    assert "entry-unload" not in receiver._short_run_cap_latched
+    assert receiver._fatal_error is None
+
+
+# --------------------------------------------------------------------------
+# Defense 2 iter-8: cap-latch lifecycle (Codex second finding)
+# --------------------------------------------------------------------------
+#
+# Codex objected that the cap state lives in the same ``_fatal_errors`` map
+# that ``_register_for_fcm_entry`` unconditionally clears after a successful
+# registration. Registration is NOT a recovery proof for a poison-message
+# crash loop: only a real healthy supervisor run (>= 30s) shows that the
+# poisoned notification is gone. The tests below pin the new lifecycle
+# contract (CA-STATE-LIFECYCLE-ASYMMETRY-001):
+#
+#   * ``_short_run_cap_latched`` is set at cap-fire time alongside the
+#     ``_fatal_errors`` entry and the Repairs issue.
+#   * ``_clear_fatal_error_for_entry`` is a no-op while the latch is set
+#     (unless ``force=True`` is passed, which only the unregister path does).
+#   * Only the healthy-run branch of the supervisor loop releases the latch,
+#     pops the cap-related ``_fatal_errors`` entry, and re-derives the
+#     aggregate ``_fatal_error``.
+
+
+def test_clear_fatal_error_is_noop_while_cap_latched() -> None:
+    """Registration-success paths cannot drop the latch (Codex iter-8 finding 2)."""
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+    receiver._fatal_errors["entry-latched"] = "FCM short-run crash loop: ..."
+    receiver._fatal_error = "FCM short-run crash loop: ..."
+    receiver._short_run_cap_latched.add("entry-latched")
+
+    # ``force`` defaults to ``False``: this is the path that
+    # ``_register_for_fcm_entry`` and the credential-update handler take.
+    receiver._clear_fatal_error_for_entry(
+        "entry-latched", reason="Registration succeeded"
+    )
+
+    # Nothing changed: the latch, the fatal-error map, and the aggregate
+    # all survive because the registration did not prove a healthy run.
+    assert "entry-latched" in receiver._short_run_cap_latched
+    assert receiver._fatal_errors["entry-latched"].startswith(
+        "FCM short-run crash loop"
+    )
+    assert receiver._fatal_error == "FCM short-run crash loop: ..."
+
+
+def test_clear_without_latch_still_clears_fatal_errors() -> None:
+    """Without an active cap latch, the clear-path behaves idempotently."""
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+    receiver._fatal_errors["entry-clean"] = "FCM auth failed ..."
+    receiver._fatal_error = "FCM auth failed ..."
+
+    receiver._clear_fatal_error_for_entry(
+        "entry-clean", reason="Registration succeeded"
+    )
+
+    assert "entry-clean" not in receiver._fatal_errors
+    assert receiver._fatal_error is None
+
+
+@pytest.mark.asyncio
+async def test_cap_fire_sets_short_run_cap_latched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cap-fire installs the latch alongside the fatal-error map and the issue."""
+    entry_id = "entry-cap-latch"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    clients = [
+        _SupervisorPushClientStub(clock=clock)
+        for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS)
+    ]
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    create_issue, _ = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert create_issue.call_count == 1
+    assert entry_id in receiver._short_run_cap_latched
+    assert receiver._fatal_errors[entry_id].startswith("FCM short-run crash loop")
+
+
+@pytest.mark.asyncio
+async def test_cap_latch_survives_registration_success_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A simulated registration-success path cannot drop the latch.
+
+    Defense 2 iter-8 (Codex second finding): without the latch, a reload or
+    credential update after cap-fire would clear the fatal-error map and the
+    Repairs issue before the supervisor proved the poison message is gone,
+    leaving the user blind during the next 10-run burst.
+    """
+    entry_id = "entry-survive"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    clients = [
+        _SupervisorPushClientStub(clock=clock)
+        for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS)
+    ]
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert entry_id in receiver._short_run_cap_latched
+    pre_message = receiver._fatal_errors[entry_id]
+
+    # Simulate ``_register_for_fcm_entry`` success path (Z. 1260) and the
+    # credential-update path (Z. 2069). Neither must release the latch.
+    receiver._clear_fatal_error_for_entry(
+        entry_id, reason="Registration succeeded"
+    )
+    receiver._clear_fatal_error_for_entry(
+        entry_id, reason="Credentials updated for entry"
+    )
+
+    assert entry_id in receiver._short_run_cap_latched
+    assert receiver._fatal_errors[entry_id] == pre_message
+
+
+# --------------------------------------------------------------------------
+# Defense 2 iter-10: cap-latch guard granularity (Codex follow-up finding)
+# --------------------------------------------------------------------------
+#
+# Codex objected that the iter-8 latch guard was unconditional and blocked
+# every later ``_clear_fatal_error_for_entry`` call while the latch was set.
+# Scenario: the cap fires, then the user reloads or re-registers; the new
+# registration hits a terminal 401/404 and overwrites ``_fatal_errors[entry_id]``
+# with a non-cap message; a credentials recovery later tries to clear that
+# fatal but is blocked by the latch guard, so the coordinator keeps seeing
+# the stale auth-fatal even after the underlying problem is fixed.
+#
+# CA-GUARD-GRANULARITY-001: the latch guard is now SELECTIVE:
+#
+#   * Latch active AND stored fatal IS the cap message
+#     -> full no-op (cap state + Repairs UI artefact preserved).
+#   * Latch active AND stored fatal is a NON-cap message
+#     -> clear the non-cap fatal, but keep the latch and the Repairs UI
+#        artefact (cap warning stays visible until a healthy run releases it).
+#   * Latch active AND no fatal stored
+#     -> full no-op (treat as cap-only state).
+#   * Latch not active OR force=True
+#     -> normal clear-all path (unchanged).
+
+
+def test_clear_clears_non_cap_fatal_while_cap_latched() -> None:
+    """Non-cap fatals must clear normally even while the cap latch is active.
+
+    Defense 2 iter-10 (Codex follow-up): the iter-8 guard was too broad and
+    blocked every clear-call, so a terminal 401/404 written into
+    ``_fatal_errors`` by a re-registration attempt after cap-fire could never
+    be dropped by a subsequent credentials recovery. The guard now blocks
+    only when the stored fatal IS the cap message; non-cap fatals are
+    dropped while latch and Repairs UI artefact stay in place.
+    """
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    # Cap is latched (set by an earlier cap-fire); a subsequent
+    # re-registration then overwrote the fatal map with a non-cap auth error.
+    receiver._short_run_cap_latched.add("entry-mixed")
+    receiver._fatal_errors["entry-mixed"] = (
+        "FCM registration failed: HTTP 401 Unauthorized"
+    )
+    receiver._fatal_error = "FCM registration failed: HTTP 401 Unauthorized"
+
+    # Credentials recovery path: ``_register_for_fcm_entry`` calls this after
+    # a new successful registration. The non-cap fatal MUST clear so the
+    # coordinator does not see a stale auth-fatal.
+    receiver._clear_fatal_error_for_entry(
+        "entry-mixed", reason="Credentials updated for entry"
+    )
+
+    # Non-cap fatal cleared.
+    assert "entry-mixed" not in receiver._fatal_errors
+    assert receiver._fatal_error is None
+    # Cap latch SURVIVES: only a real healthy supervisor run may drop it.
+    assert "entry-mixed" in receiver._short_run_cap_latched
+
+
+def test_clear_preserves_repair_issue_when_clearing_non_cap_fatal() -> None:
+    """Clearing a non-cap fatal while latched must not delete the Repairs issue.
+
+    The Repairs UI artefact (``fcm_short_run_crash_loop_<entry_id>``) is the
+    user-visible cap warning. Dropping it during an unrelated credentials
+    recovery would invalidate the cap warning before the listener proves the
+    poison message is gone (the very failure mode iter-8 pinned).
+    """
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    deleted_issues: list[tuple[str, str]] = []
+
+    def fake_async_delete_issue(hass, domain: str, issue_id: str) -> None:
+        deleted_issues.append((domain, issue_id))
+
+    monkey = pytest.MonkeyPatch()
+    try:
+        monkey.setattr(
+            fcm_receiver_ha.ir, "async_delete_issue", fake_async_delete_issue
+        )
+
+        receiver._short_run_cap_latched.add("entry-keep-issue")
+        receiver._fatal_errors["entry-keep-issue"] = (
+            "FCM registration failed: HTTP 404 Not Found"
+        )
+        receiver._fatal_error = "FCM registration failed: HTTP 404 Not Found"
+
+        receiver._clear_fatal_error_for_entry(
+            "entry-keep-issue", reason="Credentials updated for entry"
+        )
+    finally:
+        monkey.undo()
+
+    # Non-cap fatal cleared but the Repairs UI artefact must remain (no
+    # ``async_delete_issue`` call for the cap issue id).
+    assert "entry-keep-issue" not in receiver._fatal_errors
+    assert deleted_issues == []
+    assert "entry-keep-issue" in receiver._short_run_cap_latched
+
+
+def test_clear_no_stored_fatal_while_latched_is_full_noop() -> None:
+    """Latch active and no fatal stored: full no-op, latch survives."""
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    receiver._short_run_cap_latched.add("entry-no-fatal")
+    # No entry in ``_fatal_errors``.
+
+    receiver._clear_fatal_error_for_entry(
+        "entry-no-fatal", reason="Registration succeeded"
+    )
+
+    assert "entry-no-fatal" in receiver._short_run_cap_latched
+    assert "entry-no-fatal" not in receiver._fatal_errors
+
+
+# --------------------------------------------------------------------------
+# Iter-16 regression: latch-restoration on pass-through clear
+# (Codex 8cfd5b25 follow-up)
+# --------------------------------------------------------------------------
+#
+# Pinning contract for ``_short_run_cap_messages``:
+#   * Populated by the real cap-fire branch in ``_supervisor`` (snapshot of
+#     the user-visible cap message).
+#   * Restored into ``_fatal_errors[entry_id]`` by the pass-through clear
+#     branch in ``_clear_fatal_error_for_entry`` so the per-entry fatal
+#     stays visible to the coordinator/diag binary sensor across non-cap
+#     overwrites.
+#   * Dropped in lockstep with the latch in the two release paths:
+#       (a) ``force=True`` teardown
+#       (b) healthy-run cleanup branch in ``_supervisor``
+#
+# These are unit-tests of the helper contract (no supervisor loop).
+
+
+def test_iter16_pass_through_restores_cap_message_from_snapshot() -> None:
+    """Pass-through clear must restore the cap-fire snapshot.
+
+    Iter-16 (Codex follow-up on commit 8cfd5b25): without restoration the
+    coordinator and the diagnostic binary sensor lose visibility of the
+    cap-fatal state during the recovery/retry window even though
+    ``_short_run_cap_latched`` is still set.
+    """
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    cap_message = (
+        "FCM short-run crash loop: 10 consecutive runs ended within 30s "
+        "(persistent poison message suspected)"
+    )
+
+    # Simulate the state right after a cap fire + a later non-cap fatal
+    # overwriting the per-entry fatal map slot.
+    receiver._short_run_cap_latched.add("entry-restore")
+    receiver._short_run_cap_messages["entry-restore"] = cap_message
+    receiver._fatal_errors["entry-restore"] = (
+        "FCM registration failed: HTTP 401 Unauthorized"
+    )
+    receiver._fatal_error = "FCM registration failed: HTTP 401 Unauthorized"
+
+    receiver._clear_fatal_error_for_entry(
+        "entry-restore", reason="Credentials updated for entry"
+    )
+
+    # The non-cap fatal is gone, the cap snapshot is restored, the latch
+    # and the snapshot cache survive (only a healthy run or force=True may
+    # drop them).
+    assert receiver._fatal_errors["entry-restore"] == cap_message
+    assert receiver._fatal_error == cap_message
+    assert "entry-restore" in receiver._short_run_cap_latched
+    assert receiver._short_run_cap_messages["entry-restore"] == cap_message
+
+
+def test_iter16_force_true_clear_drops_cap_message_snapshot() -> None:
+    """A force=True teardown must also drop the cap-fire snapshot."""
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    receiver._short_run_cap_latched.add("entry-force")
+    receiver._short_run_cap_messages["entry-force"] = (
+        "FCM short-run crash loop: ..."
+    )
+    receiver._fatal_errors["entry-force"] = (
+        "FCM short-run crash loop: ..."
+    )
+    receiver._fatal_error = "FCM short-run crash loop: ..."
+
+    receiver._clear_fatal_error_for_entry(
+        "entry-force", reason="Unload", force=True
+    )
+
+    assert "entry-force" not in receiver._short_run_cap_latched
+    assert "entry-force" not in receiver._short_run_cap_messages
+    assert "entry-force" not in receiver._fatal_errors
+    assert receiver._fatal_error is None
+
+
+def test_iter16_pass_through_with_empty_snapshot_falls_back_to_iter10() -> None:
+    """When no snapshot was captured the iter-10 behaviour must survive.
+
+    Edge case: a stale latch is set manually (test harness) or the snapshot
+    was already dropped while the latch remained. The pass-through clear
+    must NOT fabricate a cap message - it simply clears the non-cap fatal
+    and lets the latch keep blocking future cap-fatal clears.
+    """
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    receiver._short_run_cap_latched.add("entry-empty-snapshot")
+    # NO entry in ``_short_run_cap_messages`` for this entry_id.
+    receiver._fatal_errors["entry-empty-snapshot"] = (
+        "FCM registration failed: HTTP 401 Unauthorized"
+    )
+    receiver._fatal_error = "FCM registration failed: HTTP 401 Unauthorized"
+
+    receiver._clear_fatal_error_for_entry(
+        "entry-empty-snapshot", reason="Credentials updated for entry"
+    )
+
+    # Iter-10 contract: non-cap fatal cleared, latch survives, no
+    # restoration because nothing was snapshotted.
+    assert "entry-empty-snapshot" not in receiver._fatal_errors
+    assert receiver._fatal_error is None
+    assert "entry-empty-snapshot" in receiver._short_run_cap_latched
+    assert "entry-empty-snapshot" not in receiver._short_run_cap_messages
+
+
+@pytest.mark.asyncio
+async def test_healthy_run_releases_cap_latch_and_fatal_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A healthy run (>= 30s) clears the latch, the fatal map entry, and the issue."""
+    entry_id = "entry-recover"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    # 10 short runs trip the cap; one healthy run afterwards must release it.
+    # The healthy run is modelled as a long supervisor pass (jump after the
+    # ``entry_start`` snapshot via ``jump_on_run_state_read``).
+    short_clients = [
+        _SupervisorPushClientStub(clock=clock)
+        for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS)
+    ]
+    healthy_client = _SupervisorPushClientStub(
+        clock=clock, jump_on_run_state_read=60.0
+    )
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock,
+        ensure_clients=[*short_clients, healthy_client],
+    )
+    create_issue, delete_issue = _install_ir_capture(monkeypatch)
+
+    # Phase 1: 10 short runs trip the cap and stop the supervisor.
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert create_issue.call_count == 1
+    assert entry_id in receiver._short_run_cap_latched
+    assert receiver._fatal_errors[entry_id].startswith("FCM short-run crash loop")
+
+    # Phase 2: simulate a reload (fresh stop_evt + fresh supervisor task).
+    receiver._stop_evts.pop(entry_id, None)
+    receiver.supervisors.pop(entry_id, None)
+
+    # The healthy run drops the latch from inside the supervisor loop's
+    # else branch (counter reset path).
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert entry_id not in receiver._short_run_cap_latched
+    assert entry_id not in receiver._fatal_errors
+    assert receiver._fatal_error is None
+    # Iter-16: the healthy-run cleanup branch must also retire the
+    # cap-fire snapshot so a later non-cap fatal cannot accidentally
+    # restore a stale cap message.
+    assert entry_id not in receiver._short_run_cap_messages
+    # The Repairs issue is deleted at least once on the healthy path.
+    delete_calls_for_entry = [
+        call
+        for call in delete_issue.call_args_list
+        if call.args[2] == f"fcm_short_run_crash_loop_{entry_id}"
+    ]
+    assert delete_calls_for_entry, (
+        "expected a delete_issue call for the short-run crash loop key"
+    )
+
+
+# --------------------------------------------------------------------------
+# Boundary test (Iteration-2-L3)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_long_run_boundary_exactly_30s_does_not_count_as_short(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`<` vs. `<=` drift sentry: run_duration == 30.0 must NOT count as short."""
+    assert _SHORT_RUN_THRESHOLD_S == 30.0  # pin the constant against silent drift
+
+    entry_id = "entry-boundary"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    # Frozen clock (``step=0.0``): every ``time.monotonic()`` call returns
+    # the same value unless ``.jump(seconds)`` is invoked. This is the only
+    # way to drive ``run_duration`` to *exactly* 30.0 — any auto-increment
+    # would push the read at Z. 1008 past the boundary by a few ``step``s
+    # and let an off-by-one bug (`<=` instead of `<`) hide inside the noise.
+    clock = _MonoClock(step=0.0)
+
+    # Critical ordering (Codex Iter-5 finding):
+    # ``jump_on_start`` would fire BEFORE the supervisor records
+    # ``entry_start = time.monotonic()`` (Z. 960), so the jump is baked
+    # into the snapshot and ``run_duration`` ends up ~0s. Instead, hook
+    # the jump on the first ``pc.run_state`` read (Z. 964), which is the
+    # first clock-observable event INSIDE the monitor loop, AFTER the
+    # snapshot. Then ``time.monotonic() - entry_start == 30.0`` exactly.
+    stub = _SupervisorPushClientStub(clock=clock, jump_on_run_state_read=30.0)
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=[stub]
+    )
+    create_issue, _ = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # The else-branch was hit (counter reset to 0), not the short-run branch.
+    # If `<` ever drifts to `<=`, ``run_duration == 30.0`` falls into the
+    # short-run path and ``_observed_short_run_counter`` becomes 1.
+    assert stub._observed_short_run_counter == 0, (
+        f"Boundary 30.0s was counted as short — `<` drifted to `<=`? "
+        f"Counter={stub._observed_short_run_counter}"
+    )
+    assert create_issue.call_count == 0
+    assert entry_id not in receiver._fatal_errors
+
+
+# --------------------------------------------------------------------------
+# Cross-locale symmetry (Iteration-2-L2)
+# --------------------------------------------------------------------------
+
+
+def test_translation_key_present_in_all_locales(integration_root: Path) -> None:
+    """`fcm_short_run_crash_loop` exists in every locale file under `issues`."""
+    key = "fcm_short_run_crash_loop"
+    files = {
+        "strings.json": integration_root / "strings.json",
+        "de.json": integration_root / "translations" / "de.json",
+        "en.json": integration_root / "translations" / "en.json",
+        "es.json": integration_root / "translations" / "es.json",
+        "fr.json": integration_root / "translations" / "fr.json",
+        "he.json": integration_root / "translations" / "he.json",
+        "it.json": integration_root / "translations" / "it.json",
+        "nl.json": integration_root / "translations" / "nl.json",
+        "pl.json": integration_root / "translations" / "pl.json",
+        "pt-BR.json": integration_root / "translations" / "pt-BR.json",
+        "pt.json": integration_root / "translations" / "pt.json",
+    }
+
+    titles: dict[str, str] = {}
+    descriptions: dict[str, str] = {}
+    for label, path in files.items():
+        assert path.exists(), f"locale file missing: {path}"
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert "issues" in data, f"{label}: no issues section"
+        assert key in data["issues"], f"{label}: missing key {key!r}"
+        entry = data["issues"][key]
+        assert isinstance(entry, dict), f"{label}: {key!r} must be a dict"
+        assert entry.get("title", "").strip(), f"{label}: empty title for {key!r}"
+        assert (
+            entry.get("description", "").strip()
+        ), f"{label}: empty description for {key!r}"
+        assert len(entry["description"]) >= 50, (
+            f"{label}: description too short ({len(entry['description'])} chars) "
+            f"for a repair-issue body"
+        )
+        titles[label] = entry["title"]
+        descriptions[label] = entry["description"]
+
+    # No copy-paste drift between German and English description.
+    assert descriptions["de.json"] != descriptions["en.json"], (
+        "Copy-paste drift: de.json description matches en.json — translation missing"
+    )
+    # Strings.json (master) matches en.json (English locale)
+    assert descriptions["strings.json"] == descriptions["en.json"], (
+        "strings.json description must mirror en.json"
+    )
+
+
+# --------------------------------------------------------------------------
+# Defense 2 iter-9 (Codex PR #1086 follow-up):
+# Cap-fire must TERMINATE the supervisor; the inner-loop ``break`` alone
+# falls through to the per-iteration restart block and keeps spawning fresh
+# FCM clients (retry pressure + log spam continue indefinitely despite the
+# cap latch). See CA-DEFENSE-TERMINATION-001.
+#
+# These tests deliberately do NOT rely on the helper's
+# StopIteration->stop_evt.set() emergency brake (CA-TEST-TERMINATION-001):
+# they install their own ``_ensure_client_for_entry`` mock that fails the
+# test the moment the supervisor calls it AFTER the cap should have fired.
+# That isolates the production-side termination contract from the test-helper
+# safety net.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cap_fire_terminates_outer_loop_without_helper_safety_net(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cap-fire must stop the supervisor in production, not via the test helper.
+
+    Codex iter-9 (PR #1086): ``break`` after the cap fires only exits the
+    inner monitor loop; the outer ``while not stop_evt.is_set()`` keeps
+    spinning and ``_ensure_client_for_entry`` is called for an 11th client.
+    The production fix sets ``stop_evt`` and pops ``_stop_evts[entry_id]``
+    inside the cap-fire branch, so the outer loop exits before any further
+    ensure call.
+    """
+    entry_id = "entry-cap-terminates"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    clients = [
+        _SupervisorPushClientStub(clock=clock)
+        for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS + 5)
+    ]
+    ensure_iter = iter(clients)
+    ensure_call_count = 0
+
+    async def _ensure(entry_id_inner: str, cache):  # noqa: ARG001
+        # NOTE: no StopIteration->stop_evt.set() escape hatch here. If the
+        # production cap fails to terminate the supervisor, this returns the
+        # 11th client and we explicitly fail the test below.
+        nonlocal ensure_call_count
+        ensure_call_count += 1
+        return next(ensure_iter)
+
+    monkeypatch.setattr(fcm_receiver_ha.time, "monotonic", clock)
+    monkeypatch.setattr(receiver, "_ensure_client_for_entry", _ensure)
+    register_mock = AsyncMock(return_value=True)
+    monkeypatch.setattr(receiver, "_register_for_fcm_entry", register_mock)
+    monkeypatch.setattr(fcm_receiver_ha.asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(
+        fcm_receiver_ha.random, "uniform", lambda *_a, **_kw: 0.0
+    )
+
+    real_wait_for = asyncio.wait_for
+
+    async def _instant_wait_for(fut, *, timeout=None):
+        if timeout is not None and timeout > 0:
+            coro_name = getattr(fut, "__name__", "") or getattr(
+                getattr(fut, "cr_code", None), "co_name", ""
+            )
+            if coro_name == "wait":
+                if asyncio.iscoroutine(fut):
+                    fut.close()
+                raise TimeoutError
+        return await real_wait_for(fut, timeout=timeout)
+
+    monkeypatch.setattr(fcm_receiver_ha.asyncio, "wait_for", _instant_wait_for)
+    _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # Production-side termination contract: exactly _MAX ensure calls.
+    # An 11th call would mean the outer loop kept running after cap-fire.
+    assert ensure_call_count == _MAX_CONSECUTIVE_SHORT_RUNS, (
+        f"Supervisor kept spinning after cap-fire: ensure was called "
+        f"{ensure_call_count} times (expected {_MAX_CONSECUTIVE_SHORT_RUNS}). "
+        f"Defense 2 cap is a paper tiger."
+    )
+    assert receiver.supervisors[entry_id].done()
+    assert entry_id in receiver._short_run_cap_latched
+
+
+@pytest.mark.asyncio
+async def test_cap_fire_pops_stop_evt_for_legitimate_restart(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After cap-fire, ``_stop_evts[entry_id]`` is gone so a reload restarts cleanly.
+
+    The cap-fire branch calls ``stop_evt.set()`` AND
+    ``self._stop_evts.pop(entry_id, None)``. Without the pop, the next
+    legitimate restart via ``_start_supervisor_for_entry`` would reuse the
+    already-set event through ``setdefault`` and the new supervisor would
+    terminate immediately.
+    """
+    entry_id = "entry-cap-pop"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    clients = [
+        _SupervisorPushClientStub(clock=clock)
+        for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS)
+    ]
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # After cap-fire the stop event has been consumed AND removed so that a
+    # legitimate ``_register_for_fcm_entry`` or reload constructs a fresh one.
+    assert entry_id not in receiver._stop_evts, (
+        "Stale stop event lingers in _stop_evts after cap-fire; a "
+        "legitimate restart would short-circuit because setdefault would "
+        "reuse the already-set event."
+    )
+
+
+# --------------------------------------------------------------------------
+# Iter-11: Defense-Specificity (pre-start failures excluded from cap)
+# --------------------------------------------------------------------------
+# Pins the ``became_started`` per-run latch contract:
+# - Pre-start failures (MCS unreachable / login failed, client never
+#   reaches STARTED) MUST NOT advance the short-run counter and MUST
+#   NOT clear an existing cap latch.
+# - Real poison-message short-runs (became_started=True + run<30s) MUST
+#   still advance the counter as before. The cap stays specific to the
+#   scenario it was designed for.
+# - A mixed cascade (poison-message runs interleaved with transient
+#   outages) still accumulates correctly: the outages are no-ops, the
+#   poison-message runs add up to the cap at iteration N+M_short.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pre_start_failure_does_not_advance_cap_counter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """15 pre-start failures (no STARTED reached) must NOT fire the cap.
+
+    Models the Codex iter-11 scenario: an ordinary network/Google outage
+    where ``_listen()`` exhausts its 5 connection retries (~15-20s) and
+    the client never reaches ``STARTED``. Before the gate, 10 such
+    bursts would have permanently capped the supervisor and disabled
+    FCM push until reload.
+    """
+    entry_id = "entry-pre-start"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    # 15 stubs that NEVER set become_started -> run_state stays None on
+    # every read -> ``became_started`` stays False in the supervisor.
+    clients = [
+        _SupervisorPushClientStub(clock=clock, become_started=False)
+        for _ in range(15)
+    ]
+    register_mock = _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    create_issue, _delete_issue = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # The supervisor only terminates when the helper exhausts the client
+    # list (StopIteration -> stop_evt.set()). We MUST see all 15 registration
+    # attempts -- none was prematurely cut off by a cap fire.
+    assert register_mock.await_count == 15, (
+        f"Pre-start failures advanced the cap counter and terminated "
+        f"early -- expected 15 attempts, got {register_mock.await_count}"
+    )
+    assert create_issue.call_count == 0, (
+        "Cap repair issue was created from pre-start failures; the "
+        "``became_started`` gate is broken."
+    )
+    assert entry_id not in receiver._fatal_errors
+    assert entry_id not in receiver._short_run_cap_latched
+
+
+@pytest.mark.asyncio
+async def test_mixed_burst_only_counts_real_short_runs_toward_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """5 real short-runs + 3 pre-start failures + 5 real short-runs -> cap fires at 10 real.
+
+    Pins the "counter unchanged across pre-start failures" semantics: a
+    poison-message cascade interleaved with outages must still
+    accumulate correctly. The outages are no-ops, the real short-runs
+    accumulate 5+5=10 and the cap fires on the 10th REAL short-run.
+    """
+    entry_id = "entry-mixed"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    clients: list[_SupervisorPushClientStub] = []
+    # 5 real poison-message-style short-runs (became_started=True, run<30s)
+    for _ in range(5):
+        clients.append(_SupervisorPushClientStub(clock=clock))
+    # 3 transient outages (become_started=False) -- must be ignored by the cap
+    for _ in range(3):
+        clients.append(
+            _SupervisorPushClientStub(clock=clock, become_started=False)
+        )
+    # 5 more real short-runs -- together with the first 5 these are the 10
+    # consecutive REAL short-runs that fire the cap.
+    for _ in range(5):
+        clients.append(_SupervisorPushClientStub(clock=clock))
+    # Extra clients beyond the cap-fire would expose "loop kept going".
+    for _ in range(3):
+        clients.append(_SupervisorPushClientStub(clock=clock))
+
+    register_mock = _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    create_issue, _delete_issue = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # Cap fires after the 13th client (5 real + 3 outage + 5th real = 13).
+    # Anything beyond 13 indicates the cap miscounted or did not terminate.
+    assert register_mock.await_count == 13, (
+        f"Mixed burst miscounted -- expected 13 client attempts "
+        f"(5 real + 3 outage + 5 real, cap on the 13th), got "
+        f"{register_mock.await_count}"
+    )
+    assert create_issue.call_count == 1
+    assert entry_id in receiver._short_run_cap_latched
+    assert receiver._fatal_errors[entry_id].startswith("FCM short-run crash loop")
+
+
+@pytest.mark.asyncio
+async def test_long_pre_start_does_not_release_cap_latch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Long-running pre-start failure (run>=30s) does NOT clear the cap latch.
+
+    Models a slow-to-fail connection attempt that hangs in pre-start for
+    more than 30s. Before the gate, the supervisor would have hit the
+    ``else`` branch (long run) and released the cap latch + Repairs UI
+    issue without ever proving the listener can stay up. The
+    ``became_started`` gate makes this a no-op so the latch remains.
+    """
+    entry_id = "entry-long-prestart"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    # Pre-seed the latch as if a prior cap-fire was still active. This
+    # mirrors the production state right after iter-9 termination but
+    # before any healthy run has cleared it.
+    receiver._short_run_cap_latched.add(entry_id)
+    receiver._fatal_errors[entry_id] = (
+        "FCM short-run crash loop: 10 consecutive runs ended within 30s "
+        "(persistent poison message suspected)"
+    )
+
+    clock = _MonoClock(step=0.0)
+    # become_started=False AND a 60s jump after the snapshot. Without the
+    # gate, the supervisor would see run_duration >= 30s and hit the
+    # ``else`` branch, releasing the latch.
+    stub = _SupervisorPushClientStub(
+        clock=clock, jump_on_run_state_read=60.0, become_started=False
+    )
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=[stub]
+    )
+    _create_issue, delete_issue = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # Latch survives the long pre-start (no healthy proof was observed).
+    assert entry_id in receiver._short_run_cap_latched, (
+        "Long pre-start failure cleared the cap latch without ever "
+        "proving a healthy run -- gate is broken."
+    )
+    assert entry_id in receiver._fatal_errors
+    assert receiver._fatal_errors[entry_id].startswith("FCM short-run crash loop")
+    # Repairs UI issue for the short-run cap was NOT deleted by the long
+    # pre-start. (The supervisor may issue unrelated ``fcm_stuck`` delete
+    # calls after a successful registration; we filter on the specific
+    # ``fcm_short_run_crash_loop_*`` key.)
+    cap_issue_key = f"fcm_short_run_crash_loop_{entry_id}"
+    cap_deletes = [
+        call for call in delete_issue.call_args_list
+        if len(call.args) >= 3 and call.args[2] == cap_issue_key
+    ]
+    assert cap_deletes == [], (
+        f"Long pre-start deleted the cap Repairs issue without a healthy "
+        f"run; cap_deletes={cap_deletes}"
+    )
+
+
+# --------------------------------------------------------------------------
+# Iter-12 (Codex follow-up): sampling-gap defense
+#
+# When the full lifecycle CREATED -> STARTED -> CRASH happens between two
+# monitor polls (>=0.5s), the supervisor's monitor loop NEVER reads
+# ``state == STARTED`` and ``became_started`` would remain false. The
+# vendored ``_ObservableFcmPushClient`` subclass latches
+# ``_has_been_started`` via a ``__setattr__`` hook the moment the library
+# assigns ``run_state = STARTED`` -- independent of polling cadence.
+# The supervisor's cap branch consults this latch before deciding whether
+# a short run advances the counter. (CA-DEFENSE-OBSERVABILITY-001)
+# --------------------------------------------------------------------------
+
+
+def test_observable_subclass_latches_started_transition() -> None:
+    """The ``__setattr__`` hook latches ``_has_been_started`` on STARTED.
+
+    Unit-tests the observer mechanic in isolation: bypass the library
+    ``__init__`` and only exercise the attribute hook. The latch is
+    monotonic (set on STARTED, never cleared) and ignores non-STARTED
+    state assignments.
+    """
+    pc_cls = fcm_receiver_ha._ObservableFcmPushClientCls
+    if pc_cls is None:
+        pytest.skip("Vendored library not available; subclass not active")
+
+    from custom_components.googlefindmy.Auth.firebase_messaging import (
+        FcmPushClientRunState,
+    )
+
+    # Bypass library ``__init__`` -- we only exercise the ``__setattr__``
+    # hook. Seed the latch the same way the subclass' ``__init__`` does.
+    pc = pc_cls.__new__(pc_cls)
+    object.__setattr__(pc, "_has_been_started", False)
+
+    # Non-STARTED transitions do NOT set the latch.
+    pc.run_state = FcmPushClientRunState.CREATED
+    assert pc._has_been_started is False
+    pc.run_state = FcmPushClientRunState.STARTING_LOGIN
+    assert pc._has_been_started is False
+
+    # STARTED sets the latch.
+    pc.run_state = FcmPushClientRunState.STARTED
+    assert pc._has_been_started is True
+
+    # Latch is monotonic -- subsequent non-STARTED transitions do NOT
+    # clear it (the cap needs evidence the client was EVER started, not
+    # whether it is started right now).
+    pc.run_state = FcmPushClientRunState.STOPPING
+    assert pc._has_been_started is True
+    pc.run_state = FcmPushClientRunState.STOPPED
+    assert pc._has_been_started is True
+
+
+@pytest.mark.asyncio
+async def test_micro_window_crash_advances_cap_via_observable_latch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Micro-window CREATED -> STARTED -> CRASH between polls still counts.
+
+    Models the exact scenario the cap is meant to detect: the client
+    connects, decodes a poison message, and crashes before the supervisor's
+    first ``await asyncio.sleep(FCM_MONITOR_INTERVAL_S)`` sample. The
+    monitor loop reads STOPPED/!do_listen and ``became_started`` would
+    remain false WITHOUT the subclass latch. The latch
+    (``_has_been_started=True``, set by the vendored ``__setattr__`` hook
+    during ``pc.start()``) lets the cap correctly classify the run as a
+    short crash and advance the counter. 10 such micro-window crashes
+    fire the cap.
+    """
+    entry_id = "entry-micro-window"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    # become_started=False: the monitor loop never reads ``run_state ==
+    # STARTED`` (state read returns None on the first call, forcing the
+    # ``state is None`` break path immediately).
+    # has_been_started=True: the subclass latch was set during the
+    # library's CREATED -> STARTED transition that completed BEFORE the
+    # first monitor poll.
+    clients = [
+        _SupervisorPushClientStub(
+            clock=clock, become_started=False, has_been_started=True
+        )
+        for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS)
+    ]
+    register_mock = _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    create_issue, _delete_issue = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # Cap fired despite the supervisor monitor loop never reading STARTED.
+    assert register_mock.await_count == _MAX_CONSECUTIVE_SHORT_RUNS, (
+        f"Expected exactly {_MAX_CONSECUTIVE_SHORT_RUNS} register calls "
+        f"(one per micro-window crash); got {register_mock.await_count}. "
+        f"Without the subclass latch, became_started=False would keep the "
+        f"cap from firing and the supervisor would retry indefinitely."
+    )
+    assert create_issue.call_count == 1
+    cap_issue_call = create_issue.call_args
+    assert cap_issue_call.args[2] == f"fcm_short_run_crash_loop_{entry_id}"
+    assert entry_id in receiver._short_run_cap_latched
+    assert receiver._fatal_errors[entry_id].startswith(
+        "FCM short-run crash loop"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mixed_burst_micro_window_and_pre_start_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pre-start failures interleaved with micro-window crashes count only the latter.
+
+    Cascade: 5 micro-window crashes (has_been_started=True) + 3 true
+    pre-start failures (has_been_started=False) + 5 micro-window crashes.
+    The cap MUST fire at exactly 10 cumulative micro-window crashes
+    (counter reaches threshold on the 13th supervisor pass). Pre-start
+    failures leave the counter AND the latch UNTOUCHED. This pins the
+    orthogonality of the sampling-gap defense to the pre-start-failure
+    gate from iter-11 (CA-DEFENSE-SPECIFICITY-001).
+    """
+    entry_id = "entry-mixed-burst"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    cascade = (
+        [
+            _SupervisorPushClientStub(
+                clock=clock, become_started=False, has_been_started=True
+            )
+            for _ in range(5)
+        ]
+        + [
+            _SupervisorPushClientStub(
+                clock=clock, become_started=False, has_been_started=False
+            )
+            for _ in range(3)
+        ]
+        + [
+            _SupervisorPushClientStub(
+                clock=clock, become_started=False, has_been_started=True
+            )
+            for _ in range(5)
+        ]
+    )
+    register_mock = _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=cascade
+    )
+    create_issue, _delete_issue = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # Cap fired on the 13th iteration (5 + 3 + 5 = 13 stubs total, cap
+    # advances on micro-window crashes only).
+    assert register_mock.await_count == 13, (
+        f"Expected 13 register calls (5 + 3 + 5 cascade); got "
+        f"{register_mock.await_count}. Pre-start failures must NOT count "
+        f"toward the cap (iter-11), but real micro-window crashes MUST "
+        f"(iter-12)."
+    )
+    assert create_issue.call_count == 1
+    cap_issue_call = create_issue.call_args
+    assert cap_issue_call.args[2] == f"fcm_short_run_crash_loop_{entry_id}"
+    assert entry_id in receiver._short_run_cap_latched
+
+
+# --------------------------------------------------------------------------
+# CI follow-up (PR #1086 iter-13): Class-Identity substitution defense
+#
+# Iter-12 added _ObservableFcmPushClient as a subclass of FcmPushClient. The
+# production factory must construct that subclass. Tests, however, may
+# substitute the module-level FcmPushClient symbol via monkeypatch (the
+# documented seam) to inject test doubles -- e.g. test_receiver_reuses_
+# hass_managed_session in tests/test_fcm_receiver_guard.py asserts
+# ``isinstance(created, DummyPushClient)``. A factory that always returns
+# the production subclass would break isinstance identity against the
+# patched symbol because the subclass inherits from the ORIGINAL class,
+# not from the patched one. The factory therefore checks at CALL TIME
+# whether the module symbol still points at the snapshot of the original
+# class, and instantiates the patched class directly when not.
+# (CA-SUBCLASS-IDENTITY-001)
+# --------------------------------------------------------------------------
+
+
+def test_factory_uses_observable_subclass_in_production() -> None:
+    """When the FcmPushClient symbol is untouched the factory returns the subclass.
+
+    Pins the production path: the runtime check
+    ``current is _OriginalFcmPushClient`` is true, so the factory MUST
+    instantiate ``_ObservableFcmPushClient`` (not the plain library class).
+    """
+    if fcm_receiver_ha._ObservableFcmPushClientCls is None:
+        pytest.skip("Vendored library not available; subclass not active")
+
+    from custom_components.googlefindmy.Auth.firebase_messaging import (
+        FcmPushClientConfig,
+        FcmRegisterConfig,
+    )
+
+    config = FcmPushClientConfig()
+    register_cfg = FcmRegisterConfig(
+        project_id="p",
+        app_id="a",
+        api_key="k",
+        messaging_sender_id="s",
+    )
+
+    async def _noop_cb(*_args: object, **_kw: object) -> None:
+        return None
+
+    pc = fcm_receiver_ha._FcmPushClientFactory(
+        _noop_cb,
+        register_cfg,
+        {},
+        _noop_cb,
+        config=config,
+    )
+
+    assert isinstance(pc, fcm_receiver_ha._ObservableFcmPushClientCls)
+    # Latch was seeded before super().__init__ so it is observable here.
+    assert pc._has_been_started is False
+
+
+def test_factory_honours_monkeypatched_fcm_push_client_symbol(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Substituting FcmPushClient via monkeypatch is the documented seam.
+
+    Regression pin for CA-SUBCLASS-IDENTITY-001: when tests patch the
+    module-level ``FcmPushClient`` symbol to inject a test double, the
+    factory MUST instantiate the patched class DIRECTLY -- not a subclass
+    of the original library class. Otherwise ``isinstance`` assertions on
+    the patched symbol (as used by tests in tests/test_fcm_receiver_guard
+    .py) fail because the production subclass diverges from the patched
+    class hierarchy.
+    """
+
+    captured: dict[str, object] = {}
+
+    class _PatchedClient:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(
+        fcm_receiver_ha,
+        "FcmPushClient",
+        _PatchedClient,
+    )
+
+    pc = fcm_receiver_ha._FcmPushClientFactory(
+        "callback",
+        "config",
+        {"creds": True},
+        "creds_cb",
+        http_client_session="session",
+    )
+
+    # The factory honoured the patch: identity matches the patched class,
+    # not the production subclass and not the original library class.
+    assert isinstance(pc, _PatchedClient)
+    if fcm_receiver_ha._ObservableFcmPushClientCls is not None:
+        assert not isinstance(pc, fcm_receiver_ha._ObservableFcmPushClientCls)
+    assert captured["args"][0] == "callback"
+    assert captured["kwargs"]["http_client_session"] == "session"

--- a/tests/test_fcm_receiver_ha_short_run_cap.py
+++ b/tests/test_fcm_receiver_ha_short_run_cap.py
@@ -541,6 +541,82 @@ def test_unload_clears_fatal_errors_via_force() -> None:
     assert receiver._fatal_error is None
 
 
+def test_force_teardown_leaves_fixable_reauth_repairs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Teardown (force=True) must NOT delete the fixable reauth repairs.
+
+    Codex finding (PR #1104 follow-up): ``force=True`` is reached from
+    ``unregister_coordinator``, which fires via ``async_on_unload`` on EVERY
+    unload -- including the reload Home Assistant performs right after a
+    successful reauth flow. Deleting ``fcm_reauth_required`` / legacy
+    ``fcm_stuck`` here would dismiss a still-active prompt before the new
+    supervisor has proven recovery. Only the transient short-run crash-loop
+    issue (the DELETE half of the fatal-error CREATE/DELETE pair) is cleared.
+    Actual removal cleanup lives in ``async_delete_entry_repair_issues``.
+    """
+    entry_id = "entry-teardown"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+    _create_issue, delete_issue = _install_ir_capture(monkeypatch)
+
+    receiver._clear_fatal_error_for_entry(
+        entry_id, reason="Entry unregistered", force=True
+    )
+
+    deleted = {call.args[2] for call in delete_issue.call_args_list}
+    assert f"fcm_short_run_crash_loop_{entry_id}" in deleted
+    assert f"fcm_reauth_required_{entry_id}" not in deleted
+    assert f"fcm_stuck_{entry_id}" not in deleted
+
+
+def test_async_delete_entry_repair_issues_retires_all_on_removal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On actual entry removal ALL entry-scoped FCM repairs are retired.
+
+    Codex finding (PR #1104): once the entry is gone no supervisor will run
+    again, so ``async_remove_entry`` must delete the fixable reauth prompt and
+    its legacy ``fcm_stuck`` predecessor alongside the transient short-run
+    issue, or they stay pinned for a config entry that no longer exists. This
+    is the removal-only counterpart to the reload-safe teardown above.
+    """
+    entry_id = "entry-removed"
+    hass = SimpleNamespace()
+    _create_issue, delete_issue = _install_ir_capture(monkeypatch)
+
+    FcmReceiverHA.async_delete_entry_repair_issues(hass, entry_id)
+
+    deleted = {call.args[2] for call in delete_issue.call_args_list}
+    assert f"fcm_short_run_crash_loop_{entry_id}" in deleted
+    assert f"fcm_reauth_required_{entry_id}" in deleted
+    assert f"fcm_stuck_{entry_id}" in deleted
+
+
+def test_non_teardown_clear_leaves_reauth_repair_untouched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A recovery clear (force=False) must NOT delete the reauth repairs.
+
+    Non-teardown clears (credentials updated, registration success) rely on the
+    supervisor success path to retire ``fcm_reauth_required`` / ``fcm_stuck``;
+    deleting them here would dismiss a still-valid reauth prompt before the
+    supervisor has actually re-registered successfully. Only the short-run
+    issue (the DELETE half of the fatal-error CREATE/DELETE pair) is cleared.
+    """
+    entry_id = "entry-recovery"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+    _create_issue, delete_issue = _install_ir_capture(monkeypatch)
+
+    receiver._clear_fatal_error_for_entry(entry_id, reason="Credentials updated")
+
+    deleted = {call.args[2] for call in delete_issue.call_args_list}
+    assert f"fcm_short_run_crash_loop_{entry_id}" in deleted
+    assert f"fcm_reauth_required_{entry_id}" not in deleted
+    assert f"fcm_stuck_{entry_id}" not in deleted
+
+
 # --------------------------------------------------------------------------
 # Defense 2 iter-8: cap-latch lifecycle (Codex second finding)
 # --------------------------------------------------------------------------

--- a/tests/test_fcm_receiver_manual_locate.py
+++ b/tests/test_fcm_receiver_manual_locate.py
@@ -58,7 +58,9 @@ def test_manual_locate_registration_and_cleanup(
     start_calls: list[tuple[str, Any]] = []
     register_calls: list[str] = []
 
-    async def fake_ensure(eid: str, provided_cache: Any) -> object:
+    async def fake_ensure(
+        eid: str, provided_cache: Any, generation: int | None = None
+    ) -> object:
         ensure_calls.append((eid, provided_cache))
         return object()
 

--- a/tests/test_fcm_register_android_headers.py
+++ b/tests/test_fcm_register_android_headers.py
@@ -1,0 +1,212 @@
+# tests/test_fcm_register_android_headers.py
+"""Regression tests pinning the ``X-Android-Package`` / ``X-Android-Cert`` headers.
+
+These headers satisfy Google's API-key application restrictions on the Firebase
+Installations and FCM registration endpoints. They are a Google protocol
+constant mirrored from the upstream GoogleFindMyTools project (commit
+``32cffa54``). If a future refactor silently dropped them from one of the
+outgoing requests, FCM registration would start failing at Google's edge with
+no local error path to point at the cause. The wiring tests below assert that
+each of the three call sites (``fcm_install``, ``fcm_refresh_install_token``,
+``fcm_register``) actually attaches the headers to the request, and that the
+SHA-1 normalization performed in ``FcmRegisterConfig.__post_init__`` reaches the
+wire.
+
+Async tests carry an explicit ``@pytest.mark.asyncio`` decorator so the fallback
+runner in ``tests/conftest.py::pytest_pyfunc_call`` picks them up in
+third-party environments without ``pytest-asyncio`` installed. See
+``tests/AGENTS.md`` §"Async tests".
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from custom_components.googlefindmy.Auth.firebase_messaging.fcmregister import (
+    FcmRegister,
+    FcmRegisterConfig,
+)
+
+# The production certificate fingerprint wired in ``fcm_receiver_ha.py`` is the
+# colon-stripped, lowercase form below. The raw input is intentionally given in
+# the colon-separated uppercase shape so the test also proves that
+# ``_normalize_sha1_fingerprint`` runs before the value reaches the header.
+_RAW_CERT = "38:91:8A:45:3D:07:19:93:54:F8:B1:9A:F0:5E:C6:56:2C:ED:57:88"
+_NORMALIZED_CERT = "38918a453d07199354f8b19af05ec6562ced5788"
+_BUNDLE_ID = "com.example.app"
+
+
+class _RecordingResponse:
+    """Async-context-manager response stub recording nothing, returning a body."""
+
+    def __init__(self, status: int, json_value: dict[str, Any]) -> None:
+        self.status = status
+        self._json = json_value
+
+    async def __aenter__(self) -> _RecordingResponse:  # noqa: D401 - CM contract
+        return self
+
+    async def __aexit__(self, *_exc: object) -> None:
+        return None
+
+    async def json(self) -> dict[str, Any]:
+        return self._json
+
+    async def text(self) -> str:
+        return ""
+
+
+class _RecordingSession:
+    """Minimal aiohttp session stub that records the headers of ``json=`` posts."""
+
+    def __init__(self, response: _RecordingResponse) -> None:
+        self._response = response
+        self.calls: list[dict[str, Any]] = []
+
+    def post(
+        self,
+        *,
+        url: str,
+        headers: dict[str, str],
+        json: dict[str, Any],
+        timeout: Any,
+    ) -> _RecordingResponse:
+        # Snapshot the headers: the production code mutates a single dict, so a
+        # shallow copy is required to capture the state at call time.
+        self.calls.append({"url": url, "headers": dict(headers), "json": json})
+        return self._response
+
+
+def _config(*, android_cert_sha1: str | None) -> FcmRegisterConfig:
+    return FcmRegisterConfig(
+        project_id="proj",
+        app_id="app",
+        api_key="key",
+        messaging_sender_id="1234567890123",
+        bundle_id=_BUNDLE_ID,
+        android_cert_sha1=android_cert_sha1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit contract of the header helper
+# ---------------------------------------------------------------------------
+def test_helper_sets_both_headers_and_normalizes_cert() -> None:
+    """Both headers are added, and the SHA-1 is normalized before emission."""
+
+    register = FcmRegister(_config(android_cert_sha1=_RAW_CERT))
+    headers: dict[str, str] = {}
+
+    register._add_android_restriction_headers(headers)
+
+    assert headers["X-Android-Package"] == _BUNDLE_ID
+    assert headers["X-Android-Cert"] == _NORMALIZED_CERT
+
+
+def test_helper_omits_cert_header_when_unset() -> None:
+    """Without a fingerprint the cert header must be absent (package still set)."""
+
+    register = FcmRegister(_config(android_cert_sha1=None))
+    headers: dict[str, str] = {}
+
+    register._add_android_restriction_headers(headers)
+
+    assert headers["X-Android-Package"] == _BUNDLE_ID
+    assert "X-Android-Cert" not in headers
+
+
+# ---------------------------------------------------------------------------
+# Wiring: each outgoing request carries the headers
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_fcm_install_attaches_android_headers() -> None:
+    """``fcm_install`` attaches the restriction headers to its installation POST."""
+
+    response = _RecordingResponse(
+        200,
+        {
+            "authToken": {"token": "tok", "expiresIn": "3600s"},
+            "refreshToken": "refresh",
+            "fid": "fid",
+        },
+    )
+    session = _RecordingSession(response)
+    register = FcmRegister(
+        _config(android_cert_sha1=_RAW_CERT), http_client_session=session
+    )
+
+    await register.fcm_install()
+
+    assert len(session.calls) == 1
+    sent = session.calls[0]["headers"]
+    assert sent["X-Android-Package"] == _BUNDLE_ID
+    assert sent["X-Android-Cert"] == _NORMALIZED_CERT
+
+
+@pytest.mark.asyncio
+async def test_fcm_refresh_install_token_attaches_android_headers() -> None:
+    """``fcm_refresh_install_token`` attaches the headers to its refresh POST."""
+
+    response = _RecordingResponse(200, {"token": "tok", "expiresIn": "3600s"})
+    session = _RecordingSession(response)
+    register = FcmRegister(
+        _config(android_cert_sha1=_RAW_CERT),
+        credentials={
+            "fcm": {"installation": {"refresh_token": "refresh", "fid": "fid"}}
+        },
+        http_client_session=session,
+    )
+
+    await register.fcm_refresh_install_token()
+
+    assert len(session.calls) == 1
+    sent = session.calls[0]["headers"]
+    assert sent["X-Android-Package"] == _BUNDLE_ID
+    assert sent["X-Android-Cert"] == _NORMALIZED_CERT
+
+
+@pytest.mark.asyncio
+async def test_fcm_register_attaches_android_headers() -> None:
+    """``fcm_register`` attaches the headers to its registration POST."""
+
+    response = _RecordingResponse(200, {"token": "fcm-token"})
+    session = _RecordingSession(response)
+    register = FcmRegister(
+        _config(android_cert_sha1=_RAW_CERT), http_client_session=session
+    )
+
+    await register.fcm_register(
+        gcm_data={"token": "gcm-token"},
+        installation={"token": "install-token"},
+        keys={"secret": "secret", "public": "public", "private": "private"},
+    )
+
+    assert len(session.calls) == 1
+    sent = session.calls[0]["headers"]
+    assert sent["X-Android-Package"] == _BUNDLE_ID
+    assert sent["X-Android-Cert"] == _NORMALIZED_CERT
+
+
+@pytest.mark.asyncio
+async def test_fcm_install_omits_cert_header_when_unset() -> None:
+    """With no fingerprint configured the install POST omits the cert header."""
+
+    response = _RecordingResponse(
+        200,
+        {
+            "authToken": {"token": "tok", "expiresIn": "3600s"},
+            "refreshToken": "refresh",
+            "fid": "fid",
+        },
+    )
+    session = _RecordingSession(response)
+    register = FcmRegister(_config(android_cert_sha1=None), http_client_session=session)
+
+    await register.fcm_install()
+
+    assert len(session.calls) == 1
+    sent = session.calls[0]["headers"]
+    assert sent["X-Android-Package"] == _BUNDLE_ID
+    assert "X-Android-Cert" not in sent

--- a/tests/test_fcm_repair_reauth.py
+++ b/tests/test_fcm_repair_reauth.py
@@ -1,0 +1,328 @@
+# tests/test_fcm_repair_reauth.py
+"""Tests for the fixable FCM reauth repair and its escalation thresholds.
+
+Covers the three terminal give-up points in the FCM supervisor that now raise
+the single shared fixable repair ``fcm_reauth_required_{entry_id}`` and the
+fix flow in ``custom_components/googlefindmy/repairs.py`` that drives the user
+into the config-entry reauth flow.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.data_entry_flow import FlowResultType
+
+from custom_components.googlefindmy import repairs
+from custom_components.googlefindmy.Auth import fcm_receiver_ha
+from custom_components.googlefindmy.Auth.fcm_receiver_ha import DOMAIN, FcmReceiverHA
+from custom_components.googlefindmy.exceptions import FatalRegistrationError
+
+
+class _StubClient:
+    """Minimal FCM client stub; ``start`` ends the supervisor loop."""
+
+    def __init__(self, stop_evt: asyncio.Event) -> None:
+        self.stop_evt = stop_evt
+        self.do_listen = True
+        self.run_state = None
+        self.start_calls = 0
+        self.stop_calls = 0
+
+    async def start(self) -> None:
+        self.start_calls += 1
+        self.stop_evt.set()
+
+    async def stop(self) -> None:
+        self.stop_calls += 1
+
+
+def _make_receiver(
+    monkeypatch: pytest.MonkeyPatch, entry_id: str
+) -> tuple[FcmReceiverHA, SimpleNamespace, MagicMock, MagicMock]:
+    """Build a receiver wired to capture issue-registry calls.
+
+    Mirrors the proven harness in ``test_fcm_backoff_escalation`` but for the
+    fatal-registration (404/401) escalation paths.
+    """
+    receiver = FcmReceiverHA()
+    hass = SimpleNamespace()
+    receiver.attach_hass(hass)
+
+    stop_evt = asyncio.Event()
+    receiver._stop_evts[entry_id] = stop_evt
+
+    pc = _StubClient(stop_evt)
+    monkeypatch.setattr(
+        receiver, "_ensure_client_for_entry", AsyncMock(return_value=pc)
+    )
+    # 404/401 give-up paths sleep between retries; make them instant.
+    monkeypatch.setattr(fcm_receiver_ha.asyncio, "sleep", AsyncMock())
+    # The 401 path renews tokens before retrying.
+    monkeypatch.setattr(receiver, "_invalidate_fcm_tokens", AsyncMock())
+    monkeypatch.setattr(
+        fcm_receiver_ha.ir,
+        "IssueSeverity",
+        SimpleNamespace(WARNING="warning", ERROR="error"),
+    )
+
+    create_issue = MagicMock()
+    delete_issue = MagicMock()
+    monkeypatch.setattr(fcm_receiver_ha.ir, "async_create_issue", create_issue)
+    monkeypatch.setattr(fcm_receiver_ha.ir, "async_delete_issue", delete_issue)
+
+    return receiver, hass, create_issue, delete_issue
+
+
+def _reauth_calls(create_issue: MagicMock, entry_id: str) -> list:
+    """Return the create_issue calls that raised the fixable reauth issue."""
+    return [
+        call
+        for call in create_issue.call_args_list
+        if len(call.args) >= 3 and call.args[2] == f"fcm_reauth_required_{entry_id}"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_transient_404_below_cap_does_not_escalate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T1: 404 rotation below ``_MAX_FATAL_ENDPOINT_RETRIES`` must not escalate."""
+    entry_id = "entry-id"
+    receiver, hass, create_issue, delete_issue = _make_receiver(
+        monkeypatch, entry_id
+    )
+
+    # Three transient 404s (n=1..3, well below the cap of 7), then success.
+    register_mock = AsyncMock(
+        side_effect=[
+            FatalRegistrationError("404 endpoint", is_auth_error=False),
+            FatalRegistrationError("404 endpoint", is_auth_error=False),
+            FatalRegistrationError("404 endpoint", is_auth_error=False),
+            True,
+        ]
+    )
+    monkeypatch.setattr(receiver, "_register_for_fcm_entry", register_mock)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert register_mock.await_count == 4
+    # No fixable issue raised: transient rotation cleared before the give-up.
+    assert _reauth_calls(create_issue, entry_id) == []
+    # On the successful registration the recovery delete still fires.
+    delete_issue.assert_any_call(
+        hass, DOMAIN, f"fcm_reauth_required_{entry_id}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_permanent_404_at_cap_raises_fixable_issue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T2: 404 reaching the cap raises exactly one fixable reauth issue."""
+    entry_id = "entry-id"
+    receiver, hass, create_issue, _delete_issue = _make_receiver(
+        monkeypatch, entry_id
+    )
+
+    # Seven consecutive 404s -> fatal_count == _MAX_FATAL_ENDPOINT_RETRIES (7).
+    register_mock = AsyncMock(
+        side_effect=[
+            FatalRegistrationError("404 endpoint", is_auth_error=False)
+            for _ in range(fcm_receiver_ha._MAX_FATAL_ENDPOINT_RETRIES)
+        ]
+    )
+    monkeypatch.setattr(receiver, "_register_for_fcm_entry", register_mock)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert register_mock.await_count == fcm_receiver_ha._MAX_FATAL_ENDPOINT_RETRIES
+    calls = _reauth_calls(create_issue, entry_id)
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.args[0] is hass
+    assert call.args[1] == DOMAIN
+    assert call.kwargs["is_fixable"] is True
+    assert call.kwargs["severity"] == fcm_receiver_ha.ir.IssueSeverity.ERROR
+    assert call.kwargs["translation_key"] == "fcm_reauth_required"
+    assert call.kwargs["data"]["entry_id"] == entry_id
+    assert call.kwargs["data"]["reason"] == "endpoint_404"
+
+
+@pytest.mark.asyncio
+async def test_permanent_401_at_cap_raises_fixable_issue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T3: 401 reaching the auth cap raises the fixable reauth issue."""
+    entry_id = "entry-id"
+    receiver, _hass, create_issue, _delete_issue = _make_receiver(
+        monkeypatch, entry_id
+    )
+
+    # Three consecutive 401s -> fatal_count == _MAX_FATAL_AUTH_RETRIES (3).
+    register_mock = AsyncMock(
+        side_effect=[
+            FatalRegistrationError("401 auth", is_auth_error=True)
+            for _ in range(fcm_receiver_ha._MAX_FATAL_AUTH_RETRIES)
+        ]
+    )
+    monkeypatch.setattr(receiver, "_register_for_fcm_entry", register_mock)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert register_mock.await_count == fcm_receiver_ha._MAX_FATAL_AUTH_RETRIES
+    calls = _reauth_calls(create_issue, entry_id)
+    assert len(calls) == 1
+    assert calls[0].kwargs["data"]["reason"] == "auth_401"
+    assert calls[0].kwargs["is_fixable"] is True
+
+
+@pytest.mark.asyncio
+async def test_fix_flow_factory_returns_reauth_flow() -> None:
+    """T4a: the fix-flow factory carries the entry id from the issue data."""
+    flow = await repairs.async_create_fix_flow(
+        SimpleNamespace(), "fcm_reauth_required_entry-id", {"entry_id": "entry-id"}
+    )
+    assert isinstance(flow, repairs.FcmReauthRepairFlow)
+    assert flow._entry_id == "entry-id"
+
+
+@pytest.mark.asyncio
+async def test_fix_flow_confirm_starts_reauth() -> None:
+    """T4b: confirming the repair starts reauth for the resolved entry."""
+    # ``ConfigEntry.async_start_reauth`` is a synchronous ``@callback`` returning
+    # ``None``; mock it synchronously so the test fails if production re-adds an
+    # erroneous ``await`` on that result.
+    entry = SimpleNamespace(async_start_reauth=MagicMock(return_value=None))
+    hass = SimpleNamespace(
+        config_entries=SimpleNamespace(
+            async_get_entry=lambda entry_id: (
+                entry if entry_id == "entry-id" else None
+            )
+        )
+    )
+    flow = repairs.FcmReauthRepairFlow("entry-id")
+    flow.hass = hass  # normally injected by the repairs flow manager
+
+    # A live entry means the issue must stay open (True) until the supervisor
+    # success path clears it.
+    assert flow._async_start_reauth() is True
+
+    entry.async_start_reauth.assert_called_once_with(hass)
+
+
+@pytest.mark.asyncio
+async def test_fix_flow_confirm_aborts_to_keep_issue_open() -> None:
+    """T4b-2: confirming aborts (keeps the issue) instead of CREATE_ENTRY.
+
+    Home Assistant's repairs manager deletes the issue for any non-ABORT
+    result. Returning CREATE_ENTRY here would strand the account if the launched
+    reauth flow is cancelled or fails: the supervisor already broke out at its
+    terminal 401/404 give-up points and will not re-raise. The fixable issue
+    must persist until the supervisor's success path clears it after credentials
+    are actually renewed. This guard fails if production reverts to
+    ``async_create_entry``.
+    """
+    entry = SimpleNamespace(async_start_reauth=MagicMock(return_value=None))
+    hass = SimpleNamespace(
+        config_entries=SimpleNamespace(
+            async_get_entry=lambda entry_id: (
+                entry if entry_id == "entry-id" else None
+            )
+        )
+    )
+    flow = repairs.FcmReauthRepairFlow("entry-id")
+    flow.hass = hass  # normally injected by the repairs flow manager
+    flow.flow_id = "test-flow-id"  # set by the flow manager in production
+    flow.handler = DOMAIN  # set by the flow manager in production
+
+    result = await flow.async_step_confirm(user_input={})
+
+    # ABORT keeps the fixable issue alive; the reauth flow was still launched.
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "reauth_started"
+    entry.async_start_reauth.assert_called_once_with(hass)
+
+
+@pytest.mark.asyncio
+async def test_fix_flow_missing_entry_is_noop() -> None:
+    """T4c: a stale issue (entry already gone) dismisses without raising."""
+    hass = SimpleNamespace(
+        config_entries=SimpleNamespace(async_get_entry=lambda entry_id: None)
+    )
+    flow = repairs.FcmReauthRepairFlow("entry-id")
+    flow.hass = hass
+
+    # Must not raise even though the entry cannot be resolved, and must report
+    # the repair as stale (False) so the caller dismisses it.
+    assert flow._async_start_reauth() is False
+
+    flow_no_id = repairs.FcmReauthRepairFlow(None)
+    flow_no_id.hass = hass
+    assert flow_no_id._async_start_reauth() is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("entry_id", "async_get_entry"),
+    [
+        # Entry id present in the issue data, but the entry was already removed.
+        ("entry-id", lambda entry_id: None),
+        # The issue data never carried an entry id at all.
+        (None, lambda entry_id: None),
+    ],
+)
+async def test_fix_flow_stale_confirm_dismisses_issue(
+    entry_id: str | None, async_get_entry
+) -> None:
+    """T4c-2: confirming a *stale* repair returns CREATE_ENTRY to dismiss it.
+
+    The keep-open ABORT contract only holds while a supervisor can still run for
+    the entry and clear ``fcm_reauth_required_{entry_id}`` on its success path.
+    When the entry is gone (or was never recorded), no supervisor exists to ever
+    clear the entry-scoped issue and reauth can never start. Returning
+    CREATE_ENTRY lets Home Assistant's repairs manager delete the orphaned issue
+    (only ABORT is exempt from that delete) instead of pinning an unfixable
+    repair in the UI forever. This guard fails if production reverts to keeping
+    stale repairs open.
+    """
+    hass = SimpleNamespace(
+        config_entries=SimpleNamespace(async_get_entry=async_get_entry)
+    )
+    flow = repairs.FcmReauthRepairFlow(entry_id)
+    flow.hass = hass
+    flow.flow_id = "test-flow-id"  # set by the flow manager in production
+    flow.handler = DOMAIN  # set by the flow manager in production
+
+    result = await flow.async_step_confirm(user_input={})
+
+    # CREATE_ENTRY signals the repairs manager to delete the stale issue.
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+
+
+@pytest.mark.asyncio
+async def test_successful_register_deletes_fixable_issue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T5: a successful (re-)registration clears the fixable issue."""
+    entry_id = "entry-id"
+    receiver, hass, _create_issue, delete_issue = _make_receiver(
+        monkeypatch, entry_id
+    )
+
+    register_mock = AsyncMock(side_effect=[True])
+    monkeypatch.setattr(receiver, "_register_for_fcm_entry", register_mock)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    delete_issue.assert_any_call(
+        hass, DOMAIN, f"fcm_reauth_required_{entry_id}"
+    )
+    delete_issue.assert_any_call(hass, DOMAIN, f"fcm_stuck_{entry_id}")

--- a/tests/test_fcmpushclient_b64_hardening.py
+++ b/tests/test_fcmpushclient_b64_hardening.py
@@ -1,0 +1,161 @@
+# tests/test_fcmpushclient_b64_hardening.py
+"""Regression suite for ``_safe_urlsafe_b64decode`` (defense 3).
+
+Defense layer 3 of the three-defense hotfix for the FCM listener
+poison-message cascade (CA-CASCADING-FAILURE-001). Python 3.14 switched
+``binascii.a2b_base64`` to ``strict_mode=True`` by default, which rejects
+payloads that contain newlines, leading/trailing whitespace, or missing
+padding -- conditions the wild FCM crypto-key and salt headers reliably
+produce. Before this helper, ``urlsafe_b64decode`` raised
+``binascii.Error: Incorrect padding`` on every notification, the listener
+loop's poison-message handler selective-ACKed the message and looped, and
+the memory leak observed on Home Assistant Core 2026.6.x followed.
+
+The helper restores the pre-3.14 lenient behaviour locally (whitespace
+strip + padding append) without touching the global decoder state. These
+tests pin that lenient contract against a future regression that would
+re-introduce strict decoding on dirty input.
+"""
+from __future__ import annotations
+
+import binascii
+from base64 import urlsafe_b64encode
+from unittest.mock import patch
+
+import pytest
+
+from custom_components.googlefindmy.Auth.firebase_messaging.fcmpushclient import (
+    CredentialDecryptionError,
+    FcmPushClient,
+    _safe_urlsafe_b64decode,
+)
+
+
+def _b64_no_pad(data: bytes) -> str:
+    """URL-safe base64 string without padding (matches FCM stream format)."""
+    return urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def test_missing_padding_decodes_cleanly() -> None:
+    """Unpadded base64 string decodes successfully.
+
+    FCM crypto-key and salt headers routinely omit ``=`` padding. Python
+    3.14 strict mode rejects this with ``binascii.Error: Incorrect padding``;
+    the helper must re-append padding and decode without raising.
+    """
+    payload = b"\xde\xad\xbe\xef" * 4  # 16 bytes -> 22 base64 chars (no pad)
+    unpadded = _b64_no_pad(payload)
+    assert not unpadded.endswith("=")
+
+    assert _safe_urlsafe_b64decode(unpadded) == payload
+
+
+def test_embedded_newlines_are_stripped() -> None:
+    """Base64 strings split by newlines decode after newline stripping.
+
+    Some FCM payload sources (MIME-style splits, debug-log round-tripping)
+    inject ``\\n`` mid-payload. Python 3.14 strict mode treats this as an
+    invalid character; the helper must strip it before decoding.
+    """
+    payload = b"hello-world-padding-test"
+    encoded = urlsafe_b64encode(payload).decode("ascii")
+    # Inject newlines every 8 chars (MIME-style 76-char split, scaled down).
+    dirty = "\n".join(encoded[i : i + 8] for i in range(0, len(encoded), 8))
+    assert "\n" in dirty
+
+    assert _safe_urlsafe_b64decode(dirty) == payload
+
+
+def test_leading_and_trailing_whitespace_are_stripped() -> None:
+    """Surrounding whitespace (space, tab, CR, vtab, formfeed) is removed.
+
+    HTTP header parsers sometimes leave trailing CRLF or leading SP on the
+    decoded parameter value. The helper collapses every ASCII whitespace
+    flavour (space, tab, newline, CR, vtab, formfeed) via ``bytes.split``.
+    """
+    payload = b"trailing-whitespace-defense"
+    clean = _b64_no_pad(payload)
+    dirty = f" \t{clean}\r\n\x0b\x0c"
+
+    assert _safe_urlsafe_b64decode(dirty) == payload
+
+
+def test_bytes_input_is_accepted() -> None:
+    """``bytes`` input decodes equivalently to ``str`` input.
+
+    Callers in the credential path pass ``str`` from cached JSON; future
+    callers in the wire-decode path may pass raw ``bytes`` straight out of
+    the socket. The helper accepts both without an extra encode step.
+    """
+    payload = b"bytes-input-contract"
+    encoded_str = _b64_no_pad(payload)
+    encoded_bytes = encoded_str.encode("ascii")
+
+    assert _safe_urlsafe_b64decode(encoded_bytes) == payload
+    assert _safe_urlsafe_b64decode(encoded_bytes) == _safe_urlsafe_b64decode(
+        encoded_str
+    )
+
+
+def test_python314_strict_mode_simulation_does_not_leak() -> None:
+    """Strict-mode ``binascii.a2b_base64`` does not see dirty input.
+
+    Simulates Python 3.14's strict default by patching the underlying
+    ``binascii.a2b_base64`` to refuse newlines and missing padding (the
+    exact failure mode reported on HA Core 2026.6.x). The helper must
+    pre-clean the input so that the strict decoder receives a payload it
+    accepts -- otherwise the cascade returns.
+    """
+    real_a2b = binascii.a2b_base64
+
+    def strict_a2b(data: bytes | str, *, strict_mode: bool = False) -> bytes:
+        # Mimic Python 3.14 strict_mode=True default: reject whitespace and
+        # missing padding regardless of the strict_mode kwarg the caller
+        # passes (the strict-mode default flip is the regression source).
+        if isinstance(data, str):
+            data = data.encode("ascii")
+        if any(ws in data for ws in (b" ", b"\t", b"\n", b"\r")):
+            raise binascii.Error("Invalid base64-encoded string")
+        if len(data) % 4 != 0:
+            raise binascii.Error("Incorrect padding")
+        return real_a2b(data, strict_mode=True)
+
+    payload = b"strict-mode-survives"
+    dirty = f"\n {_b64_no_pad(payload)}\r\n"
+
+    with patch.object(binascii, "a2b_base64", side_effect=strict_a2b):
+        # The helper must pre-clean before delegating; otherwise the
+        # patched strict decoder would raise.
+        assert _safe_urlsafe_b64decode(dirty) == payload
+
+
+def test_end_to_end_dirty_headers_decrypt_path_does_not_cascade() -> None:
+    """Dirty crypto-key / salt headers reach ``_decrypt_raw_data`` cleanly.
+
+    End-to-end check: ``_decrypt_raw_data`` is called with whitespace-laden
+    header strings (the field the FCM listener actually receives from the
+    wire). The helper must absorb the noise so the function reaches the
+    credential surface; a credential-stage failure here proves the header
+    decode succeeded (without the helper, ``binascii.Error`` would fire
+    before the credentials are ever consulted).
+
+    Empty credentials are passed deliberately: the test asserts the failure
+    surface, not a full decrypt. The point is that the decrypt is reached.
+    """
+    payload_key = b"\xde\xad\xbe\xef" * 4
+    payload_salt = b"\xfe\xed\xfa\xce" * 4
+    crypto_key_dirty = f"\n {_b64_no_pad(payload_key)}\r\n"
+    salt_dirty = f"  {_b64_no_pad(payload_salt)}\t"
+
+    # No keys section -> credential surface raises CredentialDecryptionError.
+    # The crucial assertion is that we get the CREDENTIAL error, not a
+    # header-stage binascii.Error. If defense 3 regresses, the header
+    # decode would raise first and this test would fail with a different
+    # exception type.
+    credentials: dict[str, object] = {"gcm": {"app_id": "x"}}
+    with pytest.raises(
+        CredentialDecryptionError, match="missing FCM key material"
+    ):
+        FcmPushClient._decrypt_raw_data(
+            credentials, crypto_key_dirty, salt_dirty, b"raw"
+        )

--- a/tests/test_fcmpushclient_b64_hardening.py
+++ b/tests/test_fcmpushclient_b64_hardening.py
@@ -16,6 +16,7 @@ strip + padding append) without touching the global decoder state. These
 tests pin that lenient contract against a future regression that would
 re-introduce strict decoding on dirty input.
 """
+
 from __future__ import annotations
 
 import binascii
@@ -129,6 +130,47 @@ def test_python314_strict_mode_simulation_does_not_leak() -> None:
         assert _safe_urlsafe_b64decode(dirty) == payload
 
 
+def test_pure_punctuation_corruption_raises_binascii_error() -> None:
+    """Non-alphabet punctuation raises instead of decoding to garbage.
+
+    The stdlib's non-validating decoder DISCARDS characters outside the
+    base64 alphabet, so ``b"!!!!"`` would decode to ``b""`` silently. The
+    validating decoder must reject it with ``binascii.Error`` so that a
+    corrupt credential field cannot masquerade as a (wrongly) decodable
+    value. Pins the validate=True contract against a regression back to the
+    lenient ``urlsafe_b64decode`` default.
+    """
+    for corrupt in ("!!!!", "@@@@", "????", "(())"):
+        with pytest.raises(binascii.Error):
+            _safe_urlsafe_b64decode(corrupt)
+
+
+def test_corrupt_secret_field_reaches_credential_error_not_poison() -> None:
+    """A corrupt ``keys.secret`` hits the credential branch, not poison skip.
+
+    Regression for the validating-decode fix. ``keys.secret`` degraded to
+    pure punctuation must raise ``CredentialDecryptionError`` out of
+    ``_decrypt_raw_data`` -- the signal the supervisor uses to invalidate
+    the key material and re-register. Without validation it would decode to
+    garbage bytes, the decrypt would fail downstream, and the listener would
+    treat permanent credential corruption as recoverable per-message poison
+    (ACK + skip), looping forever on bad credentials.
+
+    Adequacy (AGENTS.md 2.2): asserts the error *type* that drives the
+    re-registration path, not merely that the decode line executed. The
+    valid ``private`` field proves the failure is isolated to the corrupt
+    ``secret`` rather than a generic key-section rejection.
+    """
+    valid_private = _b64_no_pad(b"\x01\x02\x03\x04" * 8)
+    crypto_key = _b64_no_pad(b"\xde\xad\xbe\xef" * 4)
+    salt = _b64_no_pad(b"\xfe\xed\xfa\xce" * 4)
+    credentials: dict[str, object] = {
+        "keys": {"private": valid_private, "secret": "!!!!"}
+    }
+    with pytest.raises(CredentialDecryptionError, match="base64 decode"):
+        FcmPushClient._decrypt_raw_data(credentials, crypto_key, salt, b"raw")
+
+
 def test_end_to_end_dirty_headers_decrypt_path_does_not_cascade() -> None:
     """Dirty crypto-key / salt headers reach ``_decrypt_raw_data`` cleanly.
 
@@ -153,9 +195,7 @@ def test_end_to_end_dirty_headers_decrypt_path_does_not_cascade() -> None:
     # decode would raise first and this test would fail with a different
     # exception type.
     credentials: dict[str, object] = {"gcm": {"app_id": "x"}}
-    with pytest.raises(
-        CredentialDecryptionError, match="missing FCM key material"
-    ):
+    with pytest.raises(CredentialDecryptionError, match="missing FCM key material"):
         FcmPushClient._decrypt_raw_data(
             credentials, crypto_key_dirty, salt_dirty, b"raw"
         )

--- a/tests/test_fcmpushclient_credential_decryption.py
+++ b/tests/test_fcmpushclient_credential_decryption.py
@@ -1,0 +1,174 @@
+# tests/test_fcmpushclient_credential_decryption.py
+"""Direct unit tests for FcmPushClient._decrypt_raw_data credential failures.
+
+Regression suite for CA-CRED-VS-MSG-DECRYPT-001 iter-3 (Codex review on
+commit 14b5a45451): when the cached FCM credential material is structurally
+broken, ``_decrypt_raw_data`` must raise ``CredentialDecryptionError`` (a
+typed subclass of ``ValueError``) so the listener loop's poison-message
+defense can discriminate credential corruption (escalate to supervisor) from
+per-message decode failures (selective-ACK + skip).
+
+The iter-2 implementation used a string-prefix marker ("Credentials ...")
+which silently leaked plain ``ValueError`` from upstream libraries -- most
+notably ``cryptography.hazmat.primitives.serialization.load_der_private_key``
+raising ``ValueError("Could not deserialize key data ...")`` for valid base64
+but invalid DER content. That leak caused the listener to ACK every incoming
+message while silently dropping it. The iter-3 fix wraps every credential
+decode surface and raises ``CredentialDecryptionError`` instead, so the
+discriminator is the exception TYPE rather than the message text.
+"""
+from __future__ import annotations
+
+from base64 import urlsafe_b64encode
+
+import pytest
+
+from custom_components.googlefindmy.Auth.firebase_messaging.fcmpushclient import (
+    CredentialDecryptionError,
+    FcmPushClient,
+)
+
+
+def _b64(data: bytes) -> str:
+    """URL-safe base64 string without padding (matches FCM credential format)."""
+    return urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def test_missing_keys_section_raises_typed_error() -> None:
+    """``credentials["keys"]`` absent -> CredentialDecryptionError."""
+    credentials: dict[str, object] = {"gcm": {"app_id": "x"}}
+    with pytest.raises(CredentialDecryptionError, match="missing FCM key material"):
+        FcmPushClient._decrypt_raw_data(
+            credentials, "crypto", "salt", b"raw"
+        )
+
+
+def test_invalid_key_value_types_raise_typed_error() -> None:
+    """``keys.private``/``keys.secret`` non-string -> CredentialDecryptionError."""
+    credentials: dict[str, object] = {
+        "keys": {"private": 42, "secret": None},
+    }
+    with pytest.raises(
+        CredentialDecryptionError, match="contain invalid key values"
+    ):
+        FcmPushClient._decrypt_raw_data(
+            credentials, "crypto", "salt", b"raw"
+        )
+
+
+def test_non_base64_key_material_raises_typed_error() -> None:
+    """``keys.private`` not valid base64 -> CredentialDecryptionError, not bare binascii.Error.
+
+    Covers the b64decode failure surface (iter-2 fix). The error chain
+    preserves the original binascii.Error via ``__cause__``.
+    """
+    credentials: dict[str, object] = {
+        "keys": {
+            "private": "###not-base64###",
+            "secret": _b64(b"valid-secret-bytes"),
+        },
+    }
+    with pytest.raises(
+        CredentialDecryptionError, match="failed base64 decode"
+    ) as exc_info:
+        FcmPushClient._decrypt_raw_data(
+            credentials, _b64(b"k"), _b64(b"s"), b"raw"
+        )
+    # __cause__ chain preserves the underlying binascii.Error for diagnostics.
+    assert exc_info.value.__cause__ is not None
+
+
+def test_non_ascii_in_private_key_raises_typed_error() -> None:
+    """``keys.private`` with non-ASCII bytes -> CredentialDecryptionError.
+
+    THIS IS THE ITER-4 CODEX REGRESSION (commit ae70dccc90). ``.encode("ascii")``
+    on a corrupted cached key value raises ``UnicodeEncodeError`` BEFORE
+    ``urlsafe_b64decode`` is reached. ``UnicodeEncodeError`` is a subclass of
+    ``ValueError`` but NOT of ``binascii.Error``, so the iter-3 catch
+    ``except binascii.Error`` let it through, the listener loop's per-message
+    ValueError handler swallowed it, and every push was selective-ACKed and
+    silently dropped instead of surfacing a credential fault. The iter-4 fix
+    widens the catch to ``(binascii.Error, UnicodeError)``.
+    """
+    credentials: dict[str, object] = {
+        "keys": {
+            "private": "☃snowman",  # non-ASCII -> UnicodeEncodeError on .encode("ascii")
+            "secret": _b64(b"valid-secret-bytes-16b"),
+        },
+    }
+    with pytest.raises(
+        CredentialDecryptionError, match="failed base64 decode"
+    ) as exc_info:
+        FcmPushClient._decrypt_raw_data(
+            credentials, _b64(b"k"), _b64(b"s"), b"raw"
+        )
+    # __cause__ preserves the underlying UnicodeEncodeError for diagnostics.
+    assert exc_info.value.__cause__ is not None
+    assert isinstance(exc_info.value.__cause__, UnicodeError)
+
+
+def test_non_ascii_in_secret_raises_typed_error() -> None:
+    """``keys.secret`` with non-ASCII bytes -> CredentialDecryptionError.
+
+    Mirror of the iter-4 regression for the secret field: both cred encodes
+    run inside the same try-block, so the same widened catch must apply.
+    """
+    credentials: dict[str, object] = {
+        "keys": {
+            "private": _b64(b"\xde\xad\xbe\xef" * 16),
+            "secret": "café",  # non-ASCII -> UnicodeEncodeError
+        },
+    }
+    with pytest.raises(
+        CredentialDecryptionError, match="failed base64 decode"
+    ) as exc_info:
+        FcmPushClient._decrypt_raw_data(
+            credentials, _b64(b"k"), _b64(b"s"), b"raw"
+        )
+    assert isinstance(exc_info.value.__cause__, UnicodeError)
+
+
+def test_corrupted_der_private_key_raises_typed_error() -> None:
+    """Valid base64 but invalid DER content -> CredentialDecryptionError.
+
+    THIS IS THE ITER-3 CODEX REGRESSION. Under the iter-2 string-marker
+    discipline this path leaked a plain ValueError("Could not deserialize key
+    data ...") from cryptography, which the listener loop misinterpreted as
+    per-message poison and silently ACKed every incoming message while
+    dropping all notifications. The iter-3 fix wraps load_der_private_key and
+    re-raises as CredentialDecryptionError so the supervisor can escalate.
+    """
+    # Valid base64 of plausible-length garbage that load_der_private_key will
+    # reject. "deadbeef" * 8 = 64 bytes, looks key-sized but is not DER.
+    fake_der_payload = b"\xde\xad\xbe\xef" * 16
+    credentials: dict[str, object] = {
+        "keys": {
+            "private": _b64(fake_der_payload),
+            "secret": _b64(b"valid-secret-bytes-16b"),
+        },
+    }
+    with pytest.raises(
+        CredentialDecryptionError, match="failed DER private-key parse"
+    ) as exc_info:
+        FcmPushClient._decrypt_raw_data(
+            credentials, _b64(b"k"), _b64(b"s"), b"raw"
+        )
+    # __cause__ preserves the underlying cryptography error for diagnostics.
+    assert exc_info.value.__cause__ is not None
+
+
+def test_credential_decryption_error_is_value_error_subclass() -> None:
+    """Subclass-of-ValueError contract: backward compat for legacy ``except ValueError``.
+
+    Any external caller that catches broad ValueError still catches
+    CredentialDecryptionError. The listener loop's poison-message defense
+    uses ``isinstance`` discrimination (CredentialDecryptionError first, then
+    ValueError) to enforce the iter-3 propagation contract.
+    """
+    assert issubclass(CredentialDecryptionError, ValueError)
+    try:
+        raise CredentialDecryptionError("test")
+    except ValueError:
+        pass
+    else:
+        pytest.fail("CredentialDecryptionError should be catchable as ValueError")

--- a/tests/test_fcmpushclient_decrypt_success.py
+++ b/tests/test_fcmpushclient_decrypt_success.py
@@ -1,0 +1,109 @@
+# tests/test_fcmpushclient_decrypt_success.py
+"""Success-path unit test for ``FcmPushClient._decrypt_raw_data``.
+
+The credential-failure suite (``test_fcmpushclient_credential_decryption.py``)
+covers every *raising* branch of ``_decrypt_raw_data`` but never reaches the
+final decrypt call (lines 540-548): the call into ``http_ece.decrypt`` and the
+``return decrypted``. This test closes that gap (plan R1) without touching the
+SUT.
+
+Discipline:
+* The DER private-key hurdle at line 531 is passed with a *real* P-256 key
+  (not patched), so ``load_der_private_key`` executes for real and the success
+  path stays SUT-true (plan AE2).
+* ``http_decrypt`` is a module-level indirection (``fcmpushclient.py:83``;
+  ``http_decrypt = http_ece.decrypt``) and is monkeypatched at the module
+  attribute, so the test is deterministic without real ECE crypto material and
+  without disturbing ``http_ece`` globally (plan AE1).
+"""
+from __future__ import annotations
+
+from base64 import urlsafe_b64encode
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from custom_components.googlefindmy.Auth.firebase_messaging import fcmpushclient
+from custom_components.googlefindmy.Auth.firebase_messaging.fcmpushclient import (
+    FcmPushClient,
+)
+
+
+def _b64(data: bytes) -> str:
+    """URL-safe base64 string without padding (matches FCM credential format)."""
+    return urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _valid_p256_der() -> bytes:
+    """Generate a real, parseable P-256 PKCS8 DER private key.
+
+    A genuine key lets ``load_der_private_key`` (line 531) succeed for real
+    instead of being shadowed by a patch, keeping the success path honest.
+    """
+    key = ec.generate_private_key(ec.SECP256R1())
+    return key.private_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+
+def test_decrypt_raw_data_returns_decrypted_via_patched_http_decrypt(
+    monkeypatch,
+) -> None:
+    """Valid credentials + patched ``http_decrypt`` -> returns decrypted bytes.
+
+    Exercises lines 540-548: the ``http_decrypt`` call with the assembled
+    keyword arguments and ``return decrypted``. Asserts the keyword contract
+    (``version="aesgcm"``, decoded ``dh``/``salt``/``auth_secret``) the
+    production code passes downstream.
+    """
+    secret_bytes = b"0123456789abcdef"  # 16-byte auth secret
+    credentials = {
+        "keys": {
+            "private": _b64(_valid_p256_der()),
+            "secret": _b64(secret_bytes),
+        }
+    }
+
+    captured: dict[str, object] = {}
+    sentinel = b"DECRYPTED-SENTINEL"
+
+    def fake_http_decrypt(
+        raw_data: bytes,
+        *,
+        salt: bytes,
+        private_key: object,
+        dh: bytes,
+        version: str,
+        auth_secret: bytes,
+    ) -> bytes:
+        captured["raw_data"] = raw_data
+        captured["salt"] = salt
+        captured["private_key"] = private_key
+        captured["dh"] = dh
+        captured["version"] = version
+        captured["auth_secret"] = auth_secret
+        assert version == "aesgcm"
+        return sentinel
+
+    monkeypatch.setattr(fcmpushclient, "http_decrypt", fake_http_decrypt)
+
+    result = FcmPushClient._decrypt_raw_data(
+        credentials,
+        _b64(b"cryptokey"),
+        _b64(b"salt-bytes"),
+        b"rawbody",
+    )
+
+    assert result == sentinel
+    # The keyword contract the SUT assembles for the ECE decryptor.
+    assert captured["raw_data"] == b"rawbody"
+    assert captured["dh"] == b"cryptokey"
+    assert captured["salt"] == b"salt-bytes"
+    assert captured["auth_secret"] == secret_bytes
+    assert captured["version"] == "aesgcm"
+    # The real P-256 key object parsed by load_der_private_key was forwarded.
+    assert isinstance(
+        captured["private_key"], ec.EllipticCurvePrivateKey
+    )

--- a/tests/test_fcmpushclient_handle_data_message.py
+++ b/tests/test_fcmpushclient_handle_data_message.py
@@ -1,0 +1,172 @@
+# tests/test_fcmpushclient_handle_data_message.py
+"""Branch-coverage suite for ``FcmPushClient._handle_data_message``.
+
+Covers the 8 branch groups of the method (plan R2-R8) that no existing test
+exercises: the poison stub mocks ``_handle_message`` away, so this method ran
+~0 % on the unit level before. Each test forces exactly one branch group via
+the additive ``FcmHandleSlim`` builder (composition, real unbound method bound
+to a light container) and a controlled ``_decrypt_raw_data`` return value.
+
+The missing-credentials guard (R4) is exercised with the real production
+states ``None``/``{}`` after the accompanying guard reorder in
+``fcmpushclient.py`` moves the ``if not self.credentials: return`` check ahead
+of the ``["gcm"]["app_id"]`` dereference; the poison stub is left untouched.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from custom_components.googlefindmy.Auth.firebase_messaging.fcmpushclient import (
+    ErrorType,
+)
+from tests.helpers.fcm_handle_stub import (
+    FcmHandleSlim,
+    make_data_message,
+)
+
+
+def _set_decrypt(client: FcmHandleSlim, payload: bytes) -> None:
+    """Pin the instance ``_decrypt_raw_data`` to a fixed ``bytes`` payload.
+
+    Set as an instance attribute (not bound), so the production 4-arg call
+    ``self._decrypt_raw_data(self.credentials, crypto_key, salt, raw_data)``
+    resolves without ``self`` binding.
+    """
+    client._decrypt_raw_data = (  # type: ignore[attr-defined]
+        lambda credentials, crypto_key, salt, raw_data: payload
+    )
+
+
+class TestHandleDataMessage:
+    """One test per branch group of ``_handle_data_message`` (lines 579-655)."""
+
+    def test_deleted_messages_early_return(self) -> None:
+        """``message_type == deleted_messages`` -> early return, no callback (R2)."""
+        client = FcmHandleSlim()
+        msg = make_data_message(message_type="deleted_messages")
+
+        client._handle_data_message(msg)
+
+        assert not client.callback.called
+        assert client.warnings == []
+
+    def test_subtype_mismatch_logs_warning(self) -> None:
+        """``subtype`` != registered app id -> warning, processing continues (R3 True)."""
+        client = FcmHandleSlim()  # credentials gcm.app_id == "APPID"
+        _set_decrypt(client, b'{"ok": true}')
+        msg = make_data_message(subtype="OTHER")
+
+        client._handle_data_message(msg)
+
+        assert any("does not match" in w for w in client.warnings)
+        # Processing continued past the warning to the callback.
+        assert client.callback.called
+
+    def test_subtype_match_no_warning(self) -> None:
+        """``subtype`` == registered app id -> no mismatch warning (R3 False)."""
+        client = FcmHandleSlim()
+        _set_decrypt(client, b'{"ok": true}')
+        msg = make_data_message(subtype="APPID")
+
+        client._handle_data_message(msg)
+
+        assert client.warnings == []
+        assert client.callback.called
+
+    @pytest.mark.parametrize("credentials", [None, {}], ids=["none", "empty"])
+    def test_missing_credentials_guard_returns(
+        self, credentials: Any
+    ) -> None:
+        """Missing credentials (``None`` or ``{}``) -> guard returns early (R4).
+
+        After the production reorder the ``if not self.credentials: return``
+        guard sits *before* the ``["gcm"]["app_id"]`` dereference, so the real
+        production states reach it without raising: ``None`` (un-registered
+        client) and ``{}`` (cleared credentials). No artificial falsy dict is
+        needed. ``_decrypt_raw_data`` is left unset so any accidental call past
+        the guard would raise ``AttributeError`` and fail the test loudly.
+        """
+        client = FcmHandleSlim(credentials=credentials)
+        msg = make_data_message(subtype="APPID")
+
+        client._handle_data_message(msg)
+
+        assert not client.callback.called
+        assert client.warnings == []
+
+    def test_payload_dict_passed_through(self) -> None:
+        """JSON object payload -> forwarded to callback verbatim (R5a)."""
+        client = FcmHandleSlim()
+        _set_decrypt(client, b'{"k": "v"}')
+        msg = make_data_message()
+
+        client._handle_data_message(msg)
+
+        client.callback.assert_called_once()
+        ret_val = client.callback.call_args.args[0]
+        assert ret_val == {"k": "v"}
+
+    def test_payload_non_dict_json_wrapped_raw_json(self) -> None:
+        """Non-object JSON -> warning + ``{"_raw_json": ...}`` wrap (R5b)."""
+        client = FcmHandleSlim()
+        _set_decrypt(client, b"[1, 2, 3]")
+        msg = make_data_message()
+
+        client._handle_data_message(msg)
+
+        assert any("not an object" in w for w in client.warnings)
+        ret_val = client.callback.call_args.args[0]
+        assert ret_val == {"_raw_json": [1, 2, 3]}
+
+    def test_payload_text_not_json_wrapped_raw_text(self) -> None:
+        """Decodable non-JSON text -> ``{"_raw_text": ...}`` (R5c, covers R7)."""
+        client = FcmHandleSlim()
+        _set_decrypt(client, b"plain text")
+        msg = make_data_message()
+
+        client._handle_data_message(msg)
+
+        ret_val = client.callback.call_args.args[0]
+        assert ret_val == {"_raw_text": "plain text"}
+
+    def test_payload_non_utf8_wrapped_raw_bytes(self) -> None:
+        """Non-UTF-8 payload -> ``{"_raw_bytes": hex}`` (R5d, covers R6)."""
+        client = FcmHandleSlim()
+        _set_decrypt(client, b"\xff\xfe")
+        msg = make_data_message()
+
+        client._handle_data_message(msg)
+
+        ret_val = client.callback.call_args.args[0]
+        assert ret_val == {"_raw_bytes": "fffe"}
+
+    def test_callback_success_resets_error_count(self) -> None:
+        """Callback succeeds -> ``_reset_error_count(NOTIFY)``, no increment (R8 success)."""
+        client = FcmHandleSlim()
+        _set_decrypt(client, b'{"k": "v"}')
+        msg = make_data_message()
+
+        client._handle_data_message(msg)
+
+        client._reset_error_count.assert_called_once_with(ErrorType.NOTIFY)
+        assert not client._try_increment_error_count.called
+
+    def test_callback_exception_increments_error_count(self) -> None:
+        """Callback raises -> ``logger.exception`` + increment, no reset (R8 except)."""
+        client = FcmHandleSlim()
+        client.callback.side_effect = RuntimeError("boom")
+        _set_decrypt(client, b'{"k": "v"}')
+        msg = make_data_message()
+
+        client._handle_data_message(msg)
+
+        client._try_increment_error_count.assert_called_once_with(
+            ErrorType.NOTIFY
+        )
+        assert not client._reset_error_count.called
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_fcmpushclient_handle_data_message.py
+++ b/tests/test_fcmpushclient_handle_data_message.py
@@ -19,6 +19,7 @@ from typing import Any
 import pytest
 
 from custom_components.googlefindmy.Auth.firebase_messaging.fcmpushclient import (
+    _MAX_CONSECUTIVE_DECRYPT_FAILURES,
     ErrorType,
 )
 from tests.helpers.fcm_handle_stub import (
@@ -166,6 +167,28 @@ class TestHandleDataMessage:
             ErrorType.NOTIFY
         )
         assert not client._reset_error_count.called
+
+    def test_successful_decrypt_resets_stale_key_failure_counter(self) -> None:
+        """A successful decrypt clears the consecutive-ECE escalation counter.
+
+        Codex follow-up on PR #181: the stale-key counter
+        (``_consecutive_decrypt_failures``) only escalates on an UNINTERRUPTED
+        run of auth-tag failures. A real decrypt success proves the stored keys
+        still match the server, so it must reset the counter -- otherwise an
+        isolated corrupt body weeks apart could eventually force an unwarranted
+        re-registration. The reset is gated on a real decrypt success here (not
+        on ``_handle_message`` generally), so heartbeats cannot reset it.
+        """
+        client = FcmHandleSlim()
+        # One short of the escalation threshold, as a prior run would leave it.
+        client._consecutive_decrypt_failures = _MAX_CONSECUTIVE_DECRYPT_FAILURES - 1
+        _set_decrypt(client, b'{"ok": true}')
+        msg = make_data_message(subtype="APPID")
+
+        client._handle_data_message(msg)
+
+        assert client._consecutive_decrypt_failures == 0
+        assert client.callback.called
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_fcmpushclient_poison_message.py
+++ b/tests/test_fcmpushclient_poison_message.py
@@ -1,0 +1,480 @@
+# tests/test_fcmpushclient_poison_message.py
+"""Defense 1 (CA-CASCADING-FAILURE-001) Inner-Loop-Hardening tests.
+
+Verifies that ``FcmPushClient._listen`` survives per-message decode failures
+(``binascii.Error`` padding faults under Python 3.14 strict mode,
+``RuntimeError`` from ``_app_data_by_key`` key lookups, generic ``ValueError``
+decode errors) by skipping the offending message with a selective-ack instead
+of crashing the worker loop. Also verifies the cred-error propagation contract:
+``CredentialDecryptionError`` (credential material is missing, structurally
+invalid, fails base64 decode, or fails DER private-key parse) is re-raised so
+the supervisor surfaces it via STOPPED. Plain ``ValueError`` without that type
+is treated as per-message poison (selective-ACK + skip).
+
+The Aggregate-Anti-Cascading-Invariant test runs 100 poison messages followed
+by one valid sentinel and proves Defense 1 prevents the supervisor-restart
+cascade reported on Home Assistant Core 2026.6.x.
+"""
+from __future__ import annotations
+
+import binascii
+import logging
+import ssl
+from collections.abc import Iterator
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import http_ece
+from custom_components.googlefindmy.Auth.firebase_messaging.fcmpushclient import (
+    CredentialDecryptionError,
+    FcmPushClientRunState,
+)
+from tests.helpers.fcm_poison_stub import (
+    FcmPushClientSlim,
+    make_poison_data_message,
+    make_valid_data_message,
+)
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _stream_messages(
+    client: FcmPushClientSlim, messages: list[SimpleNamespace]
+) -> AsyncMock:
+    """Build an ``_receive_msg`` mock that yields ``messages`` then stops the loop.
+
+    After the last message the next call returns ``None`` *and* sets
+    ``client.do_listen = False`` so the worker leaves the ``while`` cleanly,
+    just as a real stream end would. Without this the test would hang.
+    """
+    it: Iterator[SimpleNamespace] = iter(messages)
+
+    async def _next() -> SimpleNamespace | None:
+        try:
+            return next(it)
+        except StopIteration:
+            client.do_listen = False
+            return None
+
+    mock = AsyncMock(side_effect=_next)
+    return mock
+
+
+def _make_handle_side_effect(
+    plan: list[BaseException | None],
+    record_handled: list[str] | None = None,
+) -> AsyncMock:
+    """Build a ``_handle_message`` mock that walks ``plan`` per call.
+
+    Each list entry is either an exception instance (raised on that call) or
+    ``None`` (treated as a successful decrypt). If ``record_handled`` is given,
+    successful decrypts append ``msg.persistent_id`` to it.
+    """
+    it = iter(plan)
+
+    async def _impl(msg: SimpleNamespace) -> None:
+        try:
+            step = next(it)
+        except StopIteration as exc:  # plan exhausted -> test bug
+            raise AssertionError(
+                "_handle_message called more often than the plan allows"
+            ) from exc
+        if isinstance(step, BaseException):
+            raise step
+        if record_handled is not None:
+            record_handled.append(msg.persistent_id)
+
+    return AsyncMock(side_effect=_impl)
+
+
+def _outer_catch_was_hit(caplog: pytest.LogCaptureFixture) -> bool:
+    """True iff the ``except Exception`` block at the bottom of ``_listen`` ran.
+
+    Defense 1 must keep the loop from ever reaching that block, so this is the
+    central anti-cascading invariant.
+    """
+    return any(
+        record.levelno == logging.ERROR
+        and "Unknown error in listener" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+# ---------------------------------------------------------------------------
+# Defense 1: per-message decode failures must not stop the worker
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_poison_message_does_not_stop_worker(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A ``binascii.Error`` decrypt failure leaves the outer-catch untouched."""
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-001", kind="padding")
+    client._receive_msg = _stream_messages(client, [msg])
+    client._handle_message = _make_handle_side_effect(
+        [binascii.Error("Incorrect padding")]
+    )
+
+    await client._listen()
+
+    assert not _outer_catch_was_hit(caplog)
+    assert client._send_selective_ack.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_poison_message_triggers_selective_ack(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The skipped message is acknowledged so the FCM server stops resending."""
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-042", kind="padding")
+    client._receive_msg = _stream_messages(client, [msg])
+    client._handle_message = _make_handle_side_effect(
+        [binascii.Error("Incorrect padding")]
+    )
+
+    await client._listen()
+
+    client._send_selective_ack.assert_awaited_once_with("poison-042")
+
+
+@pytest.mark.asyncio
+async def test_poison_message_logs_warning_not_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The skip path emits a rate-limited WARN, never a traceback ERROR."""
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-003", kind="padding")
+    client._receive_msg = _stream_messages(client, [msg])
+    client._handle_message = _make_handle_side_effect(
+        [binascii.Error("Incorrect padding")]
+    )
+
+    await client._listen()
+
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert errors == []
+    assert len(warnings) >= 1
+
+
+@pytest.mark.asyncio
+async def test_poison_message_continues_to_next_message(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """After skipping a poison message the loop processes the next one normally."""
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    poison = make_poison_data_message("poison-004", kind="padding")
+    valid = make_valid_data_message("valid-005")
+    client._receive_msg = _stream_messages(client, [poison, valid])
+    client._handle_message = _make_handle_side_effect(
+        [binascii.Error("Incorrect padding"), None]
+    )
+
+    await client._listen()
+
+    assert client._handle_message.await_count == 2
+    # First call: poison; second call: valid message passed through.
+    second_call_args = client._handle_message.await_args_list[1].args
+    assert second_call_args[0].persistent_id == "valid-005"
+
+
+@pytest.mark.asyncio
+async def test_runtime_error_from_app_data_by_key_caught(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``RuntimeError`` from ``_app_data_by_key`` is treated as poison-class."""
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-006", kind="value")
+    client._receive_msg = _stream_messages(client, [msg])
+    client._handle_message = _make_handle_side_effect(
+        [RuntimeError("couldn't find in app_data crypto-key")]
+    )
+
+    await client._listen()
+
+    assert not _outer_catch_was_hit(caplog)
+    client._send_selective_ack.assert_awaited_once_with("poison-006")
+
+
+@pytest.mark.asyncio
+async def test_ece_exception_from_body_decrypt_caught(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``http_ece.ECEException`` (corrupt body / bad auth tag) is poison-class.
+
+    Regression for Codex Finding 2: ``http_ece.decrypt`` raises
+    ``http_ece.ECEException``, which is a SIBLING of ``ValueError`` under
+    ``Exception`` -- not a subclass. The old ``except (ValueError, ...)``
+    poison arm let it bypass the selective-ACK + skip path entirely, so a
+    single corrupt encrypted body was redelivered forever and could
+    eventually trip the short-run crash cap. It must be treated as
+    per-message poison: ACK + skip, outer-catch untouched.
+    """
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-ece-012", kind="value")
+    client._receive_msg = _stream_messages(client, [msg])
+    client._handle_message = _make_handle_side_effect(
+        [http_ece.ECEException("Decryption error: bad auth tag")]
+    )
+
+    await client._listen()
+
+    assert not _outer_catch_was_hit(caplog)
+    client._send_selective_ack.assert_awaited_once_with("poison-ece-012")
+    # Not a credential fault: no credential signal must be recorded.
+    assert client.credential_error is None
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_kicks_in_after_threshold(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``log_warn_limit`` caps WARN spam at default 5 while still acking each message."""
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    # Default log_warn_limit in FcmPushClientConfig is 5.
+    assert client.config.log_warn_limit == 5
+
+    messages = [
+        make_poison_data_message(f"poison-{i:03d}", kind="padding")
+        for i in range(20)
+    ]
+    client._receive_msg = _stream_messages(client, messages)
+    client._handle_message = _make_handle_side_effect(
+        [binascii.Error("Incorrect padding")] * 20
+    )
+
+    await client._listen()
+
+    # Format string identical for every iteration -> rate limiter applies once.
+    skip_warnings = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING
+        and "Skipping FCM message that failed to decrypt" in r.getMessage()
+    ]
+    assert len(skip_warnings) == 5
+    # All 20 messages must still be acknowledged (rate limit applies to logs only).
+    assert client._send_selective_ack.await_count == 20
+
+
+@pytest.mark.asyncio
+async def test_writer_dead_during_selective_ack_falls_through(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An OSError during ack-send stops the loop so the supervisor reconnects."""
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-007", kind="padding")
+    client._receive_msg = _stream_messages(client, [msg])
+    client._handle_message = _make_handle_side_effect(
+        [binascii.Error("Incorrect padding")]
+    )
+    client._send_selective_ack = AsyncMock(side_effect=OSError("writer half-dead"))
+
+    await client._listen()
+
+    assert client.do_listen is False
+
+
+@pytest.mark.asyncio
+async def test_ssl_error_during_selective_ack_falls_through(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``ssl.SSLError`` is not always an ``OSError`` subclass -> separate catch."""
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-008", kind="padding")
+    client._receive_msg = _stream_messages(client, [msg])
+    client._handle_message = _make_handle_side_effect(
+        [binascii.Error("Incorrect padding")]
+    )
+    client._send_selective_ack = AsyncMock(side_effect=ssl.SSLError("tls dead"))
+
+    await client._listen()
+
+    assert client.do_listen is False
+
+
+@pytest.mark.asyncio
+async def test_connection_error_during_selective_ack_falls_through(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``ConnectionError`` during ack triggers the same shutdown path."""
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-009", kind="padding")
+    client._receive_msg = _stream_messages(client, [msg])
+    client._handle_message = _make_handle_side_effect(
+        [binascii.Error("Incorrect padding")]
+    )
+    client._send_selective_ack = AsyncMock(side_effect=ConnectionError("peer gone"))
+
+    await client._listen()
+
+    assert client.do_listen is False
+
+
+@pytest.mark.asyncio
+async def test_credential_decryption_error_surfaces_distinct_signal(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Cred/key-material errors surface a DISTINCT credential signal.
+
+    CredentialDecryptionError (typed exception) propagates past the
+    per-message poison catch (iter-3 contract: the discriminator is the
+    exception TYPE). It is then caught by ``_listen``'s dedicated
+    ``except CredentialDecryptionError`` arm, which records
+    ``client.credential_error`` and logs a credential-specific error --
+    NOT the generic "Unknown error in listener" outer-catch (Codex
+    Finding 1). The supervisor reads ``credential_error`` to invalidate
+    the bad key material and re-register, instead of restarting against
+    the same poison credentials until the short-run crash cap fires.
+    """
+    caplog.set_level(logging.DEBUG)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-010", kind="value")
+    client._receive_msg = _stream_messages(client, [msg])
+    cred_err = CredentialDecryptionError("Credentials missing FCM key material")
+    client._handle_message = _make_handle_side_effect([cred_err])
+
+    await client._listen()
+
+    # (a) The generic outer ``except Exception`` arm must NOT have run: a
+    #     credential fault is no longer degraded to "Unknown error".
+    assert not _outer_catch_was_hit(caplog)
+    # (b) The distinct credential signal is recorded for the supervisor.
+    assert client.credential_error is cred_err
+    # (c) A credential-specific ERROR is logged (re-registration required).
+    cred_errors = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.ERROR
+        and "credential material is corrupt" in r.getMessage()
+    ]
+    assert len(cred_errors) == 1
+    # (d) Selective-ack must NOT be sent (config fault, not per-message poison).
+    assert client._send_selective_ack.await_count == 0
+    # (e) Worker reaches its terminal state via the finally block.
+    assert client.run_state == FcmPushClientRunState.STOPPED
+    assert client.do_listen is False
+
+
+@pytest.mark.asyncio
+async def test_unmarked_value_error_is_treated_as_per_message_poison(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Plain ValueError without CredentialDecryptionError type = per-message poison.
+
+    Regression for the iter-2 stealth-drop class (CA-CRED-VS-MSG-DECRYPT-001
+    iter-3): under the old string-prefix marker discipline a plain ValueError
+    from upstream libraries (e.g. cryptography.load_der_private_key raising
+    "Could not deserialize key data") would silently drop EVERY incoming
+    message while the listener stayed "healthy". After the iter-3 fix the
+    discriminator is the exception TYPE: untyped ValueError is treated as
+    per-message poison (ACK + skip), only CredentialDecryptionError escalates.
+    """
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-011", kind="value")
+    client._receive_msg = _stream_messages(client, [msg])
+    client._handle_message = _make_handle_side_effect(
+        [ValueError("Could not deserialize key data (the data may be in an "
+                    "incorrect format, the provided password may be incorrect, "
+                    "it may be encrypted with an unsupported algorithm, or it "
+                    "may be an unsupported key type)")]
+    )
+
+    await client._listen()
+
+    # Per-message-poison path: outer catch NOT hit, ACK sent, worker keeps running
+    # until the stream end (do_listen=False from _stream_messages).
+    assert not _outer_catch_was_hit(caplog)
+    client._send_selective_ack.assert_awaited_once_with("poison-011")
+
+
+# ---------------------------------------------------------------------------
+# Aggregate Anti-Cascading-Invariant (Iteration-2-L1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_cascading_on_repeated_poison_messages(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """100 poison messages must not cascade into a supervisor restart storm.
+
+    Proves the bug class as a whole: alternating ``binascii.Error`` and
+    ``RuntimeError`` failures on 100 consecutive messages keep the worker in
+    its operational state, every message is acked in order, and the
+    outer-catch is never entered. A final valid sentinel message is processed
+    normally to show the worker is still responsive after the cascade attempt.
+    """
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+
+    poison_messages = [
+        make_poison_data_message(
+            persistent_id=f"poison-{i:03d}",
+            kind="padding" if i % 2 == 0 else "value",
+        )
+        for i in range(100)
+    ]
+    sentinel = make_valid_data_message("valid-001")
+    messages = poison_messages + [sentinel]
+
+    handled: list[str] = []
+
+    # Per-iteration run_state snapshot via _handle_message side_effect.
+    iter_states: list[FcmPushClientRunState] = []
+
+    plan: list[BaseException | None] = []
+    for i in range(100):
+        if i % 2 == 0:
+            plan.append(binascii.Error("Incorrect padding"))
+        else:
+            plan.append(RuntimeError("couldn't find in app_data crypto-key"))
+    plan.append(None)  # sentinel: valid message passes through
+
+    plan_iter = iter(plan)
+
+    async def _instrumented_handle(msg: SimpleNamespace) -> None:
+        iter_states.append(client.run_state)
+        try:
+            step = next(plan_iter)
+        except StopIteration as exc:
+            raise AssertionError("plan exhausted") from exc
+        if isinstance(step, BaseException):
+            raise step
+        handled.append(msg.persistent_id)
+
+    client._receive_msg = _stream_messages(client, messages)
+    client._handle_message = AsyncMock(side_effect=_instrumented_handle)
+
+    await client._listen()
+
+    # (a) run_state stays STARTED throughout the poison cascade.
+    assert all(state == FcmPushClientRunState.STARTED for state in iter_states), (
+        f"run_state drift during cascade: {iter_states!r}"
+    )
+    # (b) All 100 poison messages acked in order.
+    expected_acks = [f"poison-{i:03d}" for i in range(100)]
+    actual_acks = [call.args[0] for call in client._send_selective_ack.await_args_list]
+    assert actual_acks == expected_acks
+    # (c) Outer catch never entered.
+    assert not _outer_catch_was_hit(caplog)
+    # (d) Sentinel valid message processed normally after the cascade.
+    assert handled == ["valid-001"]

--- a/tests/test_fcmpushclient_poison_message.py
+++ b/tests/test_fcmpushclient_poison_message.py
@@ -28,6 +28,7 @@ import pytest
 
 import http_ece
 from custom_components.googlefindmy.Auth.firebase_messaging.fcmpushclient import (
+    _MAX_CONSECUTIVE_DECRYPT_FAILURES,
     CredentialDecryptionError,
     FcmPushClientRunState,
 )
@@ -478,3 +479,106 @@ async def test_no_cascading_on_repeated_poison_messages(
     assert not _outer_catch_was_hit(caplog)
     # (d) Sentinel valid message processed normally after the cascade.
     assert handled == ["valid-001"]
+
+
+# ---------------------------------------------------------------------------
+# Stale-key escalation (Codex follow-up on PR #181): a sustained run of
+# http_ece.ECEException means the stored DH/auth-secret keys no longer match
+# the server registration. A single ECE stays per-message poison; a run of
+# _MAX_CONSECUTIVE_DECRYPT_FAILURES escalates to CredentialDecryptionError so
+# the supervisor re-registers instead of ACKing every push forever.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sustained_ece_failures_escalate_to_credential_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A run of ``_MAX_CONSECUTIVE_DECRYPT_FAILURES`` ECEs escalates to re-register.
+
+    Codex follow-up on PR #181 ("do not ACK every ECE decrypt failure"): when
+    the stored key material is syntactically valid but stale/mismatched, every
+    push fails the auth tag with ``http_ece.ECEException``. ACKing each one
+    forever leaves ``credential_error`` unset, so the supervisor never
+    re-registers and push updates silently stop. The sustained run must surface
+    as ``CredentialDecryptionError`` instead.
+    """
+    caplog.set_level(logging.ERROR)
+    client = FcmPushClientSlim()
+    n = _MAX_CONSECUTIVE_DECRYPT_FAILURES
+    messages = [make_poison_data_message(f"ece-{i:03d}", kind="value") for i in range(n)]
+    client._receive_msg = _stream_messages(client, messages)
+    client._handle_message = _make_handle_side_effect(
+        [http_ece.ECEException("Decryption error: bad auth tag")] * n
+    )
+
+    await client._listen()
+
+    # (a) The threshold message escalated: a credential signal is recorded so
+    #     the supervisor invalidates the stale tokens and re-registers.
+    assert isinstance(client.credential_error, CredentialDecryptionError)
+    assert "stale" in str(client.credential_error)
+    # (b) It is NOT degraded to the generic "Unknown error" outer-catch.
+    assert not _outer_catch_was_hit(caplog)
+    # (c) The first n-1 were ACK+skipped (poison); the nth escalated instead of
+    #     ACKing, so exactly n-1 selective-acks were sent.
+    assert client._send_selective_ack.await_count == n - 1
+    # (d) Worker reaches its terminal state and stops listening.
+    assert client.run_state == FcmPushClientRunState.STOPPED
+    assert client.do_listen is False
+
+
+@pytest.mark.asyncio
+async def test_ece_failures_below_threshold_stay_poison(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``_MAX_CONSECUTIVE_DECRYPT_FAILURES - 1`` ECEs stay per-message poison.
+
+    Below the escalation threshold the listener must keep ACKing+skipping (a
+    handful of genuinely corrupt bodies is not a credential fault), so the
+    single-ECE poison contract (Codex Finding 2) is preserved for short runs.
+    """
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    n = _MAX_CONSECUTIVE_DECRYPT_FAILURES - 1
+    messages = [make_poison_data_message(f"ece-{i:03d}", kind="value") for i in range(n)]
+    client._receive_msg = _stream_messages(client, messages)
+    client._handle_message = _make_handle_side_effect(
+        [http_ece.ECEException("Decryption error: bad auth tag")] * n
+    )
+
+    await client._listen()
+
+    # No escalation: every message ACK+skipped, no credential signal recorded.
+    assert client.credential_error is None
+    assert client._send_selective_ack.await_count == n
+    assert not _outer_catch_was_hit(caplog)
+
+
+@pytest.mark.asyncio
+async def test_non_ece_poison_never_escalates(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``binascii.Error``/``RuntimeError`` are per-message and never re-register.
+
+    Only ``http_ece.ECEException`` (the auth-tag/body surface, which depends on
+    the stored DH/auth-secret keys) signals stale credentials. Header decode and
+    app_data lookup faults vary per message and must NOT accumulate toward
+    re-registration, even far beyond the ECE escalation threshold.
+    """
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    count = _MAX_CONSECUTIVE_DECRYPT_FAILURES * 3
+    messages = [
+        make_poison_data_message(f"p-{i:03d}", kind="padding") for i in range(count)
+    ]
+    client._receive_msg = _stream_messages(client, messages)
+    client._handle_message = _make_handle_side_effect(
+        [binascii.Error("Incorrect padding")] * count
+    )
+
+    await client._listen()
+
+    assert client.credential_error is None
+    assert client._send_selective_ack.await_count == count
+    assert not _outer_catch_was_hit(caplog)

--- a/tests/test_get_owner_key.py
+++ b/tests/test_get_owner_key.py
@@ -1,0 +1,555 @@
+# tests/test_get_owner_key.py
+"""Coverage + regression-lock tests for ``SpotApi/.../get_owner_key``.
+
+These tests exercise the *real* orchestration of ``async_get_owner_key``,
+``_retrieve_owner_key`` and ``_get_or_generate_user_owner_key_hex`` by mocking
+only their **dependencies** (``async_get_eid_info``, ``async_get_shared_key``,
+``decrypt_owner_key``, ``async_get_username``) — never the SUT functions
+themselves. Mocking the SUT away is exactly the anti-pattern that leaves a
+module at low coverage despite indirect tests (see
+``test_e2ee_token_cache_propagation.py``, which monkeypatches
+``async_get_owner_key`` as a whole).
+
+Each ``RL-*`` test pins one member of the eight bug families distilled from the
+12 fix commits in this file's git history so a regression would fail loudly:
+
+    RL-1   cache=None -> ValueError (multi-account safety; no global facade)
+    RL-2   explicit username= is used, no cache resolution
+    RL-3   without username, cache.get(username_string) is preferred
+    RL-4   empty username cache -> async_get_username(cache=cache) fallback
+    RL-5   no username resolvable -> RuntimeError
+    RL-6   per-user dict cache hit -> returned without retrieval
+    RL-7   legacy non-scoped owner_key -> migrated to owner_key_<user>
+    RL-8   force_refresh=True bypasses cache, retrieves fresh, writes cache
+    RL-9   default path calls async_get_shared_key(cache=, username=)
+    RL-10  SpotApiEmptyResponseError (trailers-only) -> ConfigEntryAuthFailed
+    RL-11  SpotAuthPermanentError -> ConfigEntryAuthFailed (session invalid)
+    RL-12  missing/empty shared_key -> RuntimeError
+    RL-13  missing encryptedOwnerKeyAndMetadata -> RuntimeError
+    RL-14  missing/empty encryptedOwnerKey -> RuntimeError
+    RL-15  InvalidTag from decrypt -> RuntimeError (actionable message)
+    RL-16  decrypted owner_key empty/wrong type -> RuntimeError
+    RL-17  hex happy path -> OwnerKeyInfo(32 bytes, version)
+    RL-18  base64url fallback + self-heal: cache normalized to hex
+    RL-19  invalid format -> cache cleared (user+legacy) + RuntimeError
+    RL-20  wrong length (16 bytes) -> cache cleared + RuntimeError
+    RL-21  raw value not dict-with-key nor str -> cache cleared + RuntimeError
+    RL-22  version normalization (int / digit-string / non-digit-string)
+    RL-23  sync facade inside the event loop -> RuntimeError
+    RL-24  sync facade outside the loop -> asyncio.run(async_get_owner_key)
+"""
+
+from __future__ import annotations
+
+import base64
+from binascii import Error as BinasciiError
+from collections.abc import Awaitable, Callable
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices import (
+    get_owner_key as gok,
+)
+
+OwnerKeyInfo = gok.OwnerKeyInfo
+_user_cache_key = gok._user_cache_key
+_LEGACY_KEY = gok._OWNER_KEY_CACHE_PREFIX
+USERNAME_KEY = gok.username_string
+
+# --- Fixtures (deterministic key material) ---------------------------------
+KEY32 = bytes(range(32))  # exactly 32 bytes (256 bit)
+HEX64 = KEY32.hex()  # 64-char lowercase hex
+B64URL = base64.urlsafe_b64encode(KEY32).decode()  # base64url of the same key
+HEX16 = bytes(range(16)).hex()  # 32 hex chars -> 16 bytes (wrong length)
+OTHER32 = bytes([0xAA] * 32)  # distinct key to prove force-refresh bypass
+ENC = b"encrypted-owner-key-blob"  # opaque; decrypt is mocked
+SHARED = b"\x11" * 32  # non-empty shared key bytes
+
+
+class _FakeCache:
+    """Minimal entry-scoped cache mirroring ``TokenCache`` semantics.
+
+    ``set(key, None)`` clears (pop), matching the production clear-on-error
+    behavior. ``generator_calls`` makes cache-hit vs. cache-miss observable.
+    """
+
+    def __init__(self) -> None:
+        self._data: dict[str, Any] = {}
+        self.generator_calls = 0
+
+    def seed(self, key: str, value: Any) -> None:
+        self._data[key] = value
+
+    async def get(self, key: str) -> Any:
+        return self._data.get(key)
+
+    async def set(self, key: str, value: Any) -> None:
+        if value is None:
+            self._data.pop(key, None)
+            return
+        self._data[key] = value
+
+    async def get_or_set(
+        self, name: str, generator: Callable[[], Awaitable[Any] | Any]
+    ) -> Any:
+        if (existing := self._data.get(name)) is not None:
+            return existing
+        self.generator_calls += 1
+        candidate = generator()
+        if hasattr(candidate, "__await__"):
+            candidate = await candidate
+        self._data[name] = candidate
+        return candidate
+
+
+def _eid_info(*, encrypted: Any = ENC, version: Any = 7) -> SimpleNamespace:
+    """Build a fake EID-info object with the metadata attribute chain."""
+    metadata = SimpleNamespace(
+        encryptedOwnerKey=encrypted, ownerKeyVersion=version
+    )
+    return SimpleNamespace(encryptedOwnerKeyAndMetadata=metadata)
+
+
+def _patch_retrieval(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    eid_info: Any = None,
+    shared: Any = SHARED,
+    decrypted: Any = KEY32,
+    eid_exc: BaseException | None = None,
+) -> dict[str, Any]:
+    """Patch the four module-level dependencies; return mocks for assertions."""
+    if eid_info is None:
+        eid_info = _eid_info()
+    m_eid = AsyncMock(side_effect=eid_exc) if eid_exc else AsyncMock(return_value=eid_info)
+    m_shared = AsyncMock(return_value=shared)
+    m_decrypt = MagicMock(return_value=decrypted)
+    m_username = AsyncMock(return_value="resolved@user.example")
+
+    monkeypatch.setattr(gok, "async_get_eid_info", m_eid)
+    monkeypatch.setattr(gok, "async_get_shared_key", m_shared)
+    monkeypatch.setattr(gok, "decrypt_owner_key", m_decrypt)
+    monkeypatch.setattr(gok, "async_get_username", m_username)
+    return {
+        "eid": m_eid,
+        "shared": m_shared,
+        "decrypt": m_decrypt,
+        "username": m_username,
+    }
+
+
+# === RL-1: multi-account safety (no global facade) =========================
+async def test_rl1_cache_none_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="multi-account safety"):
+        await gok.async_get_owner_key(cache=None)
+
+
+# === RL-2: explicit username= is used, no cache resolution =================
+async def test_rl2_explicit_username_skips_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mocks = _patch_retrieval(monkeypatch)
+    cache = _FakeCache()
+    cache.seed(_user_cache_key("explicit@user.example"), {"key": HEX64, "version": 1})
+
+    info = await gok.async_get_owner_key(cache=cache, username="explicit@user.example")
+
+    assert info.key == KEY32
+    mocks["username"].assert_not_awaited()  # explicit username -> no resolution
+
+
+# === RL-3: cache.get(username_string) preferred ============================
+async def test_rl3_cached_username_preferred(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mocks = _patch_retrieval(monkeypatch)
+    cache = _FakeCache()
+    cache.seed(USERNAME_KEY, "cached@user.example")
+    cache.seed(_user_cache_key("cached@user.example"), {"key": HEX64, "version": 2})
+
+    info = await gok.async_get_owner_key(cache=cache)
+
+    assert info.key == KEY32
+    mocks["username"].assert_not_awaited()  # cached username wins over fallback
+
+
+# === RL-4: fallback to async_get_username(cache=cache) =====================
+async def test_rl4_username_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    mocks = _patch_retrieval(monkeypatch)
+    cache = _FakeCache()
+    cache.seed(_user_cache_key("resolved@user.example"), {"key": HEX64, "version": 1})
+
+    info = await gok.async_get_owner_key(cache=cache)
+
+    assert info.key == KEY32
+    mocks["username"].assert_awaited_once_with(cache=cache)
+
+
+# === RL-5: no username resolvable -> RuntimeError ==========================
+async def test_rl5_unresolvable_username_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_retrieval(monkeypatch)
+    monkeypatch.setattr(gok, "async_get_username", AsyncMock(return_value=None))
+    cache = _FakeCache()
+
+    with pytest.raises(RuntimeError, match="Username is not configured"):
+        await gok.async_get_owner_key(cache=cache)
+
+
+async def test_empty_username_string_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Explicit empty username collapses to None -> RuntimeError (branch)."""
+    _patch_retrieval(monkeypatch)
+    cache = _FakeCache()
+    with pytest.raises(RuntimeError, match="Username is not configured"):
+        await gok.async_get_owner_key(cache=cache, username="")
+
+
+# === RL-6: per-user dict cache hit, no retrieval ===========================
+async def test_rl6_dict_cache_hit_no_retrieval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mocks = _patch_retrieval(monkeypatch)
+    cache = _FakeCache()
+    cache.seed(_user_cache_key("hit@user.example"), {"key": HEX64, "version": 9})
+
+    info = await gok.async_get_owner_key(cache=cache, username="hit@user.example")
+
+    assert info.key == KEY32
+    mocks["eid"].assert_not_awaited()  # served from cache, no server call
+    assert cache.generator_calls == 0
+
+
+# === RL-7: legacy migration within the same cache scope ====================
+async def test_rl7_legacy_dict_migration(monkeypatch: pytest.MonkeyPatch) -> None:
+    mocks = _patch_retrieval(monkeypatch)
+    cache = _FakeCache()
+    user = "legacy@user.example"
+    cache.seed(_LEGACY_KEY, {"key": HEX64, "version": 3})
+
+    info = await gok.async_get_owner_key(cache=cache, username=user)
+
+    assert info.key == KEY32
+    assert info.version == 3
+    # Migrated into the per-user scope, no fresh retrieval.
+    assert cache._data[_user_cache_key(user)] == {"key": HEX64, "version": 3}
+    mocks["eid"].assert_not_awaited()
+
+
+async def test_legacy_str_migration(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Legacy *string* value is migrated to the per-user scope (branch)."""
+    mocks = _patch_retrieval(monkeypatch)
+    cache = _FakeCache()
+    user = "legacystr@user.example"
+    cache.seed(_LEGACY_KEY, HEX64)
+
+    info = await gok.async_get_owner_key(cache=cache, username=user)
+
+    assert info.key == KEY32
+    mocks["eid"].assert_not_awaited()
+
+
+# === RL-8: force_refresh bypasses cache, retrieves fresh, writes cache =====
+async def test_rl8_force_refresh_bypasses_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mocks = _patch_retrieval(monkeypatch)
+    cache = _FakeCache()
+    user = "u@e.co"  # <= 13 chars -> exercises the redaction "else" branch
+    cache.seed(_user_cache_key(user), {"key": OTHER32.hex(), "version": 0})
+
+    info = await gok.async_get_owner_key(
+        cache=cache, username=user, force_refresh=True
+    )
+
+    assert info.key == KEY32  # fresh value, NOT the seeded OTHER32
+    mocks["eid"].assert_awaited_once()  # retrieval happened despite cache hit
+    assert cache._data[_user_cache_key(user)] == {"key": HEX64, "version": 7}
+
+
+# === RL-9: default path forwards username= to async_get_shared_key =========
+async def test_rl9_shared_key_called_with_username(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mocks = _patch_retrieval(monkeypatch)
+    cache = _FakeCache()
+    user = "multi@acct.example.com"  # > 13 chars -> redaction "if" branch
+
+    info = await gok.async_get_owner_key(cache=cache, username=user)
+
+    assert info.key == KEY32
+    mocks["shared"].assert_awaited_once_with(cache=cache, username=user)
+
+
+# === RL-10: trailers-only / empty SPOT body -> ConfigEntryAuthFailed =======
+async def test_rl10_empty_response_maps_to_auth_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_retrieval(
+        monkeypatch, eid_exc=gok.SpotApiEmptyResponseError("trailers only")
+    )
+    cache = _FakeCache()
+
+    with pytest.raises(gok.ConfigEntryAuthFailed):
+        await gok.async_get_owner_key(cache=cache, username="x@acct.example.com")
+
+
+# === RL-11: permanent auth error -> ConfigEntryAuthFailed (session invalid) =
+async def test_rl11_permanent_auth_error_maps_to_auth_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_retrieval(
+        monkeypatch, eid_exc=gok.SpotAuthPermanentError("invalid session")
+    )
+    cache = _FakeCache()
+
+    with pytest.raises(gok.ConfigEntryAuthFailed, match="session invalid"):
+        await gok.async_get_owner_key(cache=cache, username="x@acct.example.com")
+
+
+# === RL-12..RL-16, RL-22: validation/decrypt guards (getter-isolated) ======
+def _getters(*, eid_info: Any = None, shared: Any = SHARED) -> dict[str, Any]:
+    """Build happy-path getter callables to isolate downstream guards.
+
+    Allowed by the plan for RL-12..RL-16/RL-22 (NOT for RL-9/10/11, which must
+    exercise the default branch).
+    """
+    info = _eid_info() if eid_info is None else eid_info
+
+    async def eid_getter() -> Any:
+        return info
+
+    async def shared_getter() -> Any:
+        return shared
+
+    return {"eid_info_getter": eid_getter, "shared_key_getter": shared_getter}
+
+
+async def test_rl12_missing_shared_key_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(gok, "decrypt_owner_key", MagicMock(return_value=KEY32))
+    cache = _FakeCache()
+    with pytest.raises(RuntimeError, match="Shared key is missing"):
+        await gok.async_get_owner_key(
+            cache=cache, username="g@acct.example.com", **_getters(shared=b"")
+        )
+
+
+async def test_rl13_missing_metadata_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(gok, "decrypt_owner_key", MagicMock(return_value=KEY32))
+    cache = _FakeCache()
+    no_md = SimpleNamespace(encryptedOwnerKeyAndMetadata=None)
+    with pytest.raises(RuntimeError, match="encryptedOwnerKeyAndMetadata"):
+        await gok.async_get_owner_key(
+            cache=cache,
+            username="g@acct.example.com",
+            **_getters(eid_info=no_md),
+        )
+
+
+async def test_rl14_missing_encrypted_owner_key_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(gok, "decrypt_owner_key", MagicMock(return_value=KEY32))
+    cache = _FakeCache()
+    with pytest.raises(RuntimeError, match="encryptedOwnerKey"):
+        await gok.async_get_owner_key(
+            cache=cache,
+            username="g@acct.example.com",
+            **_getters(eid_info=_eid_info(encrypted=b"")),
+        )
+
+
+async def test_rl15_invalid_tag_maps_to_runtime_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        gok, "decrypt_owner_key", MagicMock(side_effect=gok.InvalidTag())
+    )
+    cache = _FakeCache()
+    with pytest.raises(RuntimeError, match="InvalidTag"):
+        await gok.async_get_owner_key(
+            cache=cache, username="g@acct.example.com", **_getters()
+        )
+
+
+async def test_rl16_empty_decrypted_key_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(gok, "decrypt_owner_key", MagicMock(return_value=b""))
+    cache = _FakeCache()
+    with pytest.raises(RuntimeError, match="empty or invalid type"):
+        await gok.async_get_owner_key(
+            cache=cache, username="g@acct.example.com", **_getters()
+        )
+
+
+# === RL-17: hex happy path -> OwnerKeyInfo(32 bytes, int version) ==========
+async def test_rl17_hex_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_retrieval(monkeypatch)
+    cache = _FakeCache()
+    cache.seed(_user_cache_key("hex@user.example"), {"key": HEX64, "version": 7})
+
+    info = await gok.async_get_owner_key(cache=cache, username="hex@user.example")
+
+    assert isinstance(info, OwnerKeyInfo)
+    assert info.key == KEY32
+    assert len(info.key) == 32
+    assert info.version == 7
+
+
+# === RL-18: base64url fallback + self-heal to hex ==========================
+async def test_rl18_base64url_self_heal(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_retrieval(monkeypatch)
+    cache = _FakeCache()
+    user = "b64@user.example"
+    cache.seed(_user_cache_key(user), B64URL)  # legacy non-hex string value
+
+    info = await gok.async_get_owner_key(cache=cache, username=user)
+
+    assert info.key == KEY32
+    assert info.version is None
+    # Self-heal: cache normalized to a hex dict for future consistency.
+    assert cache._data[_user_cache_key(user)] == {"key": HEX64, "version": None}
+
+
+# === RL-19: invalid format -> cache cleared (user + legacy) + RuntimeError ==
+async def test_rl19_invalid_format_clears_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_retrieval(monkeypatch)
+    cache = _FakeCache()
+    user = "bad@user.example"
+    cache.seed(_user_cache_key(user), "z")  # neither valid hex nor valid base64
+    cache.seed(_LEGACY_KEY, "z")
+
+    with pytest.raises(RuntimeError, match="Invalid owner_key format"):
+        await gok.async_get_owner_key(cache=cache, username=user)
+
+    assert _user_cache_key(user) not in cache._data
+    assert _LEGACY_KEY not in cache._data
+
+
+# === RL-20: wrong length (16 bytes) -> cache cleared + RuntimeError =========
+async def test_rl20_wrong_length_clears_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_retrieval(monkeypatch)
+    cache = _FakeCache()
+    user = "short@user.example"
+    cache.seed(_user_cache_key(user), HEX16)  # decodes to 16 bytes
+    cache.seed(_LEGACY_KEY, HEX16)
+
+    with pytest.raises(RuntimeError, match="exactly 32 bytes"):
+        await gok.async_get_owner_key(cache=cache, username=user)
+
+    assert _user_cache_key(user) not in cache._data
+    assert _LEGACY_KEY not in cache._data
+
+
+# === RL-21: raw value not dict-with-key nor str -> cleared + RuntimeError ===
+async def test_rl21_non_string_key_value_clears_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_retrieval(monkeypatch)
+    cache = _FakeCache()
+    user = "weird@user.example"
+    cache.seed(_user_cache_key(user), {"key": 12345, "version": 1})  # key not str
+    cache.seed(_LEGACY_KEY, {"key": 12345})
+
+    with pytest.raises(RuntimeError, match="missing or invalid"):
+        await gok.async_get_owner_key(cache=cache, username=user)
+
+    assert _user_cache_key(user) not in cache._data
+    assert _LEGACY_KEY not in cache._data
+
+
+# === RL-22: version normalization (digit-string / non-digit-string) ========
+async def test_rl22_digit_string_version_coerced(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_retrieval(monkeypatch)
+    cache = _FakeCache()
+    cache.seed(_user_cache_key("v@user.example"), {"key": HEX64, "version": "42"})
+
+    info = await gok.async_get_owner_key(cache=cache, username="v@user.example")
+
+    assert info.version == 42  # "42" coerced via .isdigit() -> int()
+
+
+async def test_rl22_non_digit_string_version_is_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_retrieval(monkeypatch)
+    cache = _FakeCache()
+    cache.seed(_user_cache_key("v2@user.example"), {"key": HEX64, "version": "abc"})
+
+    info = await gok.async_get_owner_key(cache=cache, username="v2@user.example")
+
+    assert info.version is None
+
+
+# === RL-23: sync facade inside the event loop -> RuntimeError ==============
+async def test_rl23_sync_facade_in_event_loop_raises() -> None:
+    cache = _FakeCache()
+    with pytest.raises(RuntimeError, match="event loop"):
+        gok.get_owner_key(cache=cache)
+
+
+# === RL-24: sync facade outside the loop -> asyncio.run path ===============
+def test_rl24_sync_facade_outside_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Plain sync test (no running loop) -> exercises asyncio.run branch."""
+    sentinel = OwnerKeyInfo(key=KEY32, version=1)
+    monkeypatch.setattr(gok, "async_get_owner_key", AsyncMock(return_value=sentinel))
+    cache = _FakeCache()
+
+    result = gok.get_owner_key(cache=cache)
+
+    assert result == sentinel
+
+
+# === Helper branch tests: _try_hex =========================================
+def test_try_hex_0x_prefix() -> None:
+    assert gok._try_hex("0x" + HEX64) == KEY32
+
+
+def test_try_hex_whitespace_ignored() -> None:
+    spaced = " ".join(HEX64[i : i + 8] for i in range(0, len(HEX64), 8))
+    assert gok._try_hex(spaced + "\n") == KEY32
+
+
+def test_try_hex_odd_length_padded() -> None:
+    # "abc" -> prepend "0" -> "0abc" -> bytes 0x0a 0xbc
+    assert gok._try_hex("abc") == bytes([0x0A, 0xBC])
+
+
+def test_try_hex_non_hex_raises() -> None:
+    with pytest.raises(BinasciiError):
+        gok._try_hex("nothexvalue")
+
+
+def test_try_hex_empty_string() -> None:
+    assert gok._try_hex("") == b""
+
+
+# === Helper branch tests: _try_base64_like =================================
+def test_try_base64_like_urlsafe() -> None:
+    assert gok._try_base64_like(B64URL) == KEY32
+
+
+def test_try_base64_like_strips_pem_headers() -> None:
+    std_b64 = base64.b64encode(KEY32).decode()
+    pem = f"-----BEGIN KEY-----\n{std_b64}\n-----END KEY-----\n"
+    assert gok._try_base64_like(pem) == KEY32
+
+
+def test_try_base64_like_invalid_raises() -> None:
+    # A single data char can never form a base64 byte -> both decoders raise.
+    with pytest.raises((ValueError, TypeError)):
+        gok._try_base64_like("z")

--- a/tests/test_google_uploader_teardown.py
+++ b/tests/test_google_uploader_teardown.py
@@ -1,0 +1,99 @@
+# tests/test_google_uploader_teardown.py
+"""AP9 (finding 6a): SSL-transport teardown-race classification in the FMDN uploader.
+
+``fmdn_finder/google_uploader._try_grpc_upload`` is the second grpclib stream
+write site that shared the unclassified ``AttributeError`` teardown race fixed in
+``SpotApi/spot_request.py``. These guards pin that it now classifies the asyncio
+``_write_appdata`` race as a ``ValueError`` (the path's existing failure type)
+while re-raising any unrelated ``AttributeError`` as a real bug.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.googlefindmy.fmdn_finder.google_uploader import (
+    _try_grpc_upload,
+)
+from custom_components.googlefindmy.SpotApi import spot_request as spot_request_module
+from custom_components.googlefindmy.SpotApi.spot_grpc_transport import (
+    SpotGrpcTransport,
+)
+
+_SSL_TEARDOWN_MSG = "'NoneType' object has no attribute '_write_appdata'"
+
+
+class _RaisingStream:
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    async def __aenter__(self) -> _RaisingStream:
+        return self
+
+    async def __aexit__(self, *_exc: object) -> bool:
+        return False
+
+    async def send_message(self, _msg: bytes, end: bool = True) -> None:
+        return None
+
+    async def recv_message(self) -> bytes:
+        raise self._exc
+
+
+def _install(monkeypatch: pytest.MonkeyPatch, exc: Exception) -> None:
+    import grpclib.client  # noqa: PLC0415
+
+    class _StubMethod:
+        def __init__(self, *_a: object, **_k: object) -> None:
+            return None
+
+        def open(self, metadata: Any = None, timeout: float | None = None) -> _RaisingStream:
+            return _RaisingStream(exc)
+
+    monkeypatch.setattr(grpclib.client, "UnaryUnaryMethod", _StubMethod)
+    monkeypatch.setattr(
+        spot_request_module,
+        "_pick_auth_token_async",
+        AsyncMock(return_value=("token", "kind", "user")),
+    )
+    monkeypatch.setattr(
+        SpotGrpcTransport, "get_channel", AsyncMock(return_value=object())
+    )
+    monkeypatch.setattr(SpotGrpcTransport, "async_close", AsyncMock())
+
+
+@pytest.mark.asyncio
+async def test_upload_ssl_teardown_error_becomes_value_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The asyncio teardown race is classified as the path's ValueError failure."""
+    _install(monkeypatch, AttributeError(_SSL_TEARDOWN_MSG))
+
+    with pytest.raises(ValueError, match="SSL transport teardown"):
+        await _try_grpc_upload(
+            cache=object(),  # type: ignore[arg-type]
+            payload=b"payload",
+            server="spot-pa.googleapis.com",
+            service="google.internal.spot.v1.SpotService",
+            method="UploadLocationReports",
+        )
+
+
+@pytest.mark.asyncio
+async def test_upload_unrelated_attribute_error_is_reraised(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unrelated AttributeError must not be masked as a connection failure."""
+    _install(monkeypatch, AttributeError("totally unrelated"))
+
+    with pytest.raises(AttributeError, match="totally unrelated"):
+        await _try_grpc_upload(
+            cache=object(),  # type: ignore[arg-type]
+            payload=b"payload",
+            server="spot-pa.googleapis.com",
+            service="google.internal.spot.v1.SpotService",
+            method="UploadLocationReports",
+        )

--- a/tests/test_init_basics.py
+++ b/tests/test_init_basics.py
@@ -1,0 +1,878 @@
+# tests/test_init_basics.py
+"""Basics coverage for :mod:`custom_components.googlefindmy.__init__` (Phase 4 AP-K).
+
+Leverage rationale (CA-COV-HEBEL-001): ``__init__.py`` is the largest module in the
+codebase (~4266 statements, 63 % baseline). Sixteen pure-function helpers are
+currently completely untested. They split into five families, all of which are
+risk-prioritized per Aniche RV-G3 because they execute on every config-entry
+setup/unload cycle:
+
+1. Entity-deduplication scoring (``_compute_entity_score`` /
+   ``_pick_canonical_entity_entry``): silent canonical-entity drift would hide
+   duplicate trackers from the user.
+2. Config-entry health scoring (``_entry_schema_score`` /
+   ``_entry_creation_timestamp``): drives the coalesce algorithm that decides
+   which legacy entry survives a merge.
+3. Platform/subentry identifier helpers (``_feature_name_from_platform`` /
+   ``_subentry_entry_id`` / ``_default_button_subentry_identifier``): mapping
+   bugs would route entities to the wrong subentry and corrupt the device
+   registry.
+4. Domain-data accessors (``_get_fcm_refcount`` / ``_get_nova_refcount`` and
+   their setters / receivers map / ``_sync_receiver_default_entry``): wrong
+   refcount math leaks FCM connections; this is exactly the bug class behind
+   the open memory-leak report on HA Core 2026.6.x.
+5. Button unique-id parsing and tracker identifier candidates
+   (``_normalize_legacy_button_remainder`` / ``_parse_button_unique_id`` /
+   ``_iter_tracker_identifier_candidates`` / ``_normalize_device_identifier``):
+   these power the button-relink heuristics across schema migrations.
+
+Pre-Push-Sweep (testing-strategien.md § 18.1) and CA-MOCK-001 + CA-ASSERTION-
+EMPIRIE-001 enforce that every assertion is grounded against the production
+source ranges (``__init__.py`` lines 564-784, 1053-1092, 2296-2316, 2882-3142,
+3230-3258, 3537-3704). No ``asyncio.run`` is used (CA-ASYNCIO-RUN-001) — all
+async helpers covered here are deliberately exercised through their synchronous
+contract or via ``pytest.mark.asyncio``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+
+from custom_components.googlefindmy import (
+    _DEFAULT_SUBENTRY_IDENTIFIER,
+    ConfigEntrySubentryDefinition,
+    RuntimeData,
+    _ButtonUniqueIdParts,
+    _compute_entity_score,
+    _default_button_subentry_identifier,
+    _entry_creation_timestamp,
+    _entry_schema_score,
+    _feature_name_from_platform,
+    _get_fcm_refcount,
+    _get_fcm_refcounts,
+    _get_nova_refcount,
+    _get_retry_attempts,
+    _get_retry_handles,
+    _iter_tracker_identifier_candidates,
+    _normalize_device_identifier,
+    _normalize_legacy_button_remainder,
+    _parse_button_unique_id,
+    _pick_canonical_entity_entry,
+    _runtime_data,
+    _set_fcm_refcount,
+    _set_nova_refcount,
+    _subentry_entry_id,
+    _sync_receiver_default_entry,
+)
+from custom_components.googlefindmy.const import (
+    CONF_OAUTH_TOKEN,
+    DATA_AAS_TOKEN,
+    DATA_AUTH_METHOD,
+    DATA_SECRET_BUNDLE,
+    DOMAIN,
+    SUBENTRY_TYPE_TRACKER,
+)
+
+# ---------------------------------------------------------------------------
+# Lightweight fakes (no Home Assistant fixtures needed for pure helpers)
+# ---------------------------------------------------------------------------
+
+
+class _FakeStates:
+    """Minimal ``hass.states`` substitute returning a configurable state."""
+
+    def __init__(self, mapping: dict[str, Any] | None = None) -> None:
+        self._mapping = mapping or {}
+
+    def get(self, entity_id: str) -> Any:
+        return self._mapping.get(entity_id)
+
+
+def _make_hass(states: dict[str, Any] | None = None) -> SimpleNamespace:
+    """Return a lightweight ``hass`` double exposing only ``.states.get``."""
+
+    return SimpleNamespace(states=_FakeStates(states or {}))
+
+
+def _make_entity(
+    entity_id: str,
+    *,
+    translation_key: str | None = None,
+    disabled_by: Any = None,
+) -> SimpleNamespace:
+    """Return a registry-entry double covering the score-relevant attributes."""
+
+    return SimpleNamespace(
+        entity_id=entity_id,
+        translation_key=translation_key,
+        disabled_by=disabled_by,
+    )
+
+
+def _make_state(state: str = "on") -> SimpleNamespace:
+    """Return a state object whose ``.state`` attribute is the supplied string."""
+
+    return SimpleNamespace(state=state)
+
+
+def _make_entry(
+    *,
+    data: dict[str, Any] | None = None,
+    options: dict[str, Any] | None = None,
+    created_at: datetime | None = None,
+    updated_at: datetime | None = None,
+    entry_id: str = "entry-1",
+) -> SimpleNamespace:
+    """Return a config-entry double exposing the attributes touched by helpers."""
+
+    return SimpleNamespace(
+        entry_id=entry_id,
+        data=data or {},
+        options=options or {},
+        created_at=created_at,
+        updated_at=updated_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Block A — Entity duplicate scoring (Lines 669-705)
+# ---------------------------------------------------------------------------
+
+
+class TestComputeEntityScoreBasics:
+    """``_compute_entity_score`` weights translation_key (4) + active (3) + state (3)."""
+
+    @pytest.mark.parametrize(
+        ("translation_key", "disabled_by", "state_value", "expected"),
+        [
+            (None, "user", None, 0),  # nothing
+            ("my_key", "user", None, 4),  # translation_key only
+            (None, None, None, 3),  # enabled only
+            (None, "user", "on", 3),  # active state only
+            ("my_key", None, "on", 10),  # full house
+            (
+                "my_key",
+                None,
+                STATE_UNAVAILABLE,
+                7,
+            ),  # state unavailable strips +3
+            (
+                "my_key",
+                None,
+                STATE_UNKNOWN,
+                7,
+            ),  # state unknown strips +3
+            ("my_key", "user", "off", 7),  # disabled strips +3
+        ],
+    )
+    def test_score_components_combine_additively(
+        self,
+        translation_key: str | None,
+        disabled_by: Any,
+        state_value: str | None,
+        expected: int,
+    ) -> None:
+        entity = _make_entity(
+            "sensor.foo",
+            translation_key=translation_key,
+            disabled_by=disabled_by,
+        )
+        states = {"sensor.foo": _make_state(state_value)} if state_value else {}
+        hass = _make_hass(states)
+
+        assert _compute_entity_score(hass, entity) == expected
+
+    def test_missing_state_object_does_not_credit_state_points(self) -> None:
+        """A state lookup miss must not award the +3 active-state points."""
+
+        entity = _make_entity("sensor.never_seen", translation_key="k", disabled_by=None)
+        hass = _make_hass({})  # no state recorded
+
+        # translation_key (+4) + enabled (+3) + no state ⇒ 7
+        assert _compute_entity_score(hass, entity) == 7
+
+
+class TestPickCanonicalEntityEntryBasics:
+    """``_pick_canonical_entity_entry`` keeps the highest-scoring entry; ties stay first."""
+
+    def test_returns_first_when_all_scores_tie(self) -> None:
+        first = _make_entity("sensor.a")
+        second = _make_entity("sensor.b")
+        hass = _make_hass({})
+
+        assert _pick_canonical_entity_entry(hass, [first, second]) is first
+
+    def test_prefers_higher_score(self) -> None:
+        weaker = _make_entity("sensor.weak", disabled_by="user")
+        stronger = _make_entity("sensor.strong", translation_key="k", disabled_by=None)
+        hass = _make_hass({"sensor.strong": _make_state("on")})
+
+        canonical = _pick_canonical_entity_entry(
+            hass, [weaker, stronger]
+        )
+
+        assert canonical is stronger
+
+    def test_single_entry_returns_itself(self) -> None:
+        only = _make_entity("sensor.only", translation_key="k")
+        hass = _make_hass({})
+
+        assert _pick_canonical_entity_entry(hass, [only]) is only
+
+
+# ---------------------------------------------------------------------------
+# Block B — Config-entry health scoring (Lines 751-784)
+# ---------------------------------------------------------------------------
+
+
+class TestEntrySchemaScoreBasics:
+    """``_entry_schema_score`` sums bundle, auth, oauth, aas, and option counts."""
+
+    def test_empty_entry_scores_zero(self) -> None:
+        entry = _make_entry(data={}, options={})
+
+        assert _entry_schema_score(entry) == 0
+
+    def test_mapping_bundle_scores_five(self) -> None:
+        entry = _make_entry(
+            data={DATA_SECRET_BUNDLE: {"secrets_data": {"x": 1}}},
+            options={},
+        )
+
+        # bundle is Mapping ⇒ +5; no auth/oauth/aas ⇒ total 5
+        assert _entry_schema_score(entry) == 5
+
+    def test_non_mapping_bundle_scores_two(self) -> None:
+        entry = _make_entry(
+            data={DATA_SECRET_BUNDLE: "raw-string-bundle"},
+            options={},
+        )
+
+        # bundle not Mapping but truthy ⇒ +2
+        assert _entry_schema_score(entry) == 2
+
+    def test_auth_oauth_aas_all_add(self) -> None:
+        entry = _make_entry(
+            data={
+                DATA_AUTH_METHOD: "secrets_json",
+                CONF_OAUTH_TOKEN: "oauth-x",
+                DATA_AAS_TOKEN: "aas-x",
+            },
+            options={},
+        )
+
+        # +2 (auth) +1 (oauth) +1 (aas) ⇒ 4
+        assert _entry_schema_score(entry) == 4
+
+    def test_options_length_is_added_separately(self) -> None:
+        entry = _make_entry(
+            data={},
+            options={"opt_a": 1, "opt_b": 2, "opt_c": 3},
+        )
+
+        # options-Mapping container scans through all 5 checks (zero), then
+        # len(entry.options) ⇒ 3 is added at the end
+        assert _entry_schema_score(entry) == 3
+
+    def test_non_mapping_data_is_skipped(self) -> None:
+        """Non-Mapping ``entry.data`` must short-circuit without errors."""
+
+        entry = SimpleNamespace(data="not-a-mapping", options={})
+
+        # Only ``len(entry.options) == 0`` remains. Production source line 768
+        # short-circuits the non-Mapping container with ``continue``.
+        assert _entry_schema_score(entry) == 0
+
+
+class TestEntryCreationTimestampBasics:
+    """``_entry_creation_timestamp`` prefers ``created_at`` then ``updated_at`` then inf."""
+
+    def test_created_at_takes_precedence(self) -> None:
+        created = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+        updated = datetime(2030, 1, 1, 12, 0, tzinfo=UTC)
+        entry = _make_entry(created_at=created, updated_at=updated)
+
+        assert _entry_creation_timestamp(entry) == created.timestamp()
+
+    def test_falls_back_to_updated_at_when_created_missing(self) -> None:
+        updated = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+        entry = _make_entry(created_at=None, updated_at=updated)
+
+        assert _entry_creation_timestamp(entry) == updated.timestamp()
+
+    def test_returns_inf_when_no_timestamp_available(self) -> None:
+        entry = _make_entry(created_at=None, updated_at=None)
+
+        assert _entry_creation_timestamp(entry) == float("inf")
+
+    def test_non_datetime_falls_back_to_updated_at(self) -> None:
+        """A string ``created_at`` triggers the ``updated_at`` fallback path."""
+
+        updated = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+        entry = SimpleNamespace(created_at="2026-01-01", updated_at=updated)
+
+        assert _entry_creation_timestamp(entry) == updated.timestamp()
+
+
+# ---------------------------------------------------------------------------
+# Block C — Platform / subentry identifier helpers (Lines 1053-1092, 3537-3548)
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureNameFromPlatformBasics:
+    """``_feature_name_from_platform`` returns the platform's domain string."""
+
+    def test_enum_with_string_value_returns_value(self) -> None:
+        platform = SimpleNamespace(value="sensor")
+
+        assert _feature_name_from_platform(platform) == "sensor"
+
+    def test_strips_dotted_prefix_when_value_missing(self) -> None:
+        class _Stub:
+            def __str__(self) -> str:
+                return "Platform.SENSOR"
+
+        # No ``.value`` attribute (slots not used here, no fallback string).
+        platform = _Stub()
+
+        assert _feature_name_from_platform(platform) == "sensor"
+
+    def test_lowercases_plain_str_repr(self) -> None:
+        class _Stub:
+            def __str__(self) -> str:
+                return "SENSOR"
+
+        assert _feature_name_from_platform(_Stub()) == "sensor"
+
+    def test_non_string_value_is_ignored(self) -> None:
+        """A non-string ``.value`` must fall through to the ``__str__`` path."""
+
+        class _Stub:
+            value = 42
+
+            def __str__(self) -> str:
+                return "domain.button"
+
+        # Value is int, so the first branch is skipped; ``str()`` yields the
+        # dotted form that gets split.
+        assert _feature_name_from_platform(_Stub()) == "button"
+
+
+class TestSubentryEntryIdBasics:
+    """``_subentry_entry_id`` prefers ``subentry_id`` then ``entry_id`` then ``None``."""
+
+    def test_returns_subentry_id_when_present(self) -> None:
+        subentry = SimpleNamespace(subentry_id="sub-1", entry_id="entry-1")
+
+        assert _subentry_entry_id(subentry) == "sub-1"
+
+    def test_falls_back_to_entry_id(self) -> None:
+        subentry = SimpleNamespace(subentry_id=None, entry_id="entry-1")
+
+        assert _subentry_entry_id(subentry) == "entry-1"
+
+    def test_returns_none_when_both_missing(self) -> None:
+        subentry = SimpleNamespace(subentry_id=None, entry_id=None)
+
+        assert _subentry_entry_id(subentry) is None
+
+    def test_empty_string_is_rejected(self) -> None:
+        """Empty strings must not satisfy the truthiness guard."""
+
+        subentry = SimpleNamespace(subentry_id="", entry_id="")
+
+        assert _subentry_entry_id(subentry) is None
+
+    def test_non_string_subentry_id_falls_through(self) -> None:
+        """``isinstance(str)`` check forces the fallback when type mismatches."""
+
+        subentry = SimpleNamespace(subentry_id=42, entry_id="entry-1")
+
+        assert _subentry_entry_id(subentry) == "entry-1"
+
+
+class TestDefaultButtonSubentryIdentifierBasics:
+    """``_default_button_subentry_identifier`` checks button → device_tracker → default."""
+
+    def test_returns_button_identifier_when_present(self) -> None:
+        result = _default_button_subentry_identifier(
+            {"button": "btn-id", "device_tracker": "tracker-id"}
+        )
+
+        assert result == "btn-id"
+
+    def test_falls_back_to_device_tracker(self) -> None:
+        result = _default_button_subentry_identifier(
+            {"device_tracker": "tracker-id"}
+        )
+
+        assert result == "tracker-id"
+
+    def test_returns_module_default_when_both_missing(self) -> None:
+        result = _default_button_subentry_identifier({})
+
+        assert result == _DEFAULT_SUBENTRY_IDENTIFIER
+        assert result == "core_tracking"  # empirisch: __init__.py Z. 4951
+
+    def test_skips_non_string_identifier(self) -> None:
+        """Non-string identifiers must not satisfy the truthy/type guard."""
+
+        result = _default_button_subentry_identifier(
+            {"button": 0, "device_tracker": ""}
+        )
+
+        # Both candidates fail the ``isinstance(str) and identifier`` guard, so
+        # the module-default fires.
+        assert result == _DEFAULT_SUBENTRY_IDENTIFIER
+
+
+# ---------------------------------------------------------------------------
+# Block D — RuntimeData accessors (Lines 2296-2316)
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimeDataAccessorBasics:
+    """``_runtime_data`` / ``_get_retry_attempts`` / ``_get_retry_handles`` route via runtime_data."""
+
+    def _make_runtime(self) -> RuntimeData:
+        # RuntimeData is a slots dataclass — fill required fields with magic
+        # mocks because the helpers under test only touch ``subentry_retry_*``.
+        return RuntimeData(
+            coordinator=MagicMock(),
+            token_cache=MagicMock(),
+            subentry_manager=MagicMock(),
+        )
+
+    def test_runtime_data_returns_runtime_data_object(self) -> None:
+        runtime = self._make_runtime()
+        entry = SimpleNamespace(runtime_data=runtime)
+
+        assert _runtime_data(entry) is runtime
+
+    def test_runtime_data_asserts_on_wrong_type(self) -> None:
+        entry = SimpleNamespace(runtime_data="not a RuntimeData")
+
+        with pytest.raises(AssertionError):
+            _runtime_data(entry)
+
+    def test_get_retry_attempts_returns_runtime_field(self) -> None:
+        runtime = self._make_runtime()
+        runtime.subentry_retry_attempts["sub-1"] = {"forward": 2}
+        entry = SimpleNamespace(runtime_data=runtime)
+
+        attempts = _get_retry_attempts(entry)
+
+        assert attempts is runtime.subentry_retry_attempts
+        assert attempts["sub-1"]["forward"] == 2
+
+    def test_get_retry_handles_returns_runtime_field(self) -> None:
+        runtime = self._make_runtime()
+        handle = MagicMock()
+        runtime.subentry_retry_handles["sub-1"] = handle
+        entry = SimpleNamespace(runtime_data=runtime)
+
+        handles = _get_retry_handles(entry)
+
+        assert handles is runtime.subentry_retry_handles
+        assert handles["sub-1"] is handle
+
+
+# ---------------------------------------------------------------------------
+# Block E — Domain-data accessors: FCM refcounts (Lines 3076-3122)
+# ---------------------------------------------------------------------------
+
+
+class TestFcmRefcountsBasics:
+    """``_get_fcm_refcount`` / ``_set_fcm_refcount`` enforce per-entry refcounting."""
+
+    def test_get_fcm_refcounts_normalizes_invalid_entries(self) -> None:
+        bucket: dict[str, Any] = {
+            "fcm_refcounts": {
+                "good": 3,
+                42: 5,  # non-string key
+                "bad-value": "not-an-int",
+            }
+        }
+
+        refcounts = _get_fcm_refcounts(bucket)  # type: ignore[arg-type]
+
+        # Production source line 3083 keeps only str→int pairs.
+        assert refcounts == {"good": 3}
+        # ``bucket`` is mutated in place to hold the sanitized dict.
+        assert bucket["fcm_refcounts"] is refcounts
+
+    def test_get_fcm_refcounts_creates_dict_when_missing(self) -> None:
+        bucket: dict[str, Any] = {}
+
+        refcounts = _get_fcm_refcounts(bucket)  # type: ignore[arg-type]
+
+        assert refcounts == {}
+        assert bucket["fcm_refcounts"] is refcounts
+
+    def test_get_fcm_refcount_returns_value_for_existing_entry(self) -> None:
+        bucket: dict[str, Any] = {"fcm_refcounts": {"entry-1": 7}}
+
+        assert _get_fcm_refcount(bucket, "entry-1") == 7  # type: ignore[arg-type]
+
+    def test_get_fcm_refcount_returns_zero_for_unknown_entry(self) -> None:
+        bucket: dict[str, Any] = {"fcm_refcounts": {"entry-1": 7}}
+
+        assert _get_fcm_refcount(bucket, "entry-2") == 0  # type: ignore[arg-type]
+
+    def test_set_fcm_refcount_writes_and_mirrors_default(self) -> None:
+        bucket: dict[str, Any] = {}
+
+        _set_fcm_refcount(bucket, "default", 4)  # type: ignore[arg-type]
+
+        assert bucket["fcm_refcounts"]["default"] == 4
+        # default-entry must mirror to legacy ``fcm_refcount`` key (line 3105)
+        assert bucket["fcm_refcount"] == 4
+
+    def test_set_fcm_refcount_does_not_touch_legacy_for_non_default(self) -> None:
+        bucket: dict[str, Any] = {}
+
+        _set_fcm_refcount(bucket, "entry-x", 9)  # type: ignore[arg-type]
+
+        assert bucket["fcm_refcounts"]["entry-x"] == 9
+        assert "fcm_refcount" not in bucket
+
+
+class TestNovaRefcountBasics:
+    """``_get_nova_refcount`` / ``_set_nova_refcount`` cover the Nova session counter."""
+
+    def test_get_returns_stored_int(self) -> None:
+        bucket: dict[str, Any] = {"nova_refcount": 5}
+
+        assert _get_nova_refcount(bucket) == 5  # type: ignore[arg-type]
+
+    def test_get_returns_zero_when_missing(self) -> None:
+        assert _get_nova_refcount({}) == 0  # type: ignore[arg-type]
+
+    def test_get_returns_zero_when_value_is_not_int(self) -> None:
+        """A corrupt non-int stored value must not crash the helper."""
+
+        bucket: dict[str, Any] = {"nova_refcount": "not-an-int"}
+
+        assert _get_nova_refcount(bucket) == 0  # type: ignore[arg-type]
+
+    def test_set_persists_value(self) -> None:
+        bucket: dict[str, Any] = {}
+
+        _set_nova_refcount(bucket, 3)  # type: ignore[arg-type]
+
+        assert bucket["nova_refcount"] == 3
+
+
+class TestSyncReceiverDefaultEntryBasics:
+    """``_sync_receiver_default_entry`` prefers ``set_default_entry_id`` over setattr."""
+
+    def test_uses_setter_when_available(self) -> None:
+        setter = MagicMock()
+        receiver = SimpleNamespace(set_default_entry_id=setter)
+
+        _sync_receiver_default_entry(receiver, "entry-1")
+
+        setter.assert_called_once_with("entry-1")
+
+    def test_falls_back_to_setattr_when_setter_missing(self) -> None:
+        receiver = SimpleNamespace()
+
+        _sync_receiver_default_entry(receiver, "entry-2")
+
+        assert receiver.default_entry_id == "entry-2"
+
+    def test_none_entry_is_silently_ignored(self) -> None:
+        setter = MagicMock()
+        receiver = SimpleNamespace(set_default_entry_id=setter)
+
+        _sync_receiver_default_entry(receiver, None)
+
+        setter.assert_not_called()
+        assert not hasattr(receiver, "default_entry_id")
+
+    def test_setter_exception_falls_through_to_attribute_assignment(self) -> None:
+        """When the setter raises, the helper still writes ``default_entry_id``."""
+
+        setter = MagicMock(side_effect=RuntimeError("boom"))
+        receiver = SimpleNamespace(set_default_entry_id=setter)
+
+        _sync_receiver_default_entry(receiver, "entry-x")
+
+        # Fallback path (line 3138-3141) writes the attribute despite the
+        # setter failure.
+        assert receiver.default_entry_id == "entry-x"
+
+
+# ---------------------------------------------------------------------------
+# Block F — Device identifier normalization (Lines 3230-3258)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeDeviceIdentifierBasics:
+    """``_normalize_device_identifier`` strips entry/subentry prefixes from device IDs."""
+
+    def test_empty_identifier_returns_unchanged(self) -> None:
+        assert _normalize_device_identifier(SimpleNamespace(), "") == ""
+
+    def test_identifier_without_colon_passes_through(self) -> None:
+        device = SimpleNamespace(config_entries=set())
+
+        assert (
+            _normalize_device_identifier(device, "integration_entry-1")
+            == "integration_entry-1"
+        )
+
+    def test_strips_known_config_entry_prefix(self) -> None:
+        device = SimpleNamespace(config_entries={"entry-1"})
+
+        assert (
+            _normalize_device_identifier(
+                device, "entry-1:sub-1:google-device-7"
+            )
+            == "google-device-7"
+        )
+
+    def test_only_last_segment_is_returned(self) -> None:
+        """Without matching config_entries, last segment after split is kept."""
+
+        device = SimpleNamespace(config_entries=set())
+
+        assert (
+            _normalize_device_identifier(device, "foo:bar:baz") == "baz"
+        )
+
+    def test_trailing_empty_segment_falls_back_to_ident(self) -> None:
+        """Empty last segment must not blank the identifier."""
+
+        device = SimpleNamespace(config_entries=set())
+
+        result = _normalize_device_identifier(device, "foo:")
+
+        # ``last or ident`` (production line 3258) returns the original.
+        assert result == "foo:"
+
+
+# ---------------------------------------------------------------------------
+# Block G — Legacy button remainder + button unique-id parser (Lines 3569-3704)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeLegacyButtonRemainderBasics:
+    """``_normalize_legacy_button_remainder`` strips legacy ``tracker_`` prefixes."""
+
+    def test_no_action_suffix_returns_remainder_unchanged(self) -> None:
+        result = _normalize_legacy_button_remainder(
+            "tracker_devicexlocate",
+            identifier="core_tracking",
+            suffixes=("play_sound", "stop_sound", "locate_device"),
+        )
+
+        # No matching suffix ⇒ early return.
+        assert result == "tracker_devicexlocate"
+
+    def test_strips_legacy_tracker_prefix_when_action_matches(self) -> None:
+        result = _normalize_legacy_button_remainder(
+            "tracker_device123play_sound",
+            identifier="core_tracking",
+            suffixes=("play_sound",),
+        )
+
+        # Production line 3594: returns ``{trimmed}{action_suffix}``.
+        assert result == "device123play_sound"
+
+    def test_keeps_remainder_when_payload_already_identifier_prefixed(self) -> None:
+        result = _normalize_legacy_button_remainder(
+            "core_tracking_device123play_sound",
+            identifier="core_tracking",
+            suffixes=("play_sound",),
+        )
+
+        # Payload starts with ``{identifier}_`` ⇒ early return at line 3587.
+        assert result == "core_tracking_device123play_sound"
+
+    def test_legacy_prefix_with_empty_remainder_falls_through(self) -> None:
+        """Trimming to empty must NOT strip the legacy prefix."""
+
+        result = _normalize_legacy_button_remainder(
+            "tracker_play_sound",
+            identifier="core_tracking",
+            suffixes=("play_sound",),
+        )
+
+        # ``trimmed`` ⇒ empty after slicing ``tracker_`` ⇒ break ⇒ original
+        # remainder (line 3597 reachable only when prefix absent or trimmed
+        # empty).
+        assert result == "tracker_play_sound"
+
+
+class TestParseButtonUniqueIdBasics:
+    """``_parse_button_unique_id`` decodes legacy + namespaced unique IDs."""
+
+    def _entry(self) -> SimpleNamespace:
+        return SimpleNamespace(entry_id="entry-1")
+
+    def test_returns_none_for_empty_unique_id(self) -> None:
+        assert (
+            _parse_button_unique_id(
+                "", self._entry(), {}, "core_tracking"
+            )
+            is None
+        )
+
+    def test_returns_none_for_non_string_unique_id(self) -> None:
+        assert (
+            _parse_button_unique_id(
+                42,  # type: ignore[arg-type]
+                self._entry(),
+                {},
+                "core_tracking",
+            )
+            is None
+        )
+
+    def test_full_namespaced_unique_id(self) -> None:
+        """``<domain>_<entry_id>:<sub_id>:<device_id>_<action>`` parses cleanly."""
+
+        unique = f"{DOMAIN}_entry-1:sub-7:device-A_play_sound"
+
+        parts = _parse_button_unique_id(
+            unique, self._entry(), {}, "core_tracking"
+        )
+
+        assert parts is not None
+        assert parts.entry_id == "entry-1"
+        assert parts.subentry_id == "sub-7"
+        assert parts.google_device_id == "device-A"
+        assert parts.action == "play_sound"
+
+    def test_unknown_subentry_falls_back_to_default(self) -> None:
+        """If no subentry token resolves, ``fallback_subentry_id`` is used."""
+
+        unique = f"{DOMAIN}_entry-1_device-B_play_sound"
+
+        parts = _parse_button_unique_id(
+            unique, self._entry(), {}, fallback_subentry_id="core_tracking"
+        )
+
+        assert parts is not None
+        assert parts.subentry_id == "core_tracking"
+        assert parts.google_device_id == "device-B"
+        assert parts.action == "play_sound"
+
+    def test_subentry_map_resolves_known_token(self) -> None:
+        """``subentry_map`` values can match a longest-prefix token in the remainder."""
+
+        unique = f"{DOMAIN}_entry-1_sub-known_device-Z_play_sound"
+        subentry_map = {"button": "sub-known"}
+
+        parts = _parse_button_unique_id(
+            unique, self._entry(), subentry_map, "core_tracking"
+        )
+
+        assert parts is not None
+        assert parts.subentry_id == "sub-known"
+        assert parts.google_device_id == "device-Z"
+
+    def test_mismatched_entry_id_returns_none(self) -> None:
+        """Namespaced unique ID belonging to a different entry must not resolve."""
+
+        unique = f"{DOMAIN}_other-entry:sub-1:device_play_sound"
+
+        result = _parse_button_unique_id(
+            unique, self._entry(), {}, "core_tracking"
+        )
+
+        assert result is None
+
+    def test_unknown_action_falls_back_to_split(self) -> None:
+        """When no known action suffix matches, ``rsplit('_', 1)`` is used."""
+
+        unique = "entry-1_device-X_custom"  # ``custom`` is not in suffix tuple
+
+        parts = _parse_button_unique_id(
+            unique, self._entry(), {}, "core_tracking"
+        )
+
+        assert parts is not None
+        assert parts.action == "custom"
+        assert parts.google_device_id == "device-X"
+
+    def test_returns_none_for_unparseable_unique_id(self) -> None:
+        """Single-token unique IDs without underscore must fail cleanly."""
+
+        result = _parse_button_unique_id(
+            "lonely-token", self._entry(), {}, "core_tracking"
+        )
+
+        assert result is None
+
+    def test_empty_entry_id_returns_none(self) -> None:
+        """``entry.entry_id`` must be a non-empty string (line 3635)."""
+
+        entry = SimpleNamespace(entry_id="")
+
+        result = _parse_button_unique_id(
+            f"{DOMAIN}_entry-1_device_play_sound",
+            entry,
+            {},
+            "core_tracking",
+        )
+
+        assert result is None
+
+
+class TestIterTrackerIdentifierCandidatesBasics:
+    """``_iter_tracker_identifier_candidates`` yields three layered registry lookups."""
+
+    def test_returns_three_layered_candidates(self) -> None:
+        parts = _ButtonUniqueIdParts(
+            entry_id="entry-1",
+            subentry_id="sub-7",
+            google_device_id="device-A",
+            action="play_sound",
+        )
+
+        candidates = _iter_tracker_identifier_candidates(parts)
+
+        assert candidates == (
+            (DOMAIN, "entry-1:sub-7:device-A"),
+            (DOMAIN, "entry-1:device-A"),
+            (DOMAIN, "device-A"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Block H — ConfigEntrySubentryDefinition dataclass smoke (Lines 1095-1108)
+# ---------------------------------------------------------------------------
+
+
+class TestConfigEntrySubentryDefinitionBasics:
+    """``ConfigEntrySubentryDefinition`` defaults to the tracker subentry type."""
+
+    def test_default_subentry_type_is_tracker(self) -> None:
+        definition = ConfigEntrySubentryDefinition(
+            key="trackers",
+            title="Trackers",
+            data={"some": "data"},
+        )
+
+        assert definition.key == "trackers"
+        assert definition.title == "Trackers"
+        assert definition.data == {"some": "data"}
+        assert definition.subentry_type == SUBENTRY_TYPE_TRACKER
+
+    def test_subentry_type_can_be_overridden(self) -> None:
+        definition = ConfigEntrySubentryDefinition(
+            key="trackers",
+            title="Trackers",
+            data={},
+            subentry_type="custom_type",
+        )
+
+        assert definition.subentry_type == "custom_type"

--- a/tests/test_last_seen_sensor_no_map_attributes.py
+++ b/tests/test_last_seen_sensor_no_map_attributes.py
@@ -1,0 +1,205 @@
+# tests/test_last_seen_sensor_no_map_attributes.py
+"""Regression: the last_seen TIMESTAMP sensor must not advertise map coordinates.
+
+Home Assistant auto-plots any entity that carries both ``latitude`` and
+``longitude`` state attributes on the map, regardless of its domain or
+``device_class``. ``GoogleFindMyLastSeenSensor`` is a TIMESTAMP diagnostic sensor
+and previously leaked these two keys through the shared ``_as_ha_attributes``
+helper, producing a spurious third map marker per device (next to the real
+``device_tracker`` and the ``last_location`` tracker).
+
+The fix strips ``latitude``/``longitude`` at the sensor consumer (not at the
+shared helper, which the ``device_tracker`` legitimately relies on). These tests
+encode the HA auto-map rule as an assertion and guard the helper's integrity so a
+future change cannot regress the tracker.
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Callable, Iterable
+from types import SimpleNamespace
+from typing import Any
+
+from custom_components.googlefindmy.const import (
+    SERVICE_SUBENTRY_KEY,
+    TRACKER_SUBENTRY_KEY,
+)
+from tests.helpers.config_entries_stub import make_config_entry
+
+# A decoder row with a real position. ``_as_ha_attributes`` turns this into an
+# attribute dict that includes ``latitude``/``longitude`` (the leak under test)
+# plus the diagnostic keys that must be preserved.
+_POSITION_ROW: dict[str, Any] = {
+    "id": "dev-1",
+    "device_id": "dev-1",
+    "name": "Pixel",
+    "latitude": 52.5200,
+    "longitude": 13.4050,
+    "accuracy": 12.0,
+    "last_seen": 1_700_000_000,
+    "source_label": "Owner",
+    "source_rank": 1,
+}
+
+
+async def _build_last_seen_sensor(
+    row: dict[str, Any] | None,
+    deterministic_config_subentry_id: Callable[[Any, str, str | None], str],
+) -> Any:
+    """Construct a real ``GoogleFindMyLastSeenSensor`` via the platform setup path.
+
+    Mirrors ``tests/test_duplicate_device_entities.py``: a stub coordinator that
+    subclasses the real coordinator, importlib module loading, and
+    ``sensor.async_setup_entry`` to obtain a genuine entity instance. The stub
+    serves ``row`` from ``get_device_location_data_for_subentry`` so the property
+    under test sees a controlled position.
+
+    Authored as a coroutine and awaited directly (never ``asyncio.run()``): HA
+    tests run inside pytest-asyncio's managed loop (``asyncio_mode = "auto"``);
+    a private loop would break the managed-loop fixtures (see ``tests/AGENTS.md``
+    "Async tests").
+    """
+
+    del deterministic_config_subentry_id  # side effect: patches ensure_config_subentry_id
+
+    device_tracker = importlib.import_module(
+        "custom_components.googlefindmy.device_tracker"
+    )
+    sensor = importlib.import_module("custom_components.googlefindmy.sensor")
+
+    class _StubCoordinator(device_tracker.GoogleFindMyCoordinator):
+        def __init__(self, devices: Iterable[dict[str, Any]]) -> None:
+            self._snapshot = list(devices)
+            self._listeners: list[Callable[[], None]] = []
+            self.hass = SimpleNamespace()
+            self.config_entry = make_config_entry(entry_id="entry-id")
+            self.stats: dict[str, int] = {}
+            self._device_names: dict[str, str] = {}
+            self._device_location_data: dict[str, Any] = {}
+            self._device_caps: dict[str, Any] = {}
+            self._present_last_seen: dict[str, float] = {}
+            # Row returned to the sensor property under test (settable per case).
+            self._row: dict[str, Any] | None = row
+
+        def async_add_listener(
+            self, listener: Callable[[], None]
+        ) -> Callable[[], None]:
+            self._listeners.append(listener)
+            return lambda: None
+
+        def stable_subentry_identifier(
+            self, *, key: str | None = None, feature: str | None = None
+        ) -> str:
+            assert key is not None
+            return f"{key}-identifier"
+
+        def get_subentry_metadata(
+            self, *, key: str | None = None, feature: str | None = None
+        ) -> Any:
+            if key is not None:
+                resolved = key
+            elif feature in {"button", "device_tracker", "sensor"}:
+                resolved = TRACKER_SUBENTRY_KEY
+            elif feature == "binary_sensor":
+                resolved = SERVICE_SUBENTRY_KEY
+            else:
+                resolved = TRACKER_SUBENTRY_KEY
+            return SimpleNamespace(key=resolved)
+
+        def get_subentry_snapshot(
+            self, key: str | None = None, *, feature: str | None = None
+        ) -> list[dict[str, Any]]:
+            return list(self._snapshot)
+
+        def get_device_location_data_for_subentry(
+            self, subentry_key: str, device_id: str
+        ) -> dict[str, Any] | None:
+            return self._row
+
+    class _StubConfigEntry:
+        def __init__(self, coordinator: _StubCoordinator) -> None:
+            self.runtime_data = coordinator
+            self.entry_id = "entry-id"
+            self.data: dict[str, Any] = {}
+            self.options: dict[str, Any] = {}
+            self._unsub: list[Callable[[], None]] = []
+
+        def async_on_unload(self, callback: Callable[[], None]) -> None:
+            self._unsub.append(callback)
+
+    coordinator = _StubCoordinator([{"id": "dev-1", "name": "Pixel"}])
+    entry = _StubConfigEntry(coordinator)
+
+    sensor_added: list[list[Any]] = []
+
+    def _capture_sensor(entities, update_before_add: bool = False):
+        sensor_added.append(list(entities))
+
+    await sensor.async_setup_entry(SimpleNamespace(), entry, _capture_sensor)
+
+    last_seen_entities = [
+        entity
+        for batch in sensor_added
+        for entity in batch
+        if isinstance(entity, sensor.GoogleFindMyLastSeenSensor)
+    ]
+    assert len(last_seen_entities) == 1
+    return last_seen_entities[0]
+
+
+async def test_last_seen_sensor_strips_map_coordinates(
+    deterministic_config_subentry_id: Callable[[Any, str, str | None], str],
+) -> None:
+    """A position row must not yield latitude/longitude on the TIMESTAMP sensor."""
+
+    entity = await _build_last_seen_sensor(
+        _POSITION_ROW, deterministic_config_subentry_id
+    )
+    attrs = entity.extra_state_attributes
+
+    assert attrs is not None
+    # The HA auto-map rule: neither key may be present on a non-tracker entity.
+    assert "latitude" not in attrs
+    assert "longitude" not in attrs
+
+
+async def test_last_seen_sensor_keeps_diagnostic_attributes(
+    deterministic_config_subentry_id: Callable[[Any, str, str | None], str],
+) -> None:
+    """Stripping coordinates must not drop the diagnostic attributes."""
+
+    entity = await _build_last_seen_sensor(
+        _POSITION_ROW, deterministic_config_subentry_id
+    )
+    attrs = entity.extra_state_attributes
+
+    assert attrs is not None
+    # Diagnostic keys produced by _as_ha_attributes survive the strip.
+    assert "accuracy_m" in attrs
+    assert "last_seen" in attrs
+
+
+async def test_last_seen_sensor_none_row_yields_none(
+    deterministic_config_subentry_id: Callable[[Any, str, str | None], str],
+) -> None:
+    """No location row → no attributes (unchanged None-guard behavior)."""
+
+    entity = await _build_last_seen_sensor(None, deterministic_config_subentry_id)
+    assert entity.extra_state_attributes is None
+
+
+def test_shared_helper_still_emits_coordinates_for_tracker() -> None:
+    """Helper-integrity gegentest: the shared helper must keep latitude/longitude.
+
+    The fix lives at the sensor consumer, not at ``_as_ha_attributes``. The
+    device_tracker relies on the helper emitting coordinates, so a regression that
+    moved the strip into the helper would break the legitimate tracker marker.
+    """
+
+    main = importlib.import_module("custom_components.googlefindmy.coordinator.main")
+    helper_attrs = main._as_ha_attributes(_POSITION_ROW)
+
+    assert helper_attrs is not None
+    assert helper_attrs["latitude"] == 52.5200
+    assert helper_attrs["longitude"] == 13.4050

--- a/tests/test_lskf_hasher.py
+++ b/tests/test_lskf_hasher.py
@@ -36,9 +36,9 @@ from __future__ import annotations
 import hashlib
 from unittest.mock import MagicMock
 
-import pyscrypt
 import pytest
 
+import pyscrypt
 from custom_components.googlefindmy.KeyBackup import lskf_hasher
 
 # ---------------------------------------------------------------------------

--- a/tests/test_lskf_hasher.py
+++ b/tests/test_lskf_hasher.py
@@ -1,0 +1,210 @@
+# tests/test_lskf_hasher.py
+"""Coverage + parameter lock for ``KeyBackup/lskf_hasher.py``.
+
+This module freezes the contract of the LSKF (Lock Screen Knowledge Factor)
+Scrypt key-derivation surface used to bootstrap the Google Find My key-backup
+chain. The single public derivation (``get_lskf_hash``) is exercised against the
+**real** ``pyscrypt`` library; the SHA-256 wrapper (``hash_pin``) is mocked for
+speed and determinism.
+
+Highlights
+----------
+- ``L-1`` is a *parameter lock* (contract / interop lock), **not** a
+  bug-discriminating regression lock: ``lskf_hasher.py`` has no historical
+  crypto bugfix in its git history. The exact digest for
+  ``(pin="1234", salt=0123…cdef, N=4096, r=8, p=1, dkLen=32)`` is frozen so that
+  any silent change of the Scrypt parameters — which must match Google's
+  server-side LSKF derivation — breaks the test. The expected value is produced
+  by an **independent** oracle (``hashlib.scrypt`` / OpenSSL), never mirrored
+  from ``pyscrypt`` itself, so the test cannot be circular (audit finding F-1).
+- ``CT-1 … CT-8`` cover ``ascii_to_bytes``, ``get_lskf_hash`` and ``hash_pin``
+  (length/type contract, input sensitivity, the SHA-256 envelope, the print
+  side effect, the ``TypeError`` safety net, and the empty-salt example path).
+
+Notes
+-----
+- ``CT-3``/``CT-4`` only assert *input sensitivity* (salt/PIN flow into the
+  digest), so they replace the hardcoded N=4096 with a cheap N=2 via a
+  delegating patch (audit finding F-2) instead of running two expensive 4 MiB
+  ROMix passes each.
+- The ``__main__`` brute-force harness is coverage-excluded (pyproject) and is
+  intentionally not tested (negative protocol N-4).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from unittest.mock import MagicMock
+
+import pyscrypt
+import pytest
+
+from custom_components.googlefindmy.KeyBackup import lskf_hasher
+
+# ---------------------------------------------------------------------------
+# Known-Answer-Test constants (the interop lock) — kept as named symbols so the
+# lock is self-documenting and AP-3 can grep them by string, not line number.
+# ---------------------------------------------------------------------------
+KAT_PIN = "1234"
+KAT_SALT = bytes.fromhex("0123456789abcdef0123456789abcdef")
+KAT_N = 4096
+KAT_R = 8
+KAT_P = 1
+KAT_DKLEN = 32
+
+# Independent oracle digest (hashlib.scrypt / OpenSSL), self-verified 2026-06-09.
+# Re-derivable with:
+#   hashlib.scrypt(b"1234", salt=KAT_SALT, n=4096, r=8, p=1, dklen=32).hex()
+KAT_EXPECTED_DIGEST = "3336935b371bf5698d7ca9cd0d5b98adfce195dd9772e41d327bd093f6151284"
+
+# Real ``pyscrypt.hash`` captured before any monkeypatch, so the delegating
+# fast-hash in CT-3/CT-4 cannot recurse into its own patch.
+_REAL_PYSCRYPT_HASH = pyscrypt.hash
+
+
+# ---------------------------------------------------------------------------
+# CT-1 — ascii_to_bytes
+# ---------------------------------------------------------------------------
+def test_ct1_ascii_to_bytes_roundtrip() -> None:
+    """ASCII strings encode to their byte representation."""
+    assert lskf_hasher.ascii_to_bytes("1234") == b"1234"
+    assert lskf_hasher.ascii_to_bytes("") == b""
+
+
+def test_ct1_ascii_to_bytes_rejects_non_ascii() -> None:
+    """Non-ASCII input (incl. Unicode digits) raises — documented as-is."""
+    with pytest.raises(UnicodeEncodeError):
+        lskf_hasher.ascii_to_bytes("ä")
+    with pytest.raises(UnicodeEncodeError):
+        lskf_hasher.ascii_to_bytes("１")  # noqa: RUF001 — fullwidth digit, intentional
+
+
+# ---------------------------------------------------------------------------
+# L-1 — parameter lock (real pyscrypt, single call, independent oracle)
+# ---------------------------------------------------------------------------
+def test_l1_parameter_lock_kat() -> None:
+    """Freeze the exact Scrypt digest against an independent hashlib oracle.
+
+    A failure here means either the SUT's hardcoded parameters drifted
+    (breaking interop with Google) or ``pyscrypt`` stopped being RFC-7914
+    conformant. The expected value comes from ``hashlib.scrypt``, never from
+    ``pyscrypt`` (no circularity, F-1).
+    """
+    digest = lskf_hasher.get_lskf_hash(KAT_PIN, KAT_SALT)
+
+    assert digest.hex() == KAT_EXPECTED_DIGEST
+    # Independent re-derivation in the same process, for defence in depth.
+    oracle = hashlib.scrypt(
+        KAT_PIN.encode("ascii"),
+        salt=KAT_SALT,
+        n=KAT_N,
+        r=KAT_R,
+        p=KAT_P,
+        dklen=KAT_DKLEN,
+    )
+    assert digest == oracle
+
+
+# ---------------------------------------------------------------------------
+# CT-2 — get_lskf_hash length/type contract (shares the L-1 real call's params)
+# ---------------------------------------------------------------------------
+def test_ct2_get_lskf_hash_length_and_type() -> None:
+    """The derived key is exactly 32 raw bytes."""
+    digest = lskf_hasher.get_lskf_hash(KAT_PIN, KAT_SALT)
+    assert isinstance(digest, bytes)
+    assert len(digest) == KAT_DKLEN
+
+
+# ---------------------------------------------------------------------------
+# CT-3 / CT-4 — input sensitivity with cheap N=2 (delegating patch, F-2)
+# ---------------------------------------------------------------------------
+def _fast_hash(*, password: bytes, salt: bytes, N: int, r: int, p: int, dkLen: int) -> bytes:
+    """Delegate to the real pyscrypt but with cheap params (ignores N=4096/r=8).
+
+    Used only to prove that ``get_lskf_hash`` forwards its inputs into the
+    digest; interop fidelity is covered by L-1, not here.
+    """
+    return _REAL_PYSCRYPT_HASH(password=password, salt=salt, N=2, r=1, p=p, dkLen=dkLen)
+
+
+def test_ct3_salt_changes_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Different salts yield different derived keys (salt flows into the hash)."""
+    monkeypatch.setattr(lskf_hasher.pyscrypt, "hash", _fast_hash)
+    out_a = lskf_hasher.get_lskf_hash(KAT_PIN, b"\x00" * 16)
+    out_b = lskf_hasher.get_lskf_hash(KAT_PIN, b"\xff" * 16)
+    assert out_a != out_b
+
+
+def test_ct4_pin_changes_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Different PINs yield different derived keys (password flows into the hash)."""
+    monkeypatch.setattr(lskf_hasher.pyscrypt, "hash", _fast_hash)
+    out_a = lskf_hasher.get_lskf_hash("1234", KAT_SALT)
+    out_b = lskf_hasher.get_lskf_hash("5678", KAT_SALT)
+    assert out_a != out_b
+
+
+# ---------------------------------------------------------------------------
+# CT-5 / CT-6 / CT-7 / CT-8 — hash_pin (pyscrypt mocked for speed/determinism)
+# ---------------------------------------------------------------------------
+def test_ct5_hash_pin_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``hash_pin`` returns ``(pin, sha256(lskf_hash).hexdigest())``."""
+    fixed = b"\x01" * 32
+    monkeypatch.setattr(lskf_hasher.pyscrypt, "hash", MagicMock(return_value=fixed))
+    monkeypatch.setattr(
+        lskf_hasher, "get_example_data", lambda key: "00112233445566778899aabbccddeeff"
+    )
+
+    pin, hash_hex = lskf_hasher.hash_pin("4242")
+
+    assert pin == "4242"
+    assert hash_hex == hashlib.sha256(fixed).hexdigest()
+
+
+def test_ct6_hash_pin_prints_pin_and_hash(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``hash_pin`` prints both the PIN and the hash (documents VA-LSKF-3)."""
+    monkeypatch.setattr(lskf_hasher.pyscrypt, "hash", MagicMock(return_value=b"\x02" * 32))
+    monkeypatch.setattr(
+        lskf_hasher, "get_example_data", lambda key: "00112233445566778899aabbccddeeff"
+    )
+
+    lskf_hasher.hash_pin("4242")
+
+    captured = capsys.readouterr().out
+    assert "PIN:" in captured
+    assert "Hash:" in captured
+    assert "4242" in captured
+
+
+def test_ct7_hash_pin_type_safety_net(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-bytes return from the derivation trips the ``TypeError`` guard."""
+    monkeypatch.setattr(lskf_hasher.pyscrypt, "hash", MagicMock(return_value="not-bytes"))
+    monkeypatch.setattr(
+        lskf_hasher, "get_example_data", lambda key: "00112233445566778899aabbccddeeff"
+    )
+
+    with pytest.raises(TypeError, match="get_lskf_hash must return bytes"):
+        lskf_hasher.hash_pin("4242")
+
+
+def test_ct8_hash_pin_empty_salt_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing ``sample_pin_salt`` yields an empty salt without crashing (VA-LSKF-4).
+
+    ``get_example_data("sample_pin_salt")`` is not in the ``_EXAMPLES`` dict, so
+    it returns ``""`` → ``unhexlify("") == b""`` → the derivation runs with an
+    empty salt. This freezes that real (demo-only) behaviour.
+    """
+    fake_hash = MagicMock(return_value=b"\x03" * 32)
+    monkeypatch.setattr(lskf_hasher.pyscrypt, "hash", fake_hash)
+    # Use the REAL provider: 'sample_pin_salt' is genuinely absent -> "".
+    from custom_components.googlefindmy import example_data_provider
+
+    assert example_data_provider.get_example_data("sample_pin_salt") == ""
+
+    pin, hash_hex = lskf_hasher.hash_pin("4242")
+
+    assert pin == "4242"
+    assert hash_hex == hashlib.sha256(b"\x03" * 32).hexdigest()
+    # The derivation was invoked with an empty salt (proves the silent default).
+    assert fake_hash.call_args.kwargs["salt"] == b""

--- a/tests/test_nova_request.py
+++ b/tests/test_nova_request.py
@@ -9,6 +9,7 @@ import time
 from collections.abc import Awaitable, Callable
 from typing import Any
 
+import aiohttp
 import pytest
 
 MAX_INITIAL_CALLS = 2
@@ -30,6 +31,8 @@ from custom_components.googlefindmy.NovaApi.ListDevices.nbe_list_devices import 
 from custom_components.googlefindmy.NovaApi.nova_request import (
     AsyncTTLPolicy,
     NovaAuthError,
+    NovaError,
+    NovaHTTPError,
     async_nova_request,
     register_cache_provider,
     unregister_cache_provider,
@@ -104,7 +107,7 @@ class _StubCache:
         return result
 
 
-def test_async_nova_request_returns_auth_error_on_repeated_401(
+async def test_async_nova_request_returns_auth_error_on_repeated_401(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Ensure NovaAuthError is raised instead of NameError on 401 responses.
@@ -163,14 +166,14 @@ def test_async_nova_request_returns_auth_error_on_repeated_401(
         )
 
     with pytest.raises(NovaAuthError) as err:
-        asyncio.run(_exercise())
+        await _exercise()
 
     assert err.value.status == 401
     assert isinstance(err.value.detail, str)
     assert "Unauthorized" in err.value.detail
 
 
-def test_async_nova_request_refreshes_token_after_initial_401(
+async def test_async_nova_request_refreshes_token_after_initial_401(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A 401 triggers an ADM refresh and retries with the rotated token."""
@@ -229,7 +232,7 @@ def test_async_nova_request_refreshes_token_after_initial_401(
         final_aas = await cache.get(DATA_AAS_TOKEN)
         return result, final_aas
 
-    result, final_aas = asyncio.run(_exercise())
+    result, final_aas = await _exercise()
 
     assert result == "baadf00d"
     assert final_aas == "aas-original"
@@ -277,7 +280,7 @@ class _CoordinatedSession:
         return _DummyResponse(status, body)
 
 
-def test_async_nova_request_reuses_cached_token_after_recent_refresh(
+async def test_async_nova_request_reuses_cached_token_after_recent_refresh(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Overlapping 401 retries reuse the freshly cached ADM token."""
@@ -342,7 +345,7 @@ def test_async_nova_request_reuses_cached_token_after_recent_refresh(
         results = await asyncio.gather(*tasks)
         return results, session.calls, refresh_calls
 
-    results, calls, refreshes = asyncio.run(_exercise())
+    results, calls, refreshes = await _exercise()
 
     assert results == ["6f6b", "6f6b"]
     # With the pre-request gate, only ONE refresh should occur.
@@ -361,7 +364,7 @@ def test_async_nova_request_reuses_cached_token_after_recent_refresh(
     assert successful_auths == ["Bearer refreshed-token", "Bearer refreshed-token"]
 
 
-def test_device_list_namespace_override_does_not_double_prefix(
+async def test_device_list_namespace_override_does_not_double_prefix(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Namespace-aware overrides must not prefix keys twice when 401 triggers a refresh."""
@@ -421,7 +424,7 @@ def test_device_list_namespace_override_does_not_double_prefix(
             namespace=namespace,
         )
 
-    result_hex = asyncio.run(_exercise())
+    result_hex = await _exercise()
 
     assert result_hex == "deadbeef"
     double_prefixed = [
@@ -433,7 +436,7 @@ def test_device_list_namespace_override_does_not_double_prefix(
     assert f"{namespace}:adm_token_issued_at_{username}" in set_keys
 
 
-def test_async_ttl_policy_refresh_preserves_existing_startup_probe() -> None:  # noqa: PLR0915
+async def test_async_ttl_policy_refresh_preserves_existing_startup_probe() -> None:  # noqa: PLR0915
     """401 refresh clears stale token keys without resetting startup probe counters."""
 
     async def _run() -> None:  # noqa: PLR0915
@@ -513,10 +516,10 @@ def test_async_ttl_policy_refresh_preserves_existing_startup_probe() -> None:  #
         finally:
             await cache.close()
 
-    asyncio.run(_run())
+    await _run()
 
 
-def test_async_ttl_policy_clears_namespaced_aas_token_on_invalid_refresh() -> None:
+async def test_async_ttl_policy_clears_namespaced_aas_token_on_invalid_refresh() -> None:
     """Invalid AAS tokens remove both namespaced and bare cache keys."""
 
     async def _run() -> None:
@@ -555,10 +558,10 @@ def test_async_ttl_policy_clears_namespaced_aas_token_on_invalid_refresh() -> No
         finally:
             await cache.close()
 
-    asyncio.run(_run())
+    await _run()
 
 
-def test_async_nova_request_fetches_token_when_not_supplied(
+async def test_async_nova_request_fetches_token_when_not_supplied(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Nova should resolve an ADM token when `token` kwarg is omitted."""
@@ -599,13 +602,405 @@ def test_async_nova_request_fetches_token_when_not_supplied(
             session=session,
         )
 
-    result = asyncio.run(_exercise())
+    result = await _exercise()
 
     assert result == "1020"
     assert calls and calls[0]["username"] == "user@example.com"
     assert session.calls
     headers = session.calls[0]["kwargs"].get("headers", {})
     assert headers.get("Authorization") == "Bearer resolved-token"
+
+
+async def test_async_nova_request_returns_hex_only_on_http_200(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-None return is produced exclusively by an HTTP 200.
+
+    The return contract IS the acceptance signal: ``async_nova_request`` returns
+    the hex body only when Google answers 200, and raises on every other outcome
+    (see the rejection/connection regressions below). That is what lets
+    ``api.async_play_sound`` derive "command accepted" — and therefore "keep the
+    cancel key" — purely from "the submitter returned", with no out-of-band
+    dispatch signal to keep in sync. See IRR-CA-CANCEL-KEY-ON-SUCCESS-ONLY.
+    """
+
+    cache = _StubCache()
+    session = _DummySession([_DummyResponse(200, b"\x10\x20")])
+
+    async def _fake_get_adm_token(
+        username: str | None = None, *, retries: int = 2, backoff: float = 1.0, cache: Any
+    ) -> str:
+        return "resolved-token"
+
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.NovaApi.nova_request.async_get_adm_token_api",
+        _fake_get_adm_token,
+    )
+
+    async def _exercise() -> str:
+        return await async_nova_request(
+            "testScope",
+            "00",
+            username="user@example.com",
+            cache=cache,
+            session=session,
+        )
+
+    result = await _exercise()
+
+    assert result == "1020"  # acceptance signal: a value came back from a 200
+    assert len(session.calls) == 1
+
+
+async def test_async_nova_request_raises_before_wire_on_pre_dispatch_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pre-dispatch failure raises and never returns a value.
+
+    An invalid hex payload is rejected after token resolution but before the
+    POST loop, so nothing is sent and the function raises rather than returns.
+    The caller therefore never sees a result for an unsent command and keeps a
+    previous play's cancel key intact.
+    """
+
+    cache = _StubCache()
+    session = _DummySession([_DummyResponse(200, b"\x10\x20")])
+
+    async def _fake_get_adm_token(
+        username: str | None = None, *, retries: int = 2, backoff: float = 1.0, cache: Any
+    ) -> str:
+        return "resolved-token"
+
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.NovaApi.nova_request.async_get_adm_token_api",
+        _fake_get_adm_token,
+    )
+
+    async def _exercise() -> str:
+        return await async_nova_request(
+            "testScope",
+            "zz",  # invalid hex -> ValueError before the POST loop (pre-dispatch)
+            username="user@example.com",
+            cache=cache,
+            session=session,
+        )
+
+    with pytest.raises(ValueError, match="Invalid hex payload"):
+        await _exercise()
+
+    assert session.calls == []  # nothing was sent
+
+
+async def test_async_nova_request_raises_on_connection_setup_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A connect-phase failure raises NovaError flagged as *not* dispatched.
+
+    A connect-phase timeout (``ConnectionTimeoutError``) raises the moment the
+    ``async with session.post(...)`` context is *entered*, after token and
+    payload resolution but before a single byte reaches the wire. The retry
+    handler classifies it as pre-dispatch and re-raises a ``NovaError`` with
+    ``dispatched is False``, so ``api.async_play_sound`` returns ``(False,
+    None)`` and the coordinator keeps the still-valid cancel key of a previous
+    ring intact (it can never have started a new ring).
+    """
+
+    class _ConnFailingResponse:
+        """Context manager that raises on entry, mimicking a connect failure."""
+
+        async def __aenter__(self) -> Any:
+            raise aiohttp.ConnectionTimeoutError
+
+        async def __aexit__(self, *_exc: object) -> None:
+            return None
+
+    class _ConnFailingSession:
+        """Session stub whose every POST fails during connection setup."""
+
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+
+        def post(self, *_args: object, **_kwargs: object) -> _ConnFailingResponse:
+            # post() merely builds the context manager; the failure surfaces on
+            # __aenter__, exactly like aiohttp's real connection acquisition.
+            self.calls.append({"args": _args, "kwargs": _kwargs})
+            return _ConnFailingResponse()
+
+    cache = _StubCache()
+    session = _ConnFailingSession()
+
+    async def _fake_get_adm_token(
+        username: str | None = None, *, retries: int = 2, backoff: float = 1.0, cache: Any
+    ) -> str:
+        return "resolved-token"
+
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.NovaApi.nova_request.async_get_adm_token_api",
+        _fake_get_adm_token,
+    )
+
+    # Collapse the retry backoff so the test stays fast across NOVA_MAX_RETRIES.
+    async def _instant_sleep(_: float) -> None:
+        return None
+
+    monkeypatch.setattr("asyncio.sleep", _instant_sleep)
+
+    async def _exercise() -> str:
+        return await async_nova_request(
+            "testScope",
+            "00",
+            username="user@example.com",
+            cache=cache,
+            session=session,
+        )
+
+    # Connection errors are retried, then surface as NovaError once exhausted.
+    with pytest.raises(NovaError) as exc_info:
+        await _exercise()
+
+    # Pre-dispatch: the request never reached the wire, so the cancel key must
+    # be dropped (no new ring could have started).
+    assert exc_info.value.dispatched is False
+    assert session.calls  # post() *was* attempted (and retried), only entry failed
+
+
+async def test_async_nova_request_marks_read_phase_failure_dispatched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A post-send read failure raises NovaError flagged as *dispatched*.
+
+    The ``async with session.post(...)`` context is entered (the server
+    responded with headers), but reading the body raises ``ServerDisconnectedError``.
+    The request therefore reached the wire and may have started a ring, so the
+    retry handler re-raises a ``NovaError`` with ``dispatched is True`` and
+    ``api.async_play_sound`` keeps the cancel key for a later Stop.
+    """
+
+    class _ReadFailingResponse:
+        """Response whose body read fails after the context is entered."""
+
+        def __init__(self) -> None:
+            self.status = 200
+            self.headers: dict[str, str] = {}
+
+        async def read(self) -> bytes:
+            raise aiohttp.ServerDisconnectedError("peer closed during read")
+
+        async def __aenter__(self) -> _ReadFailingResponse:
+            return self
+
+        async def __aexit__(self, *_exc: object) -> None:
+            return None
+
+    class _ReadFailingSession:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+
+        def post(self, *_args: object, **_kwargs: object) -> _ReadFailingResponse:
+            self.calls.append({"args": _args, "kwargs": _kwargs})
+            return _ReadFailingResponse()
+
+    cache = _StubCache()
+    session = _ReadFailingSession()
+
+    async def _fake_get_adm_token(
+        username: str | None = None, *, retries: int = 2, backoff: float = 1.0, cache: Any
+    ) -> str:
+        return "resolved-token"
+
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.NovaApi.nova_request.async_get_adm_token_api",
+        _fake_get_adm_token,
+    )
+
+    # Collapse the retry backoff so the test stays fast across NOVA_MAX_RETRIES.
+    async def _instant_sleep(_: float) -> None:
+        return None
+
+    monkeypatch.setattr("asyncio.sleep", _instant_sleep)
+
+    async def _exercise() -> str:
+        return await async_nova_request(
+            "testScope",
+            "00",
+            username="user@example.com",
+            cache=cache,
+            session=session,
+        )
+
+    # Read-phase errors are retried, then surface as a *dispatched* NovaError.
+    with pytest.raises(NovaError) as exc_info:
+        await _exercise()
+
+    assert exc_info.value.dispatched is True
+    assert session.calls  # the request reached the wire on every attempt
+
+
+async def test_async_nova_request_latches_dispatch_across_mixed_retry_sequence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dispatch latches across the whole retry sequence, not the last attempt.
+
+    Regression for the Codex iter-6 finding: when an *early* attempt reaches the
+    wire and fails post-send (``ServerDisconnectedError`` during read), a ring
+    may already be active. If a *later* retry then fails pre-connect
+    (``ConnectionTimeoutError``), deriving ``dispatched`` from the final
+    exception alone would wrongly report ``False`` and drop the cancel key,
+    leaving the device ringing. The retry handler must therefore latch
+    ``dispatched is True`` the moment any attempt reaches the wire and keep it
+    set regardless of how a subsequent attempt fails.
+    """
+
+    class _ReadFailingCtx:
+        """Post-send failure: context enters, body read raises."""
+
+        def __init__(self) -> None:
+            self.status = 200
+            self.headers: dict[str, str] = {}
+
+        async def read(self) -> bytes:
+            raise aiohttp.ServerDisconnectedError("peer closed during read")
+
+        async def __aenter__(self) -> _ReadFailingCtx:
+            return self
+
+        async def __aexit__(self, *_exc: object) -> None:
+            return None
+
+    class _ConnFailingCtx:
+        """Pre-connect failure: context raises on entry."""
+
+        async def __aenter__(self) -> Any:
+            raise aiohttp.ConnectionTimeoutError
+
+        async def __aexit__(self, *_exc: object) -> None:
+            return None
+
+    class _MixedSession:
+        """First POST fails post-send, every later POST fails pre-connect."""
+
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+
+        def post(self, *_args: object, **_kwargs: object) -> Any:
+            self.calls.append({"args": _args, "kwargs": _kwargs})
+            # Attempt 1 reaches the wire (read failure); the rest never connect.
+            return _ReadFailingCtx() if len(self.calls) == 1 else _ConnFailingCtx()
+
+    cache = _StubCache()
+    session = _MixedSession()
+
+    async def _fake_get_adm_token(
+        username: str | None = None, *, retries: int = 2, backoff: float = 1.0, cache: Any
+    ) -> str:
+        return "resolved-token"
+
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.NovaApi.nova_request.async_get_adm_token_api",
+        _fake_get_adm_token,
+    )
+
+    async def _instant_sleep(_: float) -> None:
+        return None
+
+    monkeypatch.setattr("asyncio.sleep", _instant_sleep)
+
+    async def _exercise() -> str:
+        return await async_nova_request(
+            "testScope",
+            "00",
+            username="user@example.com",
+            cache=cache,
+            session=session,
+        )
+
+    with pytest.raises(NovaError) as exc_info:
+        await _exercise()
+
+    # The *final* attempt failed pre-connect, but an earlier attempt reached the
+    # wire: dispatch must remain latched so the cancel key is preserved.
+    assert exc_info.value.dispatched is True
+    assert len(session.calls) > 1  # the mixed sequence actually retried
+
+
+async def test_async_nova_request_latches_dispatch_across_http_status_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dispatch latches across a sequence that *ends* on an HTTP status.
+
+    Regression for the Codex iter-8 finding: an early attempt reaches the wire
+    and fails post-send (``ServerDisconnectedError`` during read), latching
+    dispatch — a ring may already be active. If the retries are then exhausted
+    by repeated HTTP 503s, the sequence raises ``NovaHTTPError``. That exit must
+    still report ``dispatched is True`` so ``api.async_play_sound`` keeps the
+    cancel key; otherwise a later Stop cannot target the ringing device. The
+    retry-loop choke point stamps the latch onto *every* error leaving the loop,
+    HTTP-status exits included — not only the wrapped network failure (which the
+    sibling test above already covers).
+    """
+
+    class _ReadFailingCtx:
+        """Post-send failure: context enters, body read raises."""
+
+        def __init__(self) -> None:
+            self.status = 200
+            self.headers: dict[str, str] = {}
+
+        async def read(self) -> bytes:
+            raise aiohttp.ServerDisconnectedError("peer closed during read")
+
+        async def __aenter__(self) -> _ReadFailingCtx:
+            return self
+
+        async def __aexit__(self, *_exc: object) -> None:
+            return None
+
+    class _WireThenHttpSession:
+        """Attempt 1 fails post-send; every later attempt returns HTTP 503."""
+
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+
+        def post(self, *_args: object, **_kwargs: object) -> Any:
+            self.calls.append({"args": _args, "kwargs": _kwargs})
+            if len(self.calls) == 1:
+                return _ReadFailingCtx()
+            return _DummyResponse(503, b"")
+
+    cache = _StubCache()
+    session = _WireThenHttpSession()
+
+    async def _fake_get_adm_token(
+        username: str | None = None, *, retries: int = 2, backoff: float = 1.0, cache: Any
+    ) -> str:
+        return "resolved-token"
+
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.NovaApi.nova_request.async_get_adm_token_api",
+        _fake_get_adm_token,
+    )
+
+    async def _instant_sleep(_: float) -> None:
+        return None
+
+    monkeypatch.setattr("asyncio.sleep", _instant_sleep)
+
+    async def _exercise() -> str:
+        return await async_nova_request(
+            "testScope",
+            "00",
+            username="user@example.com",
+            cache=cache,
+            session=session,
+        )
+
+    with pytest.raises(NovaHTTPError) as exc_info:
+        await _exercise()
+
+    # The sequence ended on an HTTP 503, but an earlier attempt reached the wire:
+    # dispatch must remain latched so the cancel key is preserved.
+    assert exc_info.value.dispatched is True
+    assert len(session.calls) > 1  # the wire-reaching attempt actually retried
 
 
 async def test_async_nova_request_uses_central_total_timeout(
@@ -651,7 +1046,7 @@ async def test_async_nova_request_uses_central_total_timeout(
     assert timeout.total == NOVA_REQUEST_TOTAL_TIMEOUT_S
 
 
-def test_async_nova_request_uses_registered_cache_provider(
+async def test_async_nova_request_uses_registered_cache_provider(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Provider fallback supplies cache when async_nova_request cache arg is omitted."""
@@ -695,7 +1090,7 @@ def test_async_nova_request_uses_registered_cache_provider(
         finally:
             unregister_cache_provider()
 
-    result = asyncio.run(_exercise())
+    result = await _exercise()
 
     assert result == "0102"
     assert calls and calls[0]["cache"] is cache
@@ -704,17 +1099,17 @@ def test_async_nova_request_uses_registered_cache_provider(
     assert headers.get("Authorization") == "Bearer provider-token"
 
 
-def test_async_nova_request_requires_cache_when_provider_missing() -> None:
+async def test_async_nova_request_requires_cache_when_provider_missing() -> None:
     """Missing cache and provider should raise before issuing the request."""
 
     async def _exercise() -> None:
         with pytest.raises(ValueError):
             await async_nova_request("testScope", "00", username="user@example.com")
 
-    asyncio.run(_exercise())
+    await _exercise()
 
 
-def test_async_nova_request_invokes_adm_exchange_even_with_token(
+async def test_async_nova_request_invokes_adm_exchange_even_with_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Providing a token kwarg must still route through async_get_adm_token_api."""
@@ -758,7 +1153,7 @@ def test_async_nova_request_invokes_adm_exchange_even_with_token(
             session=session,
         )
 
-    result = asyncio.run(_exercise())
+    result = await _exercise()
 
     assert result == "aabb"
     assert calls and calls[0]["username"] == "user@example.com"
@@ -768,7 +1163,7 @@ def test_async_nova_request_invokes_adm_exchange_even_with_token(
     assert headers.get("Authorization") == "Bearer adm-from-override"
 
 
-def test_async_nova_request_skips_seeding_without_username(
+async def test_async_nova_request_skips_seeding_without_username(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Do not seed non-AAS override tokens when username kwarg is omitted."""
@@ -806,7 +1201,7 @@ def test_async_nova_request_skips_seeding_without_username(
         final_state["seeded"] = await cache.get(DATA_AAS_TOKEN)
         return result
 
-    result = asyncio.run(_exercise())
+    result = await _exercise()
 
     assert result == "0102"
     assert calls == [None]
@@ -816,7 +1211,7 @@ def test_async_nova_request_skips_seeding_without_username(
     assert headers.get("Authorization") == "Bearer adm-fallback"
 
 
-def test_async_nova_request_preserves_existing_aas_when_username_missing(
+async def test_async_nova_request_preserves_existing_aas_when_username_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Pre-seeded AAS token must survive flow token usage without username kwarg."""
@@ -861,7 +1256,7 @@ def test_async_nova_request_preserves_existing_aas_when_username_missing(
         final_aas = await cache.get(DATA_AAS_TOKEN)
         return result, final_aas
 
-    result, final_aas = asyncio.run(_exercise())
+    result, final_aas = await _exercise()
 
     assert result == "face"
     assert calls and calls[0]["username"] == "user@example.com"
@@ -874,7 +1269,7 @@ def test_async_nova_request_preserves_existing_aas_when_username_missing(
     assert headers.get("Authorization") == "Bearer adm-preseed"
 
 
-def test_async_nova_request_converts_flow_token_with_ephemeral_cache(
+async def test_async_nova_request_converts_flow_token_with_ephemeral_cache(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Config-flow style caches must convert AAS tokens before Nova POST."""
@@ -909,7 +1304,7 @@ def test_async_nova_request_converts_flow_token_with_ephemeral_cache(
             session=session,
         )
 
-    result = asyncio.run(_exercise())
+    result = await _exercise()
 
     assert result == "9933"
     assert calls == ["aas_et/CONFIG_FLOW"]
@@ -918,7 +1313,7 @@ def test_async_nova_request_converts_flow_token_with_ephemeral_cache(
     assert headers.get("Authorization") == "Bearer adm-token"
 
 
-def test_async_ttl_policy_invalidate_aas_token_clears_both_bare_and_namespaced() -> (
+async def test_async_ttl_policy_invalidate_aas_token_clears_both_bare_and_namespaced() -> (
     None
 ):
     """async_invalidate_aas_token must clear AAS token from both bare and namespaced keys.
@@ -971,10 +1366,10 @@ def test_async_ttl_policy_invalidate_aas_token_clears_both_bare_and_namespaced()
         finally:
             await cache.close()
 
-    asyncio.run(_run())
+    await _run()
 
 
-def test_async_nova_request_invalidates_aas_token_after_exhausted_401_retries(
+async def test_async_nova_request_invalidates_aas_token_after_exhausted_401_retries(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Persistent 401 errors after token refresh must raise a permanent error.
@@ -1053,7 +1448,7 @@ def test_async_nova_request_invalidates_aas_token_after_exhausted_401_retries(
         )
 
     with pytest.raises(NovaAuthError) as err:
-        asyncio.run(_exercise())
+        await _exercise()
 
     # After all retries exhausted, error is permanent (requires re-auth)
     assert err.value.status == 401
@@ -1064,7 +1459,7 @@ def test_async_nova_request_invalidates_aas_token_after_exhausted_401_retries(
     assert len(aas_invalidation_calls) == 0
 
 
-def test_async_nova_request_aas_token_cleared_enables_fresh_chain_on_next_cycle(
+async def test_async_nova_request_aas_token_cleared_enables_fresh_chain_on_next_cycle(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """AAS token is retained across poll cycles since it is not invalidated on 401.
@@ -1153,7 +1548,7 @@ def test_async_nova_request_aas_token_cleared_enables_fresh_chain_on_next_cycle(
 
         return aas_after_first, second_result
 
-    aas_after_first, second_result = asyncio.run(_exercise())
+    aas_after_first, second_result = await _exercise()
 
     # AAS should be preserved after first failed cycle (not invalidated)
     assert aas_after_first == "stale-aas"
@@ -1166,7 +1561,7 @@ def test_async_nova_request_aas_token_cleared_enables_fresh_chain_on_next_cycle(
     assert aas_states_before_request[0] == (1, "stale-aas")
 
 
-def test_async_nova_request_preserves_aas_token_on_successful_401_recovery(
+async def test_async_nova_request_preserves_aas_token_on_successful_401_recovery(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """AAS token must be preserved when 401 recovery succeeds within retry window.
@@ -1233,7 +1628,7 @@ def test_async_nova_request_preserves_aas_token_on_successful_401_recovery(
         final_aas = await cache.get(DATA_AAS_TOKEN)
         return result, final_aas
 
-    result, final_aas = asyncio.run(_exercise())
+    result, final_aas = await _exercise()
 
     # Request should succeed
     assert result == "beef"
@@ -1245,7 +1640,7 @@ def test_async_nova_request_preserves_aas_token_on_successful_401_recovery(
     assert len(aas_invalidation_calls) == 0
 
 
-def test_async_nova_request_no_double_aas_invalidation_on_repeated_failures(
+async def test_async_nova_request_no_double_aas_invalidation_on_repeated_failures(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """AAS invalidation must NOT happen during the 401 retry sequence.
@@ -1316,13 +1711,13 @@ def test_async_nova_request_no_double_aas_invalidation_on_repeated_failures(
         )
 
     with pytest.raises(NovaAuthError):
-        asyncio.run(_exercise())
+        await _exercise()
 
     # No AAS invalidation should occur during 401 retries
     assert invalidation_call_count == 0
 
 
-def test_async_nova_request_loop_prevention_across_multiple_cycles(
+async def test_async_nova_request_loop_prevention_across_multiple_cycles(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """AAS token is preserved across multiple consecutive failed poll cycles.
@@ -1418,7 +1813,7 @@ def test_async_nova_request_loop_prevention_across_multiple_cycles(
             refresh_override=_refresh,
         )
 
-    result = asyncio.run(_exercise())
+    result = await _exercise()
 
     # Final cycle should succeed
     assert result == "dead"
@@ -1433,7 +1828,7 @@ def test_async_nova_request_loop_prevention_across_multiple_cycles(
     assert aas_states_at_cycle_start[3][1] == "initial-stale-aas"
 
 
-def test_async_nova_request_adm_only_failure_recovers_on_second_retry(
+async def test_async_nova_request_adm_only_failure_recovers_on_second_retry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """ADM refresh alone should fix most 401 errors without invalidating AAS.
@@ -1507,7 +1902,7 @@ def test_async_nova_request_adm_only_failure_recovers_on_second_retry(
         final_aas = await cache.get(DATA_AAS_TOKEN)
         return result, final_aas
 
-    result, final_aas = asyncio.run(_exercise())
+    result, final_aas = await _exercise()
 
     # Request should succeed
     assert result == "cafebabe"
@@ -1523,7 +1918,7 @@ def test_async_nova_request_adm_only_failure_recovers_on_second_retry(
     assert 6.0 in sleep_delays
 
 
-def test_async_nova_request_aas_adm_failure_requires_full_chain_refresh(
+async def test_async_nova_request_aas_adm_failure_requires_full_chain_refresh(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """When ADM-only refresh fails, Step 2 retries ADM with AAS retained.
@@ -1600,7 +1995,7 @@ def test_async_nova_request_aas_adm_failure_requires_full_chain_refresh(
         final_aas = await cache.get(DATA_AAS_TOKEN)
         return result, final_aas
 
-    result, final_aas = asyncio.run(_exercise())
+    result, final_aas = await _exercise()
 
     # Request should succeed
     assert result == "deadbeef"
@@ -1620,7 +2015,7 @@ def test_async_nova_request_aas_adm_failure_requires_full_chain_refresh(
     assert sleep_delays == [6.0, 61.0, 6.0]
 
 
-def test_async_nova_request_full_retry_sequence_exhausted(
+async def test_async_nova_request_full_retry_sequence_exhausted(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """When all 4 retry steps fail, a permanent auth error must be raised.
@@ -1696,7 +2091,7 @@ def test_async_nova_request_full_retry_sequence_exhausted(
         )
 
     with pytest.raises(NovaAuthError) as err:
-        asyncio.run(_exercise())
+        await _exercise()
 
     # Should be a permanent error requiring re-authentication
     assert err.value.status == 401
@@ -1715,7 +2110,7 @@ def test_async_nova_request_full_retry_sequence_exhausted(
     assert sleep_delays == [6.0, 61.0, 6.0, 501.0]
 
 
-def test_async_nova_request_recovers_on_long_cooldown(
+async def test_async_nova_request_recovers_on_long_cooldown(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Recovery on step 3 (after 501s long cooldown) should succeed.
@@ -1773,7 +2168,7 @@ def test_async_nova_request_recovers_on_long_cooldown(
             refresh_override=_refresh,
         )
 
-    result = asyncio.run(_exercise())
+    result = await _exercise()
 
     # Should succeed after long cooldown
     assert result == "feedface"
@@ -1782,7 +2177,7 @@ def test_async_nova_request_recovers_on_long_cooldown(
     assert sleep_delays == [6.0, 61.0, 6.0, 501.0]
 
 
-def test_async_ttl_policy_aas_ttl_learning_records_observed_lifetime() -> None:
+async def test_async_ttl_policy_aas_ttl_learning_records_observed_lifetime() -> None:
     """AAS TTL learning should record the observed token lifetime when invalidated.
 
     This test verifies that when an AAS token is invalidated:
@@ -1836,10 +2231,10 @@ def test_async_ttl_policy_aas_ttl_learning_records_observed_lifetime() -> None:
         finally:
             await cache.close()
 
-    asyncio.run(_run())
+    await _run()
 
 
-def test_async_ttl_policy_aas_proactive_refresh_triggers_near_expiry() -> None:
+async def test_async_ttl_policy_aas_proactive_refresh_triggers_near_expiry() -> None:
     """AAS proactive refresh should NOT trigger even when approaching learned TTL.
 
     The production code no longer proactively invalidates the AAS token.
@@ -1897,10 +2292,10 @@ def test_async_ttl_policy_aas_proactive_refresh_triggers_near_expiry() -> None:
         finally:
             await cache.close()
 
-    asyncio.run(_run())
+    await _run()
 
 
-def test_async_ttl_policy_aas_proactive_refresh_skips_when_fresh() -> None:
+async def test_async_ttl_policy_aas_proactive_refresh_skips_when_fresh() -> None:
     """AAS proactive refresh should NOT trigger when token is still fresh.
 
     When the AAS token is well within its TTL, proactive refresh should skip.
@@ -1952,10 +2347,10 @@ def test_async_ttl_policy_aas_proactive_refresh_skips_when_fresh() -> None:
         finally:
             await cache.close()
 
-    asyncio.run(_run())
+    await _run()
 
 
-def test_async_ttl_policy_ignores_very_short_ttl_in_recalibration() -> None:
+async def test_async_ttl_policy_ignores_very_short_ttl_in_recalibration() -> None:
     """Very short observed TTLs should be ignored to avoid race condition artifacts.
 
     When a token expires very quickly (< MIN_TTL_FOR_LEARNING_SEC), it typically
@@ -2013,10 +2408,10 @@ def test_async_ttl_policy_ignores_very_short_ttl_in_recalibration() -> None:
         finally:
             await cache.close()
 
-    asyncio.run(_run())
+    await _run()
 
 
-def test_async_ttl_policy_accepts_legitimate_short_ttl_above_threshold() -> None:
+async def test_async_ttl_policy_accepts_legitimate_short_ttl_above_threshold() -> None:
     """TTLs above the minimum threshold should still trigger recalibration.
 
     When a token expires after MIN_TTL_FOR_LEARNING_SEC but significantly shorter
@@ -2076,10 +2471,10 @@ def test_async_ttl_policy_accepts_legitimate_short_ttl_above_threshold() -> None
         finally:
             await cache.close()
 
-    asyncio.run(_run())
+    await _run()
 
 
-def test_both_adm_and_aas_tokens_have_min_ttl_protection() -> None:
+async def test_both_adm_and_aas_tokens_have_min_ttl_protection() -> None:
     """CRITICAL: Both ADM and AAS tokens must have MIN_TTL protection.
 
     This test documents a past bug where only ADM tokens had MIN_TTL protection,
@@ -2177,4 +2572,4 @@ def test_both_adm_and_aas_tokens_have_min_ttl_protection() -> None:
         finally:
             await cache.close()
 
-    asyncio.run(_run())
+    await _run()

--- a/tests/test_nova_request.py
+++ b/tests/test_nova_request.py
@@ -20,7 +20,10 @@ from custom_components.googlefindmy.api import _EphemeralCache
 from custom_components.googlefindmy.Auth.token_cache import TokenCache
 from custom_components.googlefindmy.Auth.token_retrieval import InvalidAasTokenError
 from custom_components.googlefindmy.Auth.username_provider import username_string
-from custom_components.googlefindmy.const import DATA_AAS_TOKEN
+from custom_components.googlefindmy.const import (
+    DATA_AAS_TOKEN,
+    NOVA_REQUEST_TOTAL_TIMEOUT_S,
+)
 from custom_components.googlefindmy.NovaApi.ListDevices.nbe_list_devices import (
     async_request_device_list,
 )
@@ -603,6 +606,49 @@ def test_async_nova_request_fetches_token_when_not_supplied(
     assert session.calls
     headers = session.calls[0]["kwargs"].get("headers", {})
     assert headers.get("Authorization") == "Bearer resolved-token"
+
+
+async def test_async_nova_request_uses_central_total_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SSOT regression: the HTTP request's ``total`` budget must come from the
+    central ``NOVA_REQUEST_TOTAL_TIMEOUT_S`` constant, not a scattered literal.
+
+    The outer poll guard (``POLL_DEVICE_OUTER_TIMEOUT_S``) is budgeted against
+    this exact value, so the two must never drift apart (Codex finding: the outer
+    guard has to cover the preceding HTTP phase). Pinning the wired-through total
+    here keeps the coupling honest.
+    """
+
+    cache = _StubCache()
+    session = _DummySession([_DummyResponse(200, b"\x10\x20")])
+
+    async def _fake_get_adm_token(
+        username: str | None = None,
+        *,
+        retries: int = 2,
+        backoff: float = 1.0,
+        cache: Any,
+    ) -> str:
+        return "resolved-token"
+
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.NovaApi.nova_request.async_get_adm_token_api",
+        _fake_get_adm_token,
+    )
+
+    await async_nova_request(
+        "testScope",
+        "00",
+        username="user@example.com",
+        cache=cache,
+        session=session,
+    )
+
+    assert session.calls
+    timeout = session.calls[0]["kwargs"].get("timeout")
+    assert timeout is not None, "nova_request must pass an explicit ClientTimeout"
+    assert timeout.total == NOVA_REQUEST_TOTAL_TIMEOUT_S
 
 
 def test_async_nova_request_uses_registered_cache_provider(

--- a/tests/test_nova_request.py
+++ b/tests/test_nova_request.py
@@ -33,6 +33,7 @@ from custom_components.googlefindmy.NovaApi.nova_request import (
     NovaAuthError,
     NovaError,
     NovaHTTPError,
+    NovaRateLimitError,
     async_nova_request,
     register_cache_provider,
     unregister_cache_provider,
@@ -1001,6 +1002,267 @@ async def test_async_nova_request_latches_dispatch_across_http_status_exit(
     # dispatch must remain latched so the cancel key is preserved.
     assert exc_info.value.dispatched is True
     assert len(session.calls) > 1  # the wire-reaching attempt actually retried
+
+
+async def test_async_nova_request_latches_dispatch_on_pure_status_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pure server-status read (no read exception) latches dispatch.
+
+    Regression for the Codex finding (AP8): a 5xx/429 status reaches the server
+    even though the body read itself never fails, so the request may already
+    have started a side effect (a device ring). If a *later* retry then fails
+    pre-connect, the wrapped ``NovaError`` must still report ``dispatched is
+    True`` so ``api.async_play_sound`` keeps the cancel key. Before the fix the
+    latch flipped only inside the network-exception handler, so a pure status
+    read left it ``False`` and the ring became unstoppable.
+    """
+
+    class _ConnFailingCtx:
+        """Pre-connect failure: context raises on entry."""
+
+        async def __aenter__(self) -> Any:
+            raise aiohttp.ConnectionTimeoutError
+
+        async def __aexit__(self, *_exc: object) -> None:
+            return None
+
+    class _StatusThenConnSession:
+        """Attempt 1 reads HTTP 503 (no read error); later attempts never connect."""
+
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+
+        def post(self, *_args: object, **_kwargs: object) -> Any:
+            self.calls.append({"args": _args, "kwargs": _kwargs})
+            if len(self.calls) == 1:
+                return _DummyResponse(503, b"")
+            return _ConnFailingCtx()
+
+    cache = _StubCache()
+    session = _StatusThenConnSession()
+
+    async def _fake_get_adm_token(
+        username: str | None = None, *, retries: int = 2, backoff: float = 1.0, cache: Any
+    ) -> str:
+        return "resolved-token"
+
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.NovaApi.nova_request.async_get_adm_token_api",
+        _fake_get_adm_token,
+    )
+
+    async def _instant_sleep(_: float) -> None:
+        return None
+
+    monkeypatch.setattr("asyncio.sleep", _instant_sleep)
+
+    async def _exercise() -> str:
+        return await async_nova_request(
+            "testScope",
+            "00",
+            username="user@example.com",
+            cache=cache,
+            session=session,
+        )
+
+    with pytest.raises(NovaError) as exc_info:
+        await _exercise()
+
+    # The 503 status read on attempt 1 latched dispatch; the final pre-connect
+    # failure must not clear it.
+    assert exc_info.value.dispatched is True
+    assert len(session.calls) > 1  # the status read actually triggered a retry
+
+
+async def test_async_nova_request_pure_4xx_does_not_latch_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A permanent 4xx rejection must NOT latch dispatch (S2 boundary).
+
+    The server refuses a 403 *before* any side effect, so the cancel key must be
+    dropped — otherwise it could overwrite the still-valid key of a parallel,
+    possibly still-ringing earlier play on the same device. This pins the
+    deliberate asymmetry of the AP8 fix: only transient 5xx latch; 4xx never do.
+    """
+
+    cache = _StubCache()
+    session = _DummySession([_DummyResponse(403, b"forbidden")])
+
+    async def _fake_get_adm_token(
+        username: str | None = None, *, retries: int = 2, backoff: float = 1.0, cache: Any
+    ) -> str:
+        return "resolved-token"
+
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.NovaApi.nova_request.async_get_adm_token_api",
+        _fake_get_adm_token,
+    )
+
+    async def _instant_sleep(_: float) -> None:
+        return None
+
+    monkeypatch.setattr("asyncio.sleep", _instant_sleep)
+
+    async def _exercise() -> str:
+        return await async_nova_request(
+            "testScope",
+            "00",
+            username="user@example.com",
+            cache=cache,
+            session=session,
+        )
+
+    with pytest.raises(NovaAuthError) as exc_info:
+        await _exercise()
+
+    # A clean 4xx rejection never reached a side effect: the key must drop.
+    assert exc_info.value.dispatched is False
+
+
+@pytest.mark.parametrize("status", [501, 505, 508])
+async def test_async_nova_request_non_retryable_5xx_does_not_latch_dispatch(
+    monkeypatch: pytest.MonkeyPatch, status: int
+) -> None:
+    """A non-retryable 5xx (501/505/508) must NOT latch dispatch.
+
+    Regression for the Codex follow-up on the AP8 latch: the first cut flipped
+    the latch for *every* ``status >= 500``, but 501 Not Implemented, 505 HTTP
+    Version Not Supported and 508 Loop Detected are documented as permanent
+    config rejections — the server refuses them *before* executing the command,
+    so no device ring can have started. Latching them would let an undispatched
+    failure overwrite the still-valid cancel key of a parallel, possibly still
+    ringing earlier play on the same device. The latch is now scoped to
+    ``HTTP_DISPATCH_LATCH_ELIGIBLE`` (transient 5xx 500/502/503/504 only), so
+    these raise ``NovaHTTPError`` with ``dispatched is False``.
+    """
+
+    cache = _StubCache()
+    session = _DummySession([_DummyResponse(status, b"nope")])
+
+    async def _fake_get_adm_token(
+        username: str | None = None, *, retries: int = 2, backoff: float = 1.0, cache: Any
+    ) -> str:
+        return "resolved-token"
+
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.NovaApi.nova_request.async_get_adm_token_api",
+        _fake_get_adm_token,
+    )
+
+    async def _instant_sleep(_: float) -> None:
+        return None
+
+    monkeypatch.setattr("asyncio.sleep", _instant_sleep)
+
+    with pytest.raises(NovaHTTPError) as exc_info:
+        await async_nova_request(
+            "testScope",
+            "00",
+            username="user@example.com",
+            cache=cache,
+            session=session,
+        )
+
+    # Non-retryable 5xx is refused before any side effect: the key must drop.
+    assert exc_info.value.dispatched is False
+    assert len(session.calls) == 1  # single attempt, no retry
+
+
+async def test_async_nova_request_pure_429_does_not_latch_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pure 429 rate-limit sequence must NOT latch dispatch.
+
+    Regression for the Codex follow-up on the AP8 latch: 429 Too Many Requests
+    is rejected at the gate and never processed, so a Play Sound request that
+    only ever sees 429 cannot have started a device ring. Latching it would make
+    ``api.async_play_sound`` keep a cancel UUID for a request the server refused;
+    if the user presses Play while an older ring is still active, that bogus UUID
+    overwrites the valid cancel key and the default Stop Sound targets the wrong
+    request. 429 stays retry-eligible but is excluded from
+    ``HTTP_DISPATCH_LATCH_ELIGIBLE``, so the wrapped error reports
+    ``dispatched is False``.
+    """
+
+    cache = _StubCache()
+    # NOVA_MAX_RETRIES == 6 -> 7 attempts all rate-limited.
+    session = _DummySession([_DummyResponse(429, b"slow down") for _ in range(7)])
+
+    async def _fake_get_adm_token(
+        username: str | None = None, *, retries: int = 2, backoff: float = 1.0, cache: Any
+    ) -> str:
+        return "resolved-token"
+
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.NovaApi.nova_request.async_get_adm_token_api",
+        _fake_get_adm_token,
+    )
+
+    async def _instant_sleep(_: float) -> None:
+        return None
+
+    monkeypatch.setattr("asyncio.sleep", _instant_sleep)
+
+    with pytest.raises(NovaRateLimitError) as exc_info:
+        await async_nova_request(
+            "testScope",
+            "00",
+            username="user@example.com",
+            cache=cache,
+            session=session,
+        )
+
+    # Pure rate-limit: never processed, so the cancel key must drop.
+    assert exc_info.value.dispatched is False
+    assert len(session.calls) == 7  # exhausted the retry budget
+
+
+async def test_async_nova_request_latch_survives_later_429(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dispatch-ambiguous 5xx keeps the latch even when later attempts see 429.
+
+    The latch accumulates monotonically across the retry sequence: once an early
+    503 makes the command dispatch-ambiguous (the backend may have begun a ring),
+    a subsequent 429 must not clear that signal. This pins Codex's caveat that
+    429 should be excluded from the latch *unless* an earlier attempt was already
+    post-dispatch ambiguous.
+    """
+
+    cache = _StubCache()
+    # Attempt 1 = 503 (latches), the rest = 429 (must not clear the latch).
+    session = _DummySession(
+        [_DummyResponse(503, b"")] + [_DummyResponse(429, b"slow") for _ in range(6)]
+    )
+
+    async def _fake_get_adm_token(
+        username: str | None = None, *, retries: int = 2, backoff: float = 1.0, cache: Any
+    ) -> str:
+        return "resolved-token"
+
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.NovaApi.nova_request.async_get_adm_token_api",
+        _fake_get_adm_token,
+    )
+
+    async def _instant_sleep(_: float) -> None:
+        return None
+
+    monkeypatch.setattr("asyncio.sleep", _instant_sleep)
+
+    with pytest.raises(NovaError) as exc_info:
+        await async_nova_request(
+            "testScope",
+            "00",
+            username="user@example.com",
+            cache=cache,
+            session=session,
+        )
+
+    # The early 503 latched dispatch; the trailing 429s must not clear it.
+    assert exc_info.value.dispatched is True
+    assert len(session.calls) == 7
 
 
 async def test_async_nova_request_uses_central_total_timeout(

--- a/tests/test_poll_timeout_hardening.py
+++ b/tests/test_poll_timeout_hardening.py
@@ -1,0 +1,424 @@
+# tests/test_poll_timeout_hardening.py
+"""Regression tests for the poll-timeout hardening (B1-B3).
+
+These pin the behaviour introduced to stop the noisy
+"Poll timed out ... (FCM connected)" warnings:
+
+* B2 - the outer per-device poll guard must be strictly larger than the inner
+  FCM wait, so the inner request can return its clean empty result before the
+  outer guard fires (Nygard: stagger nested timeout budgets). It must also cover
+  the *preceding* Nova HTTP round-trip: the inner request runs HTTP (capped at
+  NOVA_REQUEST_TOTAL_TIMEOUT_S) and only then waits for FCM, so a slow-but-
+  successful HTTP call would otherwise push the FCM wait past the guard (the
+  Codex finding fixed alongside this suite).
+* B3 - an empty location result is an expected idle outcome and must log at
+  INFO, not WARNING.
+* Behaviour preservation - a genuine FCM-disconnected timeout must still count
+  as a failed cycle and advance ``_consecutive_timeouts``; the benign
+  FCM-connected timeout must not.
+* Idle diagnostics - the DEBUG-only ``_log_idle_poll_diagnostics`` helper stays
+  silent unless DEBUG is enabled and degrades gracefully for missing/garbled
+  cache timestamps.
+
+The setup mirrors ``tests/test_coordinator_timeout.py`` (explicit event loop +
+``_async_start_poll_cycle``), the established pattern for this code path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+from custom_components.googlefindmy.const import (
+    LOCATION_REQUEST_TIMEOUT_S,
+    NOVA_REQUEST_TOTAL_TIMEOUT_S,
+    POLL_DEVICE_OUTER_TIMEOUT_S,
+)
+from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
+from custom_components.googlefindmy.coordinator.helpers.stats import FcmStatus
+from custom_components.googlefindmy.coordinator.polling import PollingOperations
+from tests.helpers import drain_loop
+
+_POLLING_LOGGER = "custom_components.googlefindmy.coordinator.polling"
+
+
+class _DummyCache:
+    """Minimal cache stub satisfying the coordinator constructor."""
+
+    async def async_get_cached_value(self, _key: str):  # pragma: no cover - stub
+        return None
+
+    async def async_set_cached_value(
+        self, _key: str, _value
+    ):  # pragma: no cover - stub
+        return None
+
+
+class _DummyBus:
+    """Provide async_listen/async_fire placeholders used by the coordinator."""
+
+    def async_listen(self, *_args, **_kwargs):  # pragma: no cover - stub
+        return lambda: None
+
+    def async_fire(self, *_args, **_kwargs):  # pragma: no cover - stub
+        return None
+
+
+class _DummyHass:
+    """Lightweight Home Assistant stub capturing created tasks."""
+
+    def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+        self.loop = loop
+        self.bus = _DummyBus()
+
+    def async_create_task(self, coro, *, name: str | None = None):  # noqa: D401
+        return self.loop.create_task(coro, name=name)
+
+
+class _TimeoutAPI:
+    """API stub that always times out during location requests."""
+
+    async def async_get_device_location(self, _dev_id: str, _dev_name: str):
+        raise TimeoutError()
+
+
+class _EmptyResultAPI:
+    """API stub that returns an empty result (no reporter in range)."""
+
+    async def async_get_device_location(self, _dev_id: str, _dev_name: str):
+        return []
+
+
+def _make_coordinator(
+    monkeypatch: pytest.MonkeyPatch,
+    loop: asyncio.AbstractEventLoop,
+    api: object,
+    devices: list[dict[str, str]],
+) -> GoogleFindMyCoordinator:
+    """Build a coordinator wired with stubs, mirroring test_coordinator_timeout."""
+
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.coordinator.GoogleFindMyCoordinator._async_load_stats",
+        AsyncMock(return_value=None),
+    )
+
+    hass = _DummyHass(loop)
+    coordinator = GoogleFindMyCoordinator(hass, cache=_DummyCache())
+    coordinator.config_entry = SimpleNamespace(
+        entry_id="entry-id", options={}, data={}, title="Test Entry"
+    )
+    coordinator.api = api
+    coordinator._get_google_home_filter = lambda: None
+    coordinator._is_fcm_ready_soft = lambda: True
+    coordinator._get_ignored_set = set
+    coordinator._last_device_list = list(devices)
+
+    coordinator.data = []
+    coordinator.last_update_success = True
+    coordinator.last_exception = None
+
+    def _set_update_error(exc: Exception) -> None:
+        coordinator.last_update_success = False
+        coordinator.last_exception = exc
+
+    def _set_updated_data(data):
+        coordinator.data = data
+        coordinator.last_update_success = True
+        coordinator.last_exception = None
+
+    coordinator.async_set_update_error = _set_update_error
+    coordinator.async_set_updated_data = _set_updated_data
+    return coordinator
+
+
+def test_outer_poll_budget_exceeds_inner_wait() -> None:
+    """B2: the outer per-device guard must be strictly larger than the inner wait."""
+
+    assert POLL_DEVICE_OUTER_TIMEOUT_S > LOCATION_REQUEST_TIMEOUT_S
+
+
+def test_outer_poll_budget_covers_http_plus_fcm_phases() -> None:
+    """Codex regression: the inner request runs the Nova HTTP round-trip and the
+    FCM wait *sequentially*, so the outer guard must cover BOTH budgets.
+
+    A previous revision sized the guard as ``LOCATION_REQUEST_TIMEOUT_S + 10``
+    (40s), which a slow-but-successful HTTP call (up to NOVA_REQUEST_TOTAL_TIMEOUT_S)
+    could exhaust before the inner FCM wait even started, re-entering the spurious
+    outer-``TimeoutError`` path this hardening removes.
+    """
+
+    assert (
+        POLL_DEVICE_OUTER_TIMEOUT_S
+        >= NOVA_REQUEST_TOTAL_TIMEOUT_S + LOCATION_REQUEST_TIMEOUT_S
+    )
+
+
+def test_empty_location_logs_info_not_warning(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """B3: an empty location result is expected and must log at INFO, not WARNING."""
+
+    loop = asyncio.new_event_loop()
+    devices = [{"id": "dev-empty", "name": "Idle Tag"}]
+    coordinator = _make_coordinator(monkeypatch, loop, _EmptyResultAPI(), devices)
+
+    try:
+        with caplog.at_level(logging.INFO, logger=_POLLING_LOGGER):
+            loop.run_until_complete(
+                coordinator._async_start_poll_cycle(devices, force=True)
+            )
+    finally:
+        drain_loop(loop)
+
+    idle_records = [
+        rec
+        for rec in caplog.records
+        if rec.name == _POLLING_LOGGER
+        and "No location data returned" in rec.getMessage()
+    ]
+    assert idle_records, "expected an idle 'No location data returned' log line"
+    assert all(rec.levelno == logging.INFO for rec in idle_records)
+    assert not any(
+        rec.name == _POLLING_LOGGER
+        and rec.levelno >= logging.WARNING
+        and "No location data returned" in rec.getMessage()
+        for rec in caplog.records
+    )
+
+
+def test_fcm_disconnected_timeout_still_counts_as_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Behaviour preservation: a disconnected-FCM timeout fails the cycle."""
+
+    loop = asyncio.new_event_loop()
+    devices = [{"id": "dev-1", "name": "Device"}]
+    coordinator = _make_coordinator(monkeypatch, loop, _TimeoutAPI(), devices)
+    coordinator._fcm_status_state = FcmStatus.DISCONNECTED
+    coordinator._consecutive_timeouts = 0
+
+    try:
+        loop.run_until_complete(
+            coordinator._async_start_poll_cycle(devices, force=True)
+        )
+    finally:
+        drain_loop(loop)
+
+    assert coordinator.last_update_success is False
+    assert isinstance(coordinator.last_exception, UpdateFailed)
+    assert coordinator.stats["timeouts"] == 1
+    assert coordinator._consecutive_timeouts == 1
+
+
+def test_fcm_connected_timeout_is_benign(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A connected-FCM timeout is healthy: counted as a timeout stat but it must
+    not advance the consecutive-timeout failure counter."""
+
+    loop = asyncio.new_event_loop()
+    devices = [{"id": "dev-1", "name": "Device"}]
+    coordinator = _make_coordinator(monkeypatch, loop, _TimeoutAPI(), devices)
+    coordinator._fcm_status_state = FcmStatus.CONNECTED
+    coordinator._consecutive_timeouts = 0
+
+    try:
+        loop.run_until_complete(
+            coordinator._async_start_poll_cycle(devices, force=True)
+        )
+    finally:
+        drain_loop(loop)
+
+    assert coordinator.stats["timeouts"] == 1
+    assert coordinator._consecutive_timeouts == 0
+
+
+def _make_idle_diag_stub(**attrs: object) -> SimpleNamespace:
+    """Build a minimal stand-in exposing only what ``_log_idle_poll_diagnostics``
+    reads. This keeps the helper tests as true unit tests, without constructing a
+    full coordinator (and the async background tasks that would entail)."""
+
+    base: dict[str, object] = {
+        "_device_location_data": {},
+        "_fcm_status_changed_at": None,
+        "_fcm_status_state": FcmStatus.CONNECTED,
+    }
+    base.update(attrs)
+    return SimpleNamespace(**base)
+
+
+def _call_idle_diagnostics(stub: SimpleNamespace, *, source: str) -> None:
+    """Invoke the unbound mixin method against the lightweight stub."""
+
+    PollingOperations._log_idle_poll_diagnostics(
+        stub, "dev-1", "Idle Tag", source=source
+    )
+
+
+def test_idle_diagnostics_silent_when_debug_disabled(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The diagnostic is DEBUG-only: with DEBUG disabled it must emit nothing."""
+
+    stub = _make_idle_diag_stub(
+        _device_location_data={"dev-1": {"last_seen": 1000.0}},
+        _fcm_status_changed_at=500.0,
+    )
+
+    with caplog.at_level(logging.INFO, logger=_POLLING_LOGGER):
+        _call_idle_diagnostics(stub, source="inner-empty")
+
+    assert not [rec for rec in caplog.records if "Idle poll for" in rec.getMessage()]
+
+
+def test_idle_diagnostics_reports_ages_when_debug_enabled(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """With DEBUG enabled and a valid cache, both ages are rendered."""
+
+    stub = _make_idle_diag_stub(
+        _device_location_data={"dev-1": {"last_seen": 10.0}},
+        _fcm_status_changed_at=5.0,
+    )
+
+    with caplog.at_level(logging.DEBUG, logger=_POLLING_LOGGER):
+        _call_idle_diagnostics(stub, source="outer-timeout")
+
+    messages = [
+        rec.getMessage()
+        for rec in caplog.records
+        if "Idle poll for" in rec.getMessage()
+    ]
+    assert len(messages) == 1
+    msg = messages[0]
+    assert "outer-timeout" in msg
+    assert "last report" in msg
+    assert "ago" in msg
+    # A concrete report age must be computed, not the "never"/"unknown" fallbacks.
+    assert "never" not in msg
+
+
+def test_idle_diagnostics_handles_missing_last_seen(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No cached report at all -> the report age renders as ``never``."""
+
+    stub = _make_idle_diag_stub(
+        _device_location_data={},
+        _fcm_status_changed_at=5.0,
+    )
+
+    with caplog.at_level(logging.DEBUG, logger=_POLLING_LOGGER):
+        _call_idle_diagnostics(stub, source="inner-empty")
+
+    msg = next(
+        rec.getMessage()
+        for rec in caplog.records
+        if "Idle poll for" in rec.getMessage()
+    )
+    assert "last report never ago" in msg
+
+
+def test_idle_diagnostics_handles_garbled_timestamps(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A non-numeric ``last_seen`` and a missing FCM timestamp degrade to
+    ``unknown`` instead of raising (defensive coordinate parsing)."""
+
+    stub = _make_idle_diag_stub(
+        _device_location_data={"dev-1": {"last_seen": "not-a-number"}},
+        _fcm_status_changed_at=None,
+    )
+
+    with caplog.at_level(logging.DEBUG, logger=_POLLING_LOGGER):
+        _call_idle_diagnostics(stub, source="inner-empty")
+
+    msg = next(
+        rec.getMessage()
+        for rec in caplog.records
+        if "Idle poll for" in rec.getMessage()
+    )
+    assert "last report unknown ago" in msg
+    assert "FCM status" in msg
+    assert "for unknown" in msg
+
+
+_LOCATION_REQUEST_LOGGER = (
+    "custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker."
+    "location_request"
+)
+
+
+def test_inner_fcm_wait_timeout_logs_info_and_returns_empty(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """B3 at the inner level: when no reporter relays the BLE tag within the
+    window, ``get_location_data_for_device`` must log the FCM-wait timeout at
+    INFO (not WARNING) and return an empty list.
+
+    This pins the noise-reduction demotion on the source line itself; the
+    coordinator-level tests above only exercise a stubbed API, so without this
+    test the inner ``location_request.py`` change would be unguarded.
+    """
+
+    from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker import (
+        location_request as lr,
+    )
+
+    class _FakeReceiver:
+        async def async_register_for_location_updates(self, _canonic, _callback):
+            # Return a token but never invoke the callback, so the FCM wait
+            # below times out (the "no reporter in range" idle outcome).
+            return "fcm-token"
+
+        async def async_unregister_for_location_updates(self, _canonic):
+            return None
+
+    class _Cache:
+        entry_id = "entry-1"
+
+        async def async_get_cached_value(self, _key):
+            return None
+
+        async def async_set_cached_value(self, _key, _value):
+            return None
+
+    # Collapse the inner FCM wait so the timeout fires immediately, and stub the
+    # surrounding orchestration that is irrelevant to the logged outcome.
+    monkeypatch.setattr(lr, "LOCATION_REQUEST_TIMEOUT_S", 0)
+    monkeypatch.setattr(lr, "create_location_request", lambda *a, **k: "00")
+    monkeypatch.setattr(lr, "async_nova_request", AsyncMock(return_value=""))
+    lr.register_fcm_receiver_provider(lambda _entry=None: _FakeReceiver())
+
+    # Explicit event loop (not asyncio.run) to honour the repo's test-suite
+    # guard; mirrors the established pattern in this file.
+    loop = asyncio.new_event_loop()
+    try:
+        with caplog.at_level(logging.INFO, logger=_LOCATION_REQUEST_LOGGER):
+            result = loop.run_until_complete(
+                lr.get_location_data_for_device(
+                    "canonic-1",
+                    "Idle Tag",
+                    username="user@example.com",
+                    cache=_Cache(),
+                )
+            )
+    finally:
+        drain_loop(loop)
+        lr.unregister_fcm_receiver_provider()
+
+    assert result == []
+    timeout_records = [
+        rec
+        for rec in caplog.records
+        if rec.name == _LOCATION_REQUEST_LOGGER
+        and "No location response received" in rec.getMessage()
+    ]
+    assert timeout_records, "expected the inner FCM-wait timeout log line"
+    assert all(rec.levelno == logging.INFO for rec in timeout_records)
+    assert not any(rec.levelno >= logging.WARNING for rec in timeout_records)

--- a/tests/test_remove_entry_cleanup.py
+++ b/tests/test_remove_entry_cleanup.py
@@ -126,7 +126,13 @@ def test_async_remove_entry_purges_store_and_creates_issue(
 
     issue_id = f"cache_purged_{entry.entry_id}"
     assert any(item["issue_id"] == issue_id for item in issue_registry_capture.created)
-    assert issue_registry_capture.deleted == []
+
+    # Removal must retire every entry-scoped FCM repair issue, since no
+    # supervisor will run again to clear them (Codex PR #1104 follow-up).
+    deleted_ids = {iid for _domain, iid in issue_registry_capture.deleted}
+    assert f"fcm_reauth_required_{entry.entry_id}" in deleted_ids
+    assert f"fcm_stuck_{entry.entry_id}" in deleted_ids
+    assert f"fcm_short_run_crash_loop_{entry.entry_id}" in deleted_ids
 
 
 def test_async_remove_entry_respects_retention_option(

--- a/tests/test_restart_required_issue.py
+++ b/tests/test_restart_required_issue.py
@@ -1,3 +1,4 @@
+# tests/test_restart_required_issue.py
 """Tests for the global "restart required" Repairs watchdog (AP6).
 
 Covers detection (on-disk vs. running version), self-healing deletion, read-error

--- a/tests/test_restart_required_issue.py
+++ b/tests/test_restart_required_issue.py
@@ -1,0 +1,437 @@
+"""Tests for the global "restart required" Repairs watchdog (AP6).
+
+Covers detection (on-disk vs. running version), self-healing deletion, read-error
+resilience, single-timer idempotency across multiple ``async_setup`` calls, the
+awaitable guard for ``async_call_later``, and last-entry teardown.
+
+See ``PLAN_GFM_RESTART_REQUIRED_REPAIR.md`` AP6 (cases A-E) and the Codex-P1
+legend #1-#6.
+"""
+
+from __future__ import annotations
+
+import types
+from typing import Any
+
+import pytest
+
+import custom_components.googlefindmy as gfm
+from custom_components.googlefindmy.const import (
+    DOMAIN,
+    INTEGRATION_VERSION,
+    ISSUE_RESTART_REQUIRED_KEY,
+    TRANSLATION_KEY_RESTART_REQUIRED,
+)
+
+# pytest-asyncio runs with asyncio_mode = "auto" (see pyproject.toml / tests/AGENTS.md),
+# so coroutine tests are detected automatically; sync tests stay unmarked.
+
+
+class _Hass:
+    """Minimal Home Assistant double for the restart watchdog."""
+
+    def __init__(self) -> None:
+        self.data: dict[Any, Any] = {}
+        self.created_tasks: list[str | None] = []
+
+    async def async_add_executor_job(self, func, *args):  # type: ignore[no-untyped-def]
+        return func(*args)
+
+    def async_create_task(self, coro, name=None):  # type: ignore[no-untyped-def]
+        # Consume the coroutine so the event loop does not warn about it.
+        self.created_tasks.append(name)
+        coro.close()
+
+
+def _active_hass() -> _Hass:
+    """Return a hass double whose restart watchdog is registered.
+
+    That is the real precondition under which ``_async_check_restart_required``
+    ever runs: it is only ever scheduled by the registered timers. Tests that
+    exercise the *create* path must establish it, because the coroutine now
+    refuses to (re)create the issue once the watchdog has been torn down by a
+    concurrent last-entry unload (Codex-P1 class: tick firing after unload).
+    """
+
+    hass = _Hass()
+    gfm._domain_data(hass)["restart_check_registered"] = True
+    return hass
+
+
+@pytest.fixture(name="issue_calls")
+def _issue_calls(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[Any]]:
+    """Capture issue-registry create/delete calls."""
+
+    created: list[dict[str, Any]] = []
+    deleted: list[str] = []
+
+    def _create(hass, domain, issue_id, **kwargs):  # type: ignore[no-untyped-def]
+        created.append({"domain": domain, "issue_id": issue_id, **kwargs})
+
+    def _delete(hass, domain, issue_id):  # type: ignore[no-untyped-def]
+        deleted.append(issue_id)
+
+    monkeypatch.setattr(gfm.ir, "async_create_issue", _create)
+    monkeypatch.setattr(gfm.ir, "async_delete_issue", _delete)
+    return {"created": created, "deleted": deleted}
+
+
+# --- Fall A: disk != running -> create issue --------------------------------
+
+
+async def test_check_creates_issue_on_version_mismatch(
+    monkeypatch: pytest.MonkeyPatch, issue_calls: dict[str, list[Any]]
+) -> None:
+    hass = _active_hass()
+
+    async def _fake_installed(_hass: Any) -> str:
+        return "9.9.9-disk"
+
+    monkeypatch.setattr(gfm, "_async_read_installed_version", _fake_installed)
+    await gfm._async_check_restart_required(hass)
+
+    assert len(issue_calls["created"]) == 1
+    call = issue_calls["created"][0]
+    assert call["issue_id"] == ISSUE_RESTART_REQUIRED_KEY
+    assert call["domain"] == DOMAIN
+    assert call["is_fixable"] is False
+    assert call["translation_key"] == TRANSLATION_KEY_RESTART_REQUIRED
+    assert call["translation_placeholders"] == {
+        "running_version": INTEGRATION_VERSION,
+        "installed_version": "9.9.9-disk",
+    }
+    assert issue_calls["deleted"] == []
+
+
+# --- Race: check task finishing after last-entry teardown -------------------
+
+
+async def test_check_skips_create_after_teardown_race(
+    monkeypatch: pytest.MonkeyPatch, issue_calls: dict[str, list[Any]]
+) -> None:
+    """A mismatch detected after the watchdog was torn down must not resurrect
+    the issue (Codex-P1 class: tick firing after unload).
+
+    The timer may fire and spawn the check task an instant before the last-entry
+    unload pops ``restart_check_registered``. When the task then resumes past its
+    executor read, no timer is left to ever clear a freshly created issue -- so
+    creation must be suppressed. ``_Hass`` starts without the flag, modelling the
+    post-teardown bucket; neither create nor delete may be invoked.
+    """
+
+    hass = _Hass()
+
+    async def _fake_installed(_hass: Any) -> str:
+        return "9.9.9-disk"
+
+    monkeypatch.setattr(gfm, "_async_read_installed_version", _fake_installed)
+    await gfm._async_check_restart_required(hass)
+
+    assert issue_calls["created"] == []
+    assert issue_calls["deleted"] == []
+
+
+# --- Fall B: equal versions -> delete issue (self-healing symmetry) ---------
+
+
+async def test_check_deletes_issue_when_versions_match(
+    monkeypatch: pytest.MonkeyPatch, issue_calls: dict[str, list[Any]]
+) -> None:
+    hass = _Hass()
+
+    async def _fake_installed(_hass: Any) -> str:
+        return INTEGRATION_VERSION
+
+    monkeypatch.setattr(gfm, "_async_read_installed_version", _fake_installed)
+    await gfm._async_check_restart_required(hass)
+
+    assert issue_calls["created"] == []
+    assert issue_calls["deleted"] == [ISSUE_RESTART_REQUIRED_KEY]
+
+
+# --- Fall C: read error -> None -> delete, no create, no crash --------------
+
+
+async def test_check_clears_issue_on_read_error(
+    monkeypatch: pytest.MonkeyPatch, issue_calls: dict[str, list[Any]]
+) -> None:
+    hass = _Hass()
+
+    async def _fake_installed(_hass: Any) -> None:
+        return None
+
+    monkeypatch.setattr(gfm, "_async_read_installed_version", _fake_installed)
+    await gfm._async_check_restart_required(hass)
+
+    assert issue_calls["created"] == []
+    assert issue_calls["deleted"] == [ISSUE_RESTART_REQUIRED_KEY]
+
+
+# --- Fall C2: callback never raises into HA (Codex-P1 #4) -------------------
+
+
+async def test_check_never_raises_into_ha(
+    monkeypatch: pytest.MonkeyPatch, issue_calls: dict[str, list[Any]]
+) -> None:
+    hass = _active_hass()
+
+    async def _fake_installed(_hass: Any) -> str:
+        return "9.9.9-disk"
+
+    def _boom(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("issue registry exploded")
+
+    monkeypatch.setattr(gfm, "_async_read_installed_version", _fake_installed)
+    monkeypatch.setattr(gfm.ir, "async_create_issue", _boom)
+    # Must not propagate.
+    await gfm._async_check_restart_required(hass)
+
+
+# --- executor read path (Codex-P1 #3: no blocking IO in the loop) -----------
+
+
+async def test_check_uses_executor_read_path(
+    monkeypatch: pytest.MonkeyPatch, issue_calls: dict[str, list[Any]]
+) -> None:
+    hass = _active_hass()
+    monkeypatch.setattr(gfm, "_read_installed_version_sync", lambda: "9.9.9-disk")
+    await gfm._async_check_restart_required(hass)
+    assert len(issue_calls["created"]) == 1
+
+
+# --- sync reader coverage ---------------------------------------------------
+
+
+def test_read_installed_version_sync_reads_manifest() -> None:
+    # The real manifest on disk carries INTEGRATION_VERSION after the bump.
+    assert gfm._read_installed_version_sync() == INTEGRATION_VERSION
+
+
+def test_read_installed_version_sync_handles_bad_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _boom(*args: Any, **kwargs: Any) -> None:
+        raise ValueError("broken json")
+
+    monkeypatch.setattr(gfm.json, "load", _boom)
+    assert gfm._read_installed_version_sync() is None
+
+
+def test_read_installed_version_sync_handles_missing_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(gfm.json, "load", lambda *a, **k: {"no_version": True})
+    assert gfm._read_installed_version_sync() is None
+
+
+# --- severity resolution (PA-F6 defensive getattr) --------------------------
+
+
+async def test_create_passes_resolved_issue_severity(
+    monkeypatch: pytest.MonkeyPatch, issue_calls: dict[str, list[Any]]
+) -> None:
+    hass = _active_hass()
+
+    async def _fake_installed(_hass: Any) -> str:
+        return "9.9.9-disk"
+
+    monkeypatch.setattr(gfm, "_async_read_installed_version", _fake_installed)
+    monkeypatch.setattr(
+        gfm.ir, "IssueSeverity", types.SimpleNamespace(WARNING="warning_level")
+    )
+    await gfm._async_check_restart_required(hass)
+    assert issue_calls["created"][0]["severity"] == "warning_level"
+
+
+async def test_create_severity_fallback_without_enum(
+    monkeypatch: pytest.MonkeyPatch, issue_calls: dict[str, list[Any]]
+) -> None:
+    hass = _active_hass()
+
+    async def _fake_installed(_hass: Any) -> str:
+        return "9.9.9-disk"
+
+    monkeypatch.setattr(gfm, "_async_read_installed_version", _fake_installed)
+    monkeypatch.delattr(gfm.ir, "IssueSeverity", raising=False)
+    monkeypatch.setattr(gfm.ir, "WARNING", "fallback_warn", raising=False)
+    await gfm._async_check_restart_required(hass)
+    assert issue_calls["created"][0]["severity"] == "fallback_warn"
+
+
+# --- scheduled callback schedules the check (timer body, Codex-P1 #3) -------
+
+
+async def test_scheduled_callback_schedules_check(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hass = _Hass()
+    captured: dict[str, Any] = {}
+
+    def _fake_later(_hass: Any, _delay: Any, cb: Any) -> Any:
+        captured["cb"] = cb
+        return lambda: None
+
+    def _fake_interval(_hass: Any, cb: Any, _interval: Any) -> Any:
+        return lambda: None
+
+    monkeypatch.setattr(gfm, "async_call_later", _fake_later)
+    monkeypatch.setattr(gfm, "async_track_time_interval", _fake_interval)
+
+    bucket: dict[Any, Any] = {}
+    gfm._register_restart_required_check(hass, bucket)
+
+    # Fire the captured timer callback: it must schedule the async check as a task.
+    captured["cb"](None)
+    assert hass.created_tasks == [f"{gfm.DOMAIN}.restart_required_check"]
+
+
+# --- Fall D: single timer pair across multiple async_setup calls (P1 #6) ----
+
+
+async def test_single_timer_across_multiple_setups(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hass = _Hass()
+    monkeypatch.setattr(gfm, "_ensure_runtime_imports", lambda: None)
+
+    counts = {"later": 0, "interval": 0}
+
+    def _fake_later(_hass: Any, _delay: Any, _cb: Any) -> Any:
+        counts["later"] += 1
+        return lambda: None
+
+    def _fake_interval(_hass: Any, _cb: Any, _interval: Any) -> Any:
+        counts["interval"] += 1
+        return lambda: None
+
+    monkeypatch.setattr(gfm, "async_call_later", _fake_later)
+    monkeypatch.setattr(gfm, "async_track_time_interval", _fake_interval)
+
+    bucket = hass.data.setdefault(gfm.DATA_DOMAIN, {})
+    bucket["services_registered"] = True  # skip the service-registration branch
+
+    assert await gfm.async_setup(hass, {}) is True
+    assert await gfm.async_setup(hass, {}) is True  # second entry / racey re-entry
+
+    assert counts["later"] == 1
+    assert counts["interval"] == 1
+    assert bucket["restart_check_registered"] is True
+    assert callable(bucket["restart_check_initial_unsub"])
+    assert callable(bucket["restart_check_unsub"])
+
+
+# --- awaitable guard for async_call_later (Codex-P1 #5) ---------------------
+
+
+async def test_register_handles_awaitable_call_later(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hass = _Hass()
+
+    async def _await_handle() -> None:
+        return None
+
+    def _fake_later(_hass: Any, _delay: Any, _cb: Any) -> Any:
+        return _await_handle()
+
+    def _fake_interval(_hass: Any, _cb: Any, _interval: Any) -> Any:
+        return lambda: None
+
+    monkeypatch.setattr(gfm, "async_call_later", _fake_later)
+    monkeypatch.setattr(gfm, "async_track_time_interval", _fake_interval)
+
+    bucket: dict[Any, Any] = {}
+    gfm._register_restart_required_check(hass, bucket)
+
+    # Awaitable path: initial unsub stored as None, the awaitable scheduled.
+    assert bucket["restart_check_initial_unsub"] is None
+    assert callable(bucket["restart_check_unsub"])
+    assert hass.created_tasks  # the awaitable was scheduled as a task
+
+
+# --- Fall E: last-entry teardown cancels both timers + deletes issue --------
+
+
+async def test_teardown_cancels_timers_and_deletes_issue(
+    issue_calls: dict[str, list[Any]],
+) -> None:
+    hass = _Hass()
+    cancelled = {"initial": False, "interval": False}
+
+    bucket: dict[Any, Any] = {
+        "restart_check_registered": True,
+        "restart_check_initial_unsub": lambda: cancelled.__setitem__("initial", True),
+        "restart_check_unsub": lambda: cancelled.__setitem__("interval", True),
+    }
+
+    gfm._teardown_restart_required_check(hass, bucket)
+
+    assert cancelled == {"initial": True, "interval": True}
+    assert "restart_check_initial_unsub" not in bucket
+    assert "restart_check_unsub" not in bucket
+    assert "restart_check_registered" not in bucket
+    assert issue_calls["deleted"] == [ISSUE_RESTART_REQUIRED_KEY]
+
+
+async def test_teardown_is_safe_without_registration(
+    issue_calls: dict[str, list[Any]],
+) -> None:
+    """Teardown on a bucket that never registered must not raise."""
+
+    hass = _Hass()
+    bucket: dict[Any, Any] = {}
+    gfm._teardown_restart_required_check(hass, bucket)
+    # Issue delete is still attempted (idempotent / no-op on the HA side).
+    assert issue_calls["deleted"] == [ISSUE_RESTART_REQUIRED_KEY]
+
+
+# --- Fall F: watchdog re-arms after a last-entry reload teardown (Codex P1) --
+
+
+async def test_ensure_rearms_watchdog_after_teardown(
+    monkeypatch: pytest.MonkeyPatch,
+    issue_calls: dict[str, list[Any]],
+) -> None:
+    """A last-entry reload tears the watchdog down; the next entry setup re-arms it.
+
+    ``async_setup`` does not run again on a config-entry reload, so without the
+    re-arm in ``async_setup_entry`` (via ``_async_ensure_restart_required_check``)
+    the "updated but not yet restarted" warning would stay hidden until a full
+    Home Assistant restart, defeating the common "reload instead of restart" case.
+    """
+
+    hass = _Hass()
+    counts = {"later": 0, "interval": 0}
+
+    def _fake_later(_hass: Any, _delay: Any, _cb: Any) -> Any:
+        counts["later"] += 1
+        return lambda: None
+
+    def _fake_interval(_hass: Any, _cb: Any, _interval: Any) -> Any:
+        counts["interval"] += 1
+        return lambda: None
+
+    monkeypatch.setattr(gfm, "async_call_later", _fake_later)
+    monkeypatch.setattr(gfm, "async_track_time_interval", _fake_interval)
+
+    bucket: dict[Any, Any] = {}
+
+    # 1) Component load arms the watchdog exactly once.
+    await gfm._async_ensure_restart_required_check(hass, bucket)
+    assert bucket["restart_check_registered"] is True
+    assert (counts["later"], counts["interval"]) == (1, 1)
+
+    # 2) Idempotent: a redundant ensure (e.g. a second entry) must not double-arm.
+    await gfm._async_ensure_restart_required_check(hass, bucket)
+    assert (counts["later"], counts["interval"]) == (1, 1)
+
+    # 3) Last-entry reload: teardown cancels the timers and pops the flag.
+    gfm._teardown_restart_required_check(hass, bucket)
+    assert "restart_check_registered" not in bucket
+
+    # 4) The reload's async_setup_entry re-arms the watchdog (the regression).
+    await gfm._async_ensure_restart_required_check(hass, bucket)
+    assert bucket["restart_check_registered"] is True
+    assert (counts["later"], counts["interval"]) == (2, 2)
+    assert callable(bucket["restart_check_initial_unsub"])
+    assert callable(bucket["restart_check_unsub"])

--- a/tests/test_sensor_coverage_supplement.py
+++ b/tests/test_sensor_coverage_supplement.py
@@ -1,0 +1,58 @@
+# tests/test_sensor_coverage_supplement.py
+"""Coverage supplement for sensor.py branches introduced by the last_seen fix.
+
+Primary file for AP4 (per-file >95% coverage of ``sensor.py``). This module
+closes the branch matrix of the AP1-modified
+``GoogleFindMyLastSeenSensor.extra_state_attributes`` property that the bugfix
+regression test (``test_last_seen_sensor_no_map_attributes.py``) does not yet
+exercise, in particular the *position-less row* path where the coordinate strip
+is a no-op but the diagnostic attributes must still survive.
+
+The exhaustive ``--cov-report=term-missing``-driven gap closure across the other
+``sensor.py`` entity classes runs in the PR/CI environment (Python 3.13, real
+Home Assistant); see AP4 DoD-1/DoD-2. The planning container cannot execute the
+HA test suite, so this file focuses on the changed-code branches that are most
+load-bearing for not regressing the file's coverage (risk F6).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from tests.test_last_seen_sensor_no_map_attributes import _build_last_seen_sensor
+
+# A decoder row with diagnostics but no resolvable position. ``_as_ha_attributes``
+# omits latitude/longitude (both None), so the consumer's ``pop`` is a no-op while
+# the diagnostic keys remain.
+_POSITIONLESS_ROW: dict[str, Any] = {
+    "id": "dev-1",
+    "device_id": "dev-1",
+    "name": "Pixel",
+    "accuracy": 25.0,
+    "last_seen": 1_700_000_000,
+    "source_label": "Network",
+    "source_rank": 2,
+}
+
+
+async def test_last_seen_sensor_positionless_row_keeps_diagnostics(
+    deterministic_config_subentry_id: Callable[[Any, str, str | None], str],
+) -> None:
+    """A row without coordinates yields diagnostics and never adds lat/lon.
+
+    Exercises the branch where the helper emits no coordinate keys: the strip is a
+    no-op, the result is non-empty, and the TIMESTAMP sensor still surfaces its
+    diagnostic attributes.
+    """
+
+    entity = await _build_last_seen_sensor(
+        _POSITIONLESS_ROW, deterministic_config_subentry_id
+    )
+    attrs = entity.extra_state_attributes
+
+    assert attrs is not None
+    assert "latitude" not in attrs
+    assert "longitude" not in attrs
+    assert "accuracy_m" in attrs
+    assert "last_seen" in attrs

--- a/tests/test_shared_key_retrieval.py
+++ b/tests/test_shared_key_retrieval.py
@@ -1,0 +1,385 @@
+# tests/test_shared_key_retrieval.py
+"""Unit and regression tests for ``KeyBackup.shared_key_retrieval``.
+
+These tests drive the entry-scoped shared-key retrieval helper towards full
+line/branch coverage and lock in three previously fixed bugs:
+
+* **Cross-account leakage** - the helper must read/write strictly against the
+  per-entry ``TokenCache`` it is handed; two account caches must never bleed
+  into each other (module docstring lines 13-15).
+* **"Five browser windows" guard** - the interactive browser flow may run at
+  most once per process; a second attempt must fail fast instead of opening
+  another Chrome window (``_browser_flow_attempted`` guard).
+* **base64 -> hex self-heal** - a stored base64/base64url/PEM-like value must be
+  normalised to hex on first read so later reads stay on the fast hex path.
+"""
+
+from __future__ import annotations
+
+import base64
+import sys
+from collections.abc import Awaitable, Callable
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+from custom_components.googlefindmy.KeyBackup import shared_key_retrieval as skr
+
+# A deterministic 32-byte key used across the suite.
+_RAW_KEY = bytes(range(32))
+_HEX_KEY = _RAW_KEY.hex()
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class FakeCache:
+    """Duck-typed stand-in for ``TokenCache`` (get/set/get_or_set only).
+
+    Mirrors the real ``is not None`` semantics of ``get_or_set`` so that a
+    value stored as ``None`` is treated as absent and triggers regeneration.
+    """
+
+    def __init__(self, initial: dict[str, Any] | None = None) -> None:
+        self._data: dict[str, Any] = dict(initial or {})
+        self.set_calls: list[tuple[str, Any]] = []
+
+    async def get(self, name: str) -> Any:
+        return self._data.get(name)
+
+    async def set(self, name: str, value: Any | None) -> None:
+        self.set_calls.append((name, value))
+        self._data[name] = value
+
+    async def get_or_set(
+        self, name: str, generator: Callable[[], Awaitable[Any] | Any]
+    ) -> Any:
+        existing = self._data.get(name)
+        if existing is not None:
+            return existing
+        candidate = generator()
+        if hasattr(candidate, "__await__"):
+            candidate = await candidate
+        await self.set(name, candidate)
+        return candidate
+
+
+class FailingSetCache(FakeCache):
+    """``FakeCache`` whose first ``set`` raises, to exercise the guard path."""
+
+    def __init__(self, initial: dict[str, Any] | None = None) -> None:
+        super().__init__(initial)
+        self._failed = False
+
+    async def set(self, name: str, value: Any | None) -> None:
+        if not self._failed:
+            self._failed = True
+            raise RuntimeError("simulated cache failure")
+        await super().set(name, value)
+
+
+@pytest.fixture(autouse=True)
+def _reset_browser_guard() -> Any:
+    """Isolate the module-level one-shot browser-flow guard between tests."""
+    skr._browser_flow_attempted = False
+    yield
+    skr._browser_flow_attempted = False
+
+
+@pytest.fixture
+def tty_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pretend we run in an interactive TTY (CLI mode)."""
+    monkeypatch.setattr(sys, "stdin", SimpleNamespace(isatty=lambda: True))
+
+
+@pytest.fixture
+def no_tty_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pretend we run head-less (Home Assistant / non-interactive mode)."""
+    monkeypatch.setattr(sys, "stdin", SimpleNamespace(isatty=lambda: False))
+
+
+# ---------------------------------------------------------------------------
+# _decode_hex_32
+# ---------------------------------------------------------------------------
+
+
+def test_decode_hex_32_plain() -> None:
+    assert skr._decode_hex_32(_HEX_KEY) == _RAW_KEY
+
+
+def test_decode_hex_32_accepts_prefix_whitespace_and_uppercase() -> None:
+    spaced = "0X" + " ".join(_HEX_KEY[i : i + 2].upper() for i in range(0, len(_HEX_KEY), 2))
+    assert skr._decode_hex_32(spaced) == _RAW_KEY
+
+
+def test_decode_hex_32_pads_odd_length() -> None:
+    # 63 hex chars (odd) that pad to a valid 32-byte value: drop one leading "0".
+    odd = _HEX_KEY[1:]
+    assert len(odd) % 2 == 1
+    assert skr._decode_hex_32(odd) == _RAW_KEY
+
+
+def test_decode_hex_32_rejects_non_hex() -> None:
+    with pytest.raises(ValueError, match="non-hex"):
+        skr._decode_hex_32("zz" * 32)
+
+
+def test_decode_hex_32_rejects_wrong_length() -> None:
+    with pytest.raises(ValueError, match="invalid length"):
+        skr._decode_hex_32("ab" * 16)  # 16 bytes, not 32
+
+
+def test_decode_hex_32_handles_none_like_empty() -> None:
+    with pytest.raises(ValueError, match="invalid length"):
+        skr._decode_hex_32("")
+
+
+# ---------------------------------------------------------------------------
+# _decode_base64_like_32
+# ---------------------------------------------------------------------------
+
+
+def test_decode_base64_like_32_standard() -> None:
+    encoded = base64.b64encode(_RAW_KEY).decode()
+    assert skr._decode_base64_like_32(encoded) == _RAW_KEY
+
+
+def test_decode_base64_like_32_urlsafe_and_pem_and_whitespace() -> None:
+    body = base64.urlsafe_b64encode(_RAW_KEY).decode()
+    pem = f"-----BEGIN KEY-----\n{body[:20]}\n{body[20:]}\n-----END KEY-----"
+    assert skr._decode_base64_like_32(pem) == _RAW_KEY
+
+
+def test_decode_base64_like_32_rejects_wrong_length() -> None:
+    encoded = base64.b64encode(b"short").decode()
+    with pytest.raises(ValueError, match="invalid length"):
+        skr._decode_base64_like_32(encoded)
+
+
+# ---------------------------------------------------------------------------
+# _user_scoped_key
+# ---------------------------------------------------------------------------
+
+
+def test_user_scoped_key_format() -> None:
+    assert skr._user_scoped_key("alice") == "shared_key_alice"
+
+
+# ---------------------------------------------------------------------------
+# _get_or_generate_shared_key_hex
+# ---------------------------------------------------------------------------
+
+
+async def test_generate_requires_cache() -> None:
+    with pytest.raises(ValueError, match="TokenCache instance is required"):
+        await skr._get_or_generate_shared_key_hex(cache=None, username=None)  # type: ignore[arg-type]
+
+
+async def test_generate_returns_cached_entry_scoped_value() -> None:
+    cache = FakeCache({skr._CACHE_KEY_BASE: _HEX_KEY})
+    result = await skr._get_or_generate_shared_key_hex(cache=cache, username="alice")
+    assert result == _HEX_KEY
+    assert cache.set_calls == []  # pure cache hit, no writes
+
+
+async def test_generate_migrates_legacy_user_scoped_key() -> None:
+    cache = FakeCache({skr._user_scoped_key("alice"): _HEX_KEY})
+    result = await skr._get_or_generate_shared_key_hex(cache=cache, username="alice")
+    assert result == _HEX_KEY
+    # Migration persists the value under the canonical entry-scoped key.
+    assert (skr._CACHE_KEY_BASE, _HEX_KEY) in cache.set_calls
+
+
+async def test_generate_invokes_generator_when_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_retrieve() -> str:
+        return _HEX_KEY
+
+    monkeypatch.setattr(skr, "_retrieve_shared_key_hex", fake_retrieve)
+    cache = FakeCache()
+    result = await skr._get_or_generate_shared_key_hex(cache=cache, username=None)
+    assert result == _HEX_KEY
+
+
+async def test_generate_rejects_non_string_generator_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_retrieve() -> Any:
+        return 12345  # not a string
+
+    monkeypatch.setattr(skr, "_retrieve_shared_key_hex", fake_retrieve)
+    cache = FakeCache()
+    with pytest.raises(RuntimeError, match="non-string value"):
+        await skr._get_or_generate_shared_key_hex(cache=cache, username=None)
+
+
+async def test_force_refresh_clears_then_regenerates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_retrieve() -> str:
+        return _HEX_KEY
+
+    monkeypatch.setattr(skr, "_retrieve_shared_key_hex", fake_retrieve)
+    cache = FakeCache({skr._CACHE_KEY_BASE: "deadbeef" * 8})
+    result = await skr._get_or_generate_shared_key_hex(
+        cache=cache, username="alice", force_refresh=True
+    )
+    assert result == _HEX_KEY
+    # The stale value was explicitly cleared before regeneration.
+    assert (skr._CACHE_KEY_BASE, None) in cache.set_calls
+    assert (skr._user_scoped_key("alice"), None) in cache.set_calls
+
+
+async def test_force_refresh_tolerates_clear_failure() -> None:
+    cache = FailingSetCache({skr._CACHE_KEY_BASE: _HEX_KEY})
+    # The first set() raises; the helper must swallow it and fall back to the
+    # still-cached value rather than propagating the error.
+    result = await skr._get_or_generate_shared_key_hex(
+        cache=cache, username=None, force_refresh=True
+    )
+    assert result == _HEX_KEY
+
+
+# ---------------------------------------------------------------------------
+# _retrieve_shared_key_hex (TTY gating + one-shot guard)
+# ---------------------------------------------------------------------------
+
+
+async def test_retrieve_raises_in_non_interactive_mode(no_tty_stdin: None) -> None:
+    with pytest.raises(RuntimeError, match="non-interactive environment"):
+        await skr._retrieve_shared_key_hex()
+
+
+async def test_retrieve_returns_interactive_result(
+    tty_stdin: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def fake_flow() -> str:
+        return _HEX_KEY
+
+    monkeypatch.setattr(skr, "_interactive_flow_hex", fake_flow)
+    assert await skr._retrieve_shared_key_hex() == _HEX_KEY
+    # The guard flips so a second call in the same process is refused.
+    assert skr._browser_flow_attempted is True
+
+
+async def test_retrieve_guard_blocks_second_browser_attempt(
+    tty_stdin: None,
+) -> None:
+    """Regression: the browser flow must not open a second Chrome window."""
+    skr._browser_flow_attempted = True
+    with pytest.raises(RuntimeError, match="already attempted"):
+        await skr._retrieve_shared_key_hex()
+
+
+async def test_retrieve_wraps_interactive_failure(
+    tty_stdin: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def boom() -> str:
+        raise ValueError("no chrome")
+
+    monkeypatch.setattr(skr, "_interactive_flow_hex", boom)
+    with pytest.raises(RuntimeError, match="Shared key retrieval failed"):
+        await skr._retrieve_shared_key_hex()
+
+
+# ---------------------------------------------------------------------------
+# _interactive_flow_hex
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_flow(
+    monkeypatch: pytest.MonkeyPatch, return_value: Any
+) -> None:
+    """Inject a fake ``shared_key_flow`` module and a pass-through executor."""
+    module = ModuleType("custom_components.googlefindmy.KeyBackup.shared_key_flow")
+    module.request_shared_key_flow = lambda: return_value  # type: ignore[attr-defined]
+    monkeypatch.setitem(
+        sys.modules,
+        "custom_components.googlefindmy.KeyBackup.shared_key_flow",
+        module,
+    )
+
+    async def passthrough(func: Callable[..., Any], *args: Any) -> Any:
+        return func(*args)
+
+    monkeypatch.setattr(skr, "_run_in_executor", passthrough)
+
+
+async def test_interactive_flow_accepts_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_flow(monkeypatch, _RAW_KEY)
+    assert await skr._interactive_flow_hex() == _HEX_KEY
+
+
+async def test_interactive_flow_rejects_wrong_length_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_flow(monkeypatch, b"too-short")
+    with pytest.raises(RuntimeError, match="invalid length"):
+        await skr._interactive_flow_hex()
+
+
+async def test_interactive_flow_rejects_empty_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_flow(monkeypatch, "   ")
+    with pytest.raises(RuntimeError, match="empty/invalid result"):
+        await skr._interactive_flow_hex()
+
+
+async def test_interactive_flow_accepts_hex_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_flow(monkeypatch, _HEX_KEY)
+    assert await skr._interactive_flow_hex() == _HEX_KEY
+
+
+async def test_interactive_flow_accepts_base64_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_flow(monkeypatch, base64.urlsafe_b64encode(_RAW_KEY).decode())
+    assert await skr._interactive_flow_hex() == _HEX_KEY
+
+
+# ---------------------------------------------------------------------------
+# async_get_shared_key (public API)
+# ---------------------------------------------------------------------------
+
+
+async def test_async_get_shared_key_requires_cache() -> None:
+    with pytest.raises(ValueError, match="TokenCache instance is required"):
+        await skr.async_get_shared_key(cache=None)  # type: ignore[arg-type]
+
+
+async def test_async_get_shared_key_hex_fast_path() -> None:
+    cache = FakeCache({skr._CACHE_KEY_BASE: _HEX_KEY})
+    assert await skr.async_get_shared_key(cache=cache) == _RAW_KEY
+
+
+async def test_async_get_shared_key_self_heals_base64_to_hex() -> None:
+    """Regression: a stored base64 value is normalised to hex on first read."""
+    b64_value = base64.urlsafe_b64encode(_RAW_KEY).decode()
+    cache = FakeCache({skr._CACHE_KEY_BASE: b64_value})
+    result = await skr.async_get_shared_key(cache=cache)
+    assert result == _RAW_KEY
+    # The cache now holds the normalised hex form, not the original base64.
+    assert await cache.get(skr._CACHE_KEY_BASE) == _HEX_KEY
+
+
+async def test_async_get_shared_key_isolates_accounts() -> None:
+    """Regression: per-entry caches must not leak across accounts."""
+    key_a = bytes([1]) * 32
+    key_b = bytes([2]) * 32
+    cache_a = FakeCache({skr._CACHE_KEY_BASE: key_a.hex()})
+    cache_b = FakeCache({skr._CACHE_KEY_BASE: key_b.hex()})
+
+    assert await skr.async_get_shared_key(cache=cache_a) == key_a
+    assert await skr.async_get_shared_key(cache=cache_b) == key_b
+    # Account B's read never wrote into account A's cache and vice versa.
+    assert cache_a.set_calls == []
+    assert cache_b.set_calls == []

--- a/tests/test_spot_grpc_client.py
+++ b/tests/test_spot_grpc_client.py
@@ -371,7 +371,10 @@ class _DummyEntry:
         self.data = {"email": "user@example.com"}
         self.reauth_calls = 0
 
-    async def async_start_reauth(self, hass) -> None:  # noqa: D401 - stub signature
+    def async_start_reauth(self, hass) -> None:  # noqa: D401 - stub signature
+        # Mirror the real ``ConfigEntry.async_start_reauth``: a synchronous
+        # ``@callback`` returning ``None``. An async stub would mask a stray
+        # ``await`` in production code (see test_manual_locate_starts_reauth).
         self.reauth_calls += 1
 
 
@@ -458,7 +461,12 @@ async def test_manual_locate_starts_reauth(monkeypatch: pytest.MonkeyPatch) -> N
         AsyncMock(return_value=None),
     )
 
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(HomeAssistantError) as exc_info:
         await coordinator.async_locate_device("dev-1")
 
     assert entry.reauth_calls == 1
+    # The success branch must report that reauth was started. A stray ``await``
+    # on the synchronous ``@callback`` would raise ``TypeError`` (swallowed by
+    # the defensive ``except``), leaving ``reauth_started`` False and emitting
+    # the "please re-authenticate" message instead. Guard against that.
+    assert "has been started" in str(exc_info.value)

--- a/tests/test_spot_grpc_resilience.py
+++ b/tests/test_spot_grpc_resilience.py
@@ -235,6 +235,90 @@ async def test_protocol_error_triggers_reset(monkeypatch: pytest.MonkeyPatch) ->
     transport.reset.assert_awaited_once()
 
 
+_SSL_TEARDOWN_ERR = AttributeError(
+    "'NoneType' object has no attribute '_write_appdata'"
+)
+
+
+@pytest.mark.asyncio
+async def test_ssl_teardown_error_resets_and_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AP9 (finding 6a): the SSL-transport teardown race resets and retries.
+
+    grpclib writing to a detached SSL transport raises
+    ``AttributeError('... _write_appdata')`` from asyncio.sslproto. The new
+    handler must treat it like the other transient transport errors: reset the
+    (possibly poisoned) channel and retry within budget.
+    """
+    plan: list[Exception | bytes | None] = [_SSL_TEARDOWN_ERR, b"reply"]
+    _install_stub_method(monkeypatch, plan)
+    transport = AsyncMock()
+    transport.get_channel = AsyncMock(return_value=object())
+    transport.reset = AsyncMock()
+    cache = _DummyCache()
+
+    result = await spot_request_module.async_spot_request(
+        "Scope",
+        b"payload",
+        cache=cache,
+        transport=transport,  # type: ignore[arg-type]
+    )
+
+    assert result == b"reply"
+    transport.reset.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_ssl_teardown_error_exhausts_to_network_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AP9: a persistent teardown race converts to SpotNetworkError after retries."""
+    plan: list[Exception | bytes | None] = [_SSL_TEARDOWN_ERR]
+    _install_stub_method(monkeypatch, plan)
+    transport = AsyncMock()
+    transport.get_channel = AsyncMock(return_value=object())
+    transport.reset = AsyncMock()
+    cache = _DummyCache()
+
+    with pytest.raises(spot_request_module.SpotNetworkError):
+        await spot_request_module.async_spot_request(
+            "Scope",
+            b"payload",
+            cache=cache,
+            transport=transport,  # type: ignore[arg-type]
+        )
+
+    assert transport.reset.await_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_non_teardown_attribute_error_is_reraised(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AP9 (guard B): an unrelated AttributeError must NOT be masked.
+
+    The discriminator only matches the asyncio ``_write_appdata`` signature;
+    any other AttributeError is a genuine bug and is re-raised without a reset.
+    """
+    plan: list[Exception | bytes | None] = [AttributeError("totally unrelated")]
+    _install_stub_method(monkeypatch, plan)
+    transport = AsyncMock()
+    transport.get_channel = AsyncMock(return_value=object())
+    transport.reset = AsyncMock()
+    cache = _DummyCache()
+
+    with pytest.raises(AttributeError, match="totally unrelated"):
+        await spot_request_module.async_spot_request(
+            "Scope",
+            b"payload",
+            cache=cache,
+            transport=transport,  # type: ignore[arg-type]
+        )
+
+    assert transport.reset.await_count == 0
+
+
 def test_polling_path_translates_auth_error(monkeypatch: pytest.MonkeyPatch) -> None:
     """SpotAuthPermanentError from the API should surface as ConfigEntryAuthFailed."""
 

--- a/tests/test_spot_grpc_transport.py
+++ b/tests/test_spot_grpc_transport.py
@@ -13,6 +13,7 @@ import pytest
 from custom_components.googlefindmy.SpotApi.spot_grpc_transport import (
     RawCodec,
     SpotGrpcTransport,
+    is_ssl_transport_teardown_error,
 )
 
 
@@ -243,3 +244,23 @@ async def test_ssl_context_created_lazily_via_to_thread(
     await transport.get_channel()
 
     assert to_thread.await_count == 1
+
+
+def test_is_ssl_transport_teardown_error_signature() -> None:
+    """AP9 (finding 6a): the predicate isolates the fragile asyncio signature.
+
+    It must match exactly the SSL-transport teardown ``AttributeError`` and
+    nothing else, so every other AttributeError keeps propagating as a real bug.
+    Acts as an early-warning unit test should a future CPython rename the
+    internal ``_write_appdata`` attribute.
+    """
+    assert (
+        is_ssl_transport_teardown_error(
+            AttributeError("'NoneType' object has no attribute '_write_appdata'")
+        )
+        is True
+    )
+    # Wrong type / wrong signature / non-exception input must not match.
+    assert is_ssl_transport_teardown_error(AttributeError("other attribute")) is False
+    assert is_ssl_transport_teardown_error(ValueError("_write_appdata")) is False
+    assert is_ssl_transport_teardown_error(RuntimeError("_write_appdata")) is False

--- a/tests/test_spot_token_retrieval.py
+++ b/tests/test_spot_token_retrieval.py
@@ -1,0 +1,306 @@
+# tests/test_spot_token_retrieval.py
+"""Coverage + regression-lock tests for ``Auth/spot_token_retrieval``.
+
+These tests exercise the *real* orchestration of ``async_get_spot_token`` and
+``_async_generate_spot_token`` by mocking only their **dependencies**
+(``async_request_token``, ``request_token``, ``async_get_aas_token``,
+``async_get_username``) — never the SUT functions themselves. Mocking the SUT
+away is exactly the anti-pattern that left this module at 23 % coverage despite
+an existing propagation test (see ``test_spot_and_nova_cache_propagation.py``,
+which monkeypatches ``async_get_spot_token`` as a whole).
+
+Each ``RL-*`` test pins one member of the 6-commit "entry-scoped cache
+propagation" bug family so a regression would fail loudly:
+
+    RL-1  async happy path forwards ``cache=`` AND ``aas_provider=``   (bfd4a4f1)
+    RL-2  sync fallback forwards ``cache=`` AND resolved ``aas_token=`` (9b78b80a)
+    RL-3  without a provider, AAS is resolved from the SAME cache       (bfd4a4f1)
+    RL-4  ``cache=None`` raises ValueError (multi-account safety)       (1dd738e6)
+    RL-5  ``username=None`` resolved via provider; empty -> RuntimeError
+    RL-6  empty token from sync fallback -> RuntimeError
+    RL-7  cache key ``spot_token_{username}`` + ``get_or_set`` caching
+    RL-8  caller-supplied ``aas_provider`` is honored, not overwritten
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.Auth import (
+    spot_token_retrieval as spot_module,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeCache:
+    """Minimal entry-scoped cache mirroring ``TokenCache.get_or_set`` semantics.
+
+    Tracks how often the generator runs so cache-hit vs. cache-miss is testable.
+    """
+
+    def __init__(self) -> None:
+        self._data: dict[str, Any] = {}
+        self.generator_calls = 0
+
+    async def get(self, key: str) -> Any:
+        return self._data.get(key)
+
+    async def set(self, key: str, value: Any) -> None:
+        if value is None:
+            self._data.pop(key, None)
+            return
+        self._data[key] = value
+
+    async def get_or_set(
+        self, name: str, generator: Callable[[], Awaitable[Any] | Any]
+    ) -> Any:
+        if (existing := self._data.get(name)) is not None:
+            return existing
+        self.generator_calls += 1
+        candidate = generator()
+        if hasattr(candidate, "__await__"):
+            candidate = await candidate
+        self._data[name] = candidate
+        return candidate
+
+
+def _patch_deps(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    async_token: str | None = "async-token",
+    sync_token: str = "sync-token",
+    aas_token: str = "aas-default",
+    username: str | None = "user@example.com",
+) -> dict[str, Any]:
+    """Patch the four module-level dependencies; return the mocks for assertions."""
+
+    m_async_request = AsyncMock(return_value=async_token)
+    m_request = MagicMock(return_value=sync_token)
+    m_async_aas = AsyncMock(return_value=aas_token)
+    m_async_username = AsyncMock(return_value=username)
+
+    monkeypatch.setattr(spot_module, "async_request_token", m_async_request)
+    monkeypatch.setattr(spot_module, "request_token", m_request)
+    monkeypatch.setattr(spot_module, "async_get_aas_token", m_async_aas)
+    monkeypatch.setattr(spot_module, "async_get_username", m_async_username)
+
+    return {
+        "async_request_token": m_async_request,
+        "request_token": m_request,
+        "async_get_aas_token": m_async_aas,
+        "async_get_username": m_async_username,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# RL-1: async happy path forwards cache= AND aas_provider=                      #
+# --------------------------------------------------------------------------- #
+async def test_rl1_async_path_forwards_cache_and_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = _FakeCache()
+    deps = _patch_deps(monkeypatch, async_token="spot-async")
+
+    async def custom_provider() -> str:
+        return "provider-aas"
+
+    token = await spot_module.async_get_spot_token(
+        "user@example.com", cache=cache, aas_provider=custom_provider
+    )
+
+    assert token == "spot-async"
+    deps["async_request_token"].assert_awaited_once()
+    _, kwargs = deps["async_request_token"].call_args
+    assert kwargs["cache"] is cache
+    assert kwargs["aas_provider"] is custom_provider
+    # Happy path must NOT touch the sync fallback.
+    deps["request_token"].assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# RL-2: sync fallback forwards cache= AND resolved aas_token=                   #
+# --------------------------------------------------------------------------- #
+async def test_rl2_sync_fallback_forwards_cache_and_aas_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = _FakeCache()
+    # async path returns empty -> sync fallback engaged.
+    deps = _patch_deps(monkeypatch, async_token="", sync_token="spot-sync")
+
+    async def custom_provider() -> str:
+        return "resolved-aas"
+
+    token = await spot_module.async_get_spot_token(
+        "user@example.com", cache=cache, aas_provider=custom_provider
+    )
+
+    assert token == "spot-sync"
+    deps["request_token"].assert_called_once()
+    _, kwargs = deps["request_token"].call_args
+    assert kwargs["cache"] is cache
+    assert kwargs["aas_token"] == "resolved-aas"
+
+
+# --------------------------------------------------------------------------- #
+# RL-3: without provider, AAS resolved from the SAME cache                      #
+# --------------------------------------------------------------------------- #
+async def test_rl3_fallback_aas_uses_same_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = _FakeCache()
+    deps = _patch_deps(
+        monkeypatch, async_token="", sync_token="spot-sync", aas_token="aas-cache"
+    )
+
+    token = await spot_module.async_get_spot_token("user@example.com", cache=cache)
+
+    assert token == "spot-sync"
+    deps["async_get_aas_token"].assert_awaited_once()
+    _, kwargs = deps["async_get_aas_token"].call_args
+    assert kwargs["cache"] is cache
+    # Resolved AAS token must flow into the sync retriever.
+    _, rt_kwargs = deps["request_token"].call_args
+    assert rt_kwargs["aas_token"] == "aas-cache"
+
+
+# --------------------------------------------------------------------------- #
+# RL-4: cache=None -> ValueError (multi-account safety)                         #
+# --------------------------------------------------------------------------- #
+async def test_rl4_cache_none_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="TokenCache instance is required"):
+        await spot_module.async_get_spot_token("user@example.com", cache=None)
+
+
+# --------------------------------------------------------------------------- #
+# RL-5: username resolution via provider; invalid -> RuntimeError              #
+# --------------------------------------------------------------------------- #
+async def test_rl5_username_resolved_from_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = _FakeCache()
+    deps = _patch_deps(
+        monkeypatch, async_token="spot-async", username="resolved@example.com"
+    )
+
+    token = await spot_module.async_get_spot_token(None, cache=cache)
+
+    assert token == "spot-async"
+    deps["async_get_username"].assert_awaited_once()
+    _, kwargs = deps["async_get_username"].call_args
+    assert kwargs["cache"] is cache
+    # Cache key must use the resolved username.
+    assert "spot_token_resolved@example.com" in cache._data
+
+
+async def test_rl5_empty_username_raises_runtime_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = _FakeCache()
+    _patch_deps(monkeypatch, username=None)
+
+    with pytest.raises(RuntimeError, match="username is not configured"):
+        await spot_module.async_get_spot_token(None, cache=cache)
+
+
+# --------------------------------------------------------------------------- #
+# RL-6: empty token from sync fallback -> RuntimeError                          #
+# --------------------------------------------------------------------------- #
+async def test_rl6_empty_sync_token_raises_runtime_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = _FakeCache()
+    _patch_deps(monkeypatch, async_token="", sync_token="")
+
+    async def custom_provider() -> str:
+        return "resolved-aas"
+
+    with pytest.raises(RuntimeError, match="request_token returned empty token"):
+        await spot_module.async_get_spot_token(
+            "user@example.com", cache=cache, aas_provider=custom_provider
+        )
+
+
+# --------------------------------------------------------------------------- #
+# RL-7: cache key spot_token_{username} + get_or_set caching                    #
+# --------------------------------------------------------------------------- #
+async def test_rl7_cache_hit_skips_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = _FakeCache()
+    cache._data["spot_token_user@example.com"] = "cached-token"
+    deps = _patch_deps(monkeypatch)
+
+    token = await spot_module.async_get_spot_token("user@example.com", cache=cache)
+
+    assert token == "cached-token"
+    assert cache.generator_calls == 0
+    deps["async_request_token"].assert_not_awaited()
+
+
+async def test_rl7_cache_miss_stores_under_expected_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = _FakeCache()
+    _patch_deps(monkeypatch, async_token="fresh-token")
+
+    token = await spot_module.async_get_spot_token("user@example.com", cache=cache)
+
+    assert token == "fresh-token"
+    assert cache.generator_calls == 1
+    assert cache._data["spot_token_user@example.com"] == "fresh-token"
+
+
+# --------------------------------------------------------------------------- #
+# RL-8: caller-supplied aas_provider honored, not overwritten by fallback       #
+# --------------------------------------------------------------------------- #
+async def test_rl8_custom_provider_not_overwritten(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = _FakeCache()
+    deps = _patch_deps(monkeypatch, async_token="", sync_token="spot-sync")
+
+    async def custom_provider() -> str:
+        return "custom-aas"
+
+    token = await spot_module.async_get_spot_token(
+        "user@example.com", cache=cache, aas_provider=custom_provider
+    )
+
+    assert token == "spot-sync"
+    # The default cache-based AAS resolver must NOT be used when a provider is given.
+    deps["async_get_aas_token"].assert_not_awaited()
+    _, rt_kwargs = deps["request_token"].call_args
+    assert rt_kwargs["aas_token"] == "custom-aas"
+
+
+# --------------------------------------------------------------------------- #
+# Branch completeness: async-immediate vs. sync-fallback dispatch               #
+# --------------------------------------------------------------------------- #
+async def test_branch_async_immediate_skips_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = _FakeCache()
+    deps = _patch_deps(monkeypatch, async_token="immediate")
+
+    token = await spot_module.async_get_spot_token("user@example.com", cache=cache)
+
+    assert token == "immediate"
+    deps["request_token"].assert_not_called()
+    deps["async_get_aas_token"].assert_not_awaited()
+
+
+async def test_branch_none_async_token_uses_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = _FakeCache()
+    deps = _patch_deps(monkeypatch, async_token=None, sync_token="from-thread")
+
+    token = await spot_module.async_get_spot_token("user@example.com", cache=cache)
+
+    assert token == "from-thread"
+    deps["request_token"].assert_called_once()


### PR DESCRIPTION
## Summary

Forward-ports the `1.7.1` development branch from the fork into `1.7`. The headline is a
deeper FCM cascading-failure defense and a self-healing supervisor, plus several small
user-facing fixes, all backed by a large strictly-additive test suite. CI is green on the
fork and the branch merges cleanly into `1.7` (no conflicts).

This is **incremental** on top of the FCM work already in `1.7`: the basic missing-padding
re-pad (`urlsafe_b64decode(... + b"=" * (-len % 4))`) and the 404/HTML register classifier
are already present in `1.7` (released in `V1.7.0-6`). This branch deepens that foundation
rather than re-introducing it.

## Headline changes

### 1. FCM listener: cascading-failure defense beyond inline re-pad

The inline re-pad already in `1.7` fixes Python 3.14's stricter `binascii` for the
*missing-padding* case. This branch widens the protection so a single bad push can no longer
take down the listener loop:

- **Whitespace-tolerant decode helper** (`_safe_urlsafe_b64decode`): strips stray
  whitespace/newlines before re-padding, restoring pre-3.14 lenient behaviour for all
  FCM-stream base64, not just the missing-`=` case.
- **Typed `CredentialDecryptionError`** separates per-message decode failures from genuine
  credential-material corruption; corrupt encrypted bodies (`http_ece.ECEException`) and
  invalid base64 are treated as poison, not as listener-fatal.
- **Per-message poison defense:** an undecodable single message is ACK'd and skipped instead
  of crash-restarting the client, so it cannot wedge at the head of the queue (the #176-class
  loop).

### 2. Self-healing supervisor and credential re-registration

The listener supervisor now recovers from states that previously needed a manual restart:

- **Wedged-restart heal + registration error split:** sustained restart failures and ECE
  decrypt failures are escalated to a re-registration that keeps the GCM device identity
  (`reregister_keeping_identity`), refreshing FCM tokens without forcing a re-auth when the
  Google credentials are still valid. Registration error classes are split so a per-message
  fault and genuine credential corruption no longer share one code path.
- **Generation-aware teardown:** per-entry state purge is made symmetric and the
  config-entry teardown race is guarded, so an aborted/unwinding supervisor can no longer
  clobber the credentials, routing or fatal-error latch of the live generation (TOCTOU
  hardening, #1107 / #1108).
- **Fixable reauth Repair (#1104):** when push stays stuck despite the self-heal, a Repairs
  issue offers a one-click reauth flow instead of leaving the user without a path forward
  (new `repairs.py`).

### 3. Restart-required Repairs warning after update (#1101)

When the integration files are updated (e.g. via HACS) but Home Assistant still runs the
previously loaded version, a Repairs issue now prompts for a restart. A periodic,
executor-based watchdog compares the on-disk `INTEGRATION_VERSION` against the version
captured at load time and raises/clears the issue. Localized strings in 12 languages; read
errors clear the issue instead of leaving it stale; guarded against resurrection on a timer
tick that races config-entry unload, and re-armed after a fast config-entry reload.

### 4. `last_seen` sensor no longer plots a spurious map marker (#1102)

The `last_seen` timestamp sensor passed `_as_ha_attributes` through unfiltered, emitting
`latitude`/`longitude` and causing HA to plot a third marker per device. The coordinate pair
is now stripped at the sensor consumer (via the HA `ATTR_LATITUDE`/`ATTR_LONGITUDE`
constants); the shared helper stays correct for the `device_tracker`, which legitimately
carries coordinates. Live-state attribute only, so it self-heals on the next state write
after the upgrade restart — no entity deletion or reconfigure.

### 5. Play-Sound keeps its cancel key so Stop-Sound can still cancel a ring (#1100 / #1106)

The Play-Sound client-side request UUID (the cancel/correlation key for Stop-Sound) was only
stored on the happy path, so a Stop after a partial/failed play sent a fresh UUID that never
correlated and left the tracker ringing. Cancel-key retention is now derived from the wire
contract: `async_nova_request` returns the body only on HTTP 200 and tags every re-raised
`NovaError` with a sticky `dispatched` latch that flips true as soon as any attempt reaches
the wire. So `api.async_play_sound` keeps the cancel key whenever a request provably reached
Google (even if a later retry fails pre-connect) and only drops it for purely pre-dispatch
failures — Stop-Sound can still target a device that may already be ringing.

### 6. Polling: stagger nested timeouts, demote idle logs (#1095)

Per-device polling wrapped the location request in an outer `asyncio.wait_for()` using the
same 30 s budget as the inner FCM wait, so the outer guard won the race and raised a spurious
`TimeoutError` before the inner clean empty-result could return — surfacing as repeated
warnings for idle BLE tags with no reporter in range. The outer guard is now strictly larger
than the inner wait and budgets both the Nova HTTP and FCM phases
(`POLL_DEVICE_OUTER_TIMEOUT_S`), and the idle "FCM connected" timeout is demoted to INFO.

### 7. Smaller correctness fixes

- **`grpclib` moved to the main dependency group (#1096):** it is a runtime import
  (`SpotApi/spot_grpc_transport.py`) but sat under dev dependencies, so `poetry install
  --only main` produced an integration that failed to import it at runtime.
- **SPOT gRPC SSL-transport teardown race classified:** the benign asyncio SSL-transport
  teardown error during gRPC shutdown is recognised instead of surfacing as a failure.
- **X-Android-Package/Cert headers pinned (#1098):** regression coverage so a refactor can
  no longer silently drop the Google API-key restriction headers on FCM registration.

## Test coverage

A large, strictly-additive suite forward-ported from the coverage-integration branch:
Class-A structure/behaviour tests (config flow, init, coordinator
identity/locate/main/polling/registry) plus crypto-family regression locks (shared-key
retrieval, SPOT-token retrieval, owner-key, cloud-key decryptor CBC alignment, LSKF Scrypt
parameters) and the FCM binascii-padding crypto family pinned to 100 %. The supervisor
lifecycle, generation-aware teardown, dispatch-latch and reauth-Repair fixes each ship with
their own regression tests. The coverage floor was recalibrated to 67 % after the port.

## Diff scope

- 84 files changed, +20,188 / −288.
- Component code: 30 files, +2,871 / −193 — heaviest in `Auth/fcm_receiver_ha.py`,
  `Auth/firebase_messaging/fcmpushclient.py`, `__init__.py`, `NovaApi/nova_request.py`,
  `coordinator/polling.py`, `repairs.py` (new), `api.py`.
- Remainder: 49 test modules (the coverage suite above plus the per-fix regression tests).
- `manifest.json` version `1.7.0-6` → `1.7.1`.

## Compatibility

- Target: HA Core 2026.6.x.
- `manifest.json` keeps `@BSkando` as codeowner and `BSkando/GoogleFindMy-HA` as the
  documentation/issue tracker.
- No config schema changes; existing entries continue to work without re-auth.

## Test plan

- [x] CI green on the fork (`jleinenbach:1.7.1`)
- [x] Crypto-family + Class-A suites at the calibrated coverage floor (67 %)
- [x] Clean merge into `1.7` confirmed (`MERGEABLE` / `CLEAN`, no conflicts)
- [ ] Smoke check on a real HA install: poisoned single push no longer loops; healthy run clears any latched state
- [ ] Smoke check: wedged push escalates to the fixable reauth Repair; a successful reauth clears it
- [ ] Smoke check: restart-required Repairs issue appears after a HACS update and clears after restart
- [ ] Smoke check: no third map marker from `last_seen`; Stop-Sound cancels a partially-failed Play

## Note on the divergence

`1.7.1` branched from the `#1088` FCM-classifier-hardening point and developed independently
while `1.7` advanced (1.7.0-5/-6, docs, translations). The branch currently merges into `1.7`
conflict-free. If you prefer a narrower landing, the FCM hardening, the supervisor self-heal
and the small fixes can each be split into standalone follow-ups.
