### PR TITLE
feat: integrate 1.7.2 (E2EE stale-key reauth, encryption-key status sensor, quieter logs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,7 +414,7 @@ jobs:
           PYTHONPATH: .
         run: |
           set -o pipefail
-          poetry run pytest -q --cov --cov-report=xml --cov-report=term --cov-fail-under=67 2>&1 | tee pytest_output.log
+          poetry run pytest -q --cov --cov-report=xml --cov-report=term --cov-fail-under=69 2>&1 | tee pytest_output.log
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ The manifest classifies Google Find My Device as a **hub** integration. Home Ass
 
 ### <ins>Authentication Part 1 (External Steps)</ins>
 1. Navigate to [GoogleFindMyTools](https://github.com/leonboe1/GoogleFindMyTools?tab=readme-ov-file#how-to-use) repository and follow the directions on "How to use" the main.py script.
+   > [!IMPORTANT]
+   > Run the authentication script from the **same public IP address / network** that your Home Assistant instance uses, and sign in with the **same Google account** that owns the trackers. Google ties the end-to-end encryption keys in `secrets.json` to the account and may revoke them when requests arrive from a different IP or region. A mismatch produces a bundle that lists your devices and can ring them, but cannot decrypt any location reports — see [Devices appear but no location updates](#authentication-expires-repeatedly).
 2. **CRITICAL STEP!**  Complete the **ENTIRE** authentication process to generate `Auth/secrets.json`
 > [!WARNING]
 >While going through the process in main.py to authenticate, you **MUST** go through **2 login processes!**  After the first login is successful, your available devices will be listed.  You must complete the next step to display location data for one of your devices.  You will then login again.  After you complete this step, you should see valid location data for your device, followed by several errors that are not important.  ONLY at this point are you ready to move on to the next step!

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -2963,6 +2963,35 @@ class FcmReceiverHA:
 
     # -------------------- Decode helper --------------------
 
+    def _note_decrypt_failure_for_entry(
+        self, entry_id: str, *, stale: bool, error: Exception
+    ) -> None:
+        """Feed a background-path decryption failure into the matching coordinator(s).
+
+        Mirrors the poll path so a push-only setup escalates to re-authentication
+        identically (one shared counter, no second divergent code path). Because the
+        background decode runs outside a coordinator update cycle, an escalation
+        cannot be surfaced by raising ``ConfigEntryAuthFailed`` here; instead the
+        entry's reauth flow is started directly -- the same synchronous ``@callback``
+        mechanism repairs.py and coordinator/locate.py already use. It is idempotent:
+        Home Assistant does not duplicate an already-open reauth flow.
+
+        This must never break the push path, so all failures are swallowed to debug.
+        """
+        hass = self._hass
+        for coordinator in self._coordinators_for_entries({entry_id}):
+            try:
+                escalate = coordinator.note_decrypt_failure(stale=stale, error=error)
+            except Exception as err:  # noqa: BLE001 - never break the push path
+                _LOGGER.debug(
+                    "note_decrypt_failure failed for entry %s: %s", entry_id, err
+                )
+                continue
+            if escalate and hass is not None:
+                entry = getattr(coordinator, "config_entry", None)
+                if entry is not None:
+                    entry.async_start_reauth(hass)
+
     async def _decode_background_location_async(  # noqa: PLR0911
         self, entry_id: str, hex_string: str
     ) -> JSONDict:
@@ -2991,18 +3020,25 @@ class FcmReceiverHA:
                     raw_locations = await async_decrypt_location_response_locations(
                         device_update, cache=cache
                     )
-                except StaleOwnerKeyError:
+                except StaleOwnerKeyError as stale_err:
                     _LOGGER.info(
-                        "Background location update skipped (stale key) for entry %s",
+                        "Background location update skipped (stale tracker key) for "
+                        "entry %s",
                         entry_id,
+                    )
+                    self._note_decrypt_failure_for_entry(
+                        entry_id, stale=True, error=stale_err
                     )
                     return {}
                 except DecryptionError as dec_err:
                     _LOGGER.warning(
                         "Background location decryption failed for entry %s: %s. "
-                        "This may resolve after re-authentication or key refresh.",
+                        "Escalates to re-authentication if it persists.",
                         entry_id,
                         dec_err,
+                    )
+                    self._note_decrypt_failure_for_entry(
+                        entry_id, stale=False, error=dec_err
                     )
                     return {}
                 except InvalidTag:

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -2992,6 +2992,26 @@ class FcmReceiverHA:
                 if entry is not None:
                     entry.async_start_reauth(hass)
 
+    def _note_decrypt_success_for_entry(self, entry_id: str) -> None:
+        """Feed a background-path decryption success into the matching coordinator(s).
+
+        Symmetric counterpart of :meth:`_note_decrypt_failure_for_entry`. The
+        background decode shares the coordinator's account-wide decrypt-failure
+        counter, so a successful background decrypt must clear it just like a
+        clean poll cycle does. Without this, push-only accounts whose scheduled
+        polls stay idle could accumulate a couple of *non-consecutive* background
+        decrypt failures up to the reauth threshold even though real locations
+        keep arriving and decrypting -- a spurious reauth prompt. Swallowed to
+        debug so it never breaks the push path.
+        """
+        for coordinator in self._coordinators_for_entries({entry_id}):
+            try:
+                coordinator.note_decrypt_success()
+            except Exception as err:  # noqa: BLE001 - never break the push path
+                _LOGGER.debug(
+                    "note_decrypt_success failed for entry %s: %s", entry_id, err
+                )
+
     async def _decode_background_location_async(  # noqa: PLR0911
         self, entry_id: str, hex_string: str
     ) -> JSONDict:
@@ -3055,6 +3075,19 @@ class FcmReceiverHA:
             )
             if not locations:
                 return {}
+
+            # Usable decrypted records: positive proof the account-wide shared key
+            # still works (mirrors the poll cycle's cycle_had_successful_decrypt
+            # gate). Clear the shared reauth budget so non-consecutive background
+            # failures interleaved with successful pushes cannot strand a healthy
+            # account at the reauth threshold.
+            # Keyed on the source entry_id -- the cache that actually performed
+            # this decrypt -- and symmetric with the failure paths above. Routed
+            # fan-out targets share the source's FCM registration token, hence the
+            # same account-wide owner_key, so the source success already proves
+            # their key; clearing the routed target set instead would break the
+            # source entry's own reset invariant.
+            self._note_decrypt_success_for_entry(entry_id)
 
             best_record: Mapping[str, Any] | None = None
             best_key: tuple[float, int, int] | None = None

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -3002,15 +3002,21 @@ class FcmReceiverHA:
         clean poll cycle does. Without this, push-only accounts whose scheduled
         polls stay idle could accumulate a couple of *non-consecutive* background
         decrypt failures up to the reauth threshold even though real locations
-        keep arriving and decrypting -- a spurious reauth prompt. Swallowed to
-        debug so it never breaks the push path.
+        keep arriving and decrypting -- a spurious reauth prompt. The same idle
+        push-only condition would also strand the diagnostic encryption-key
+        sensor on a stale ``shared_key_invalid`` / ``shared_key_missing`` status,
+        so this proven decrypt heals the account-wide sensor state too via
+        :meth:`note_background_decrypt_success`. Swallowed to debug so it never
+        breaks the push path.
         """
         for coordinator in self._coordinators_for_entries({entry_id}):
             try:
-                coordinator.note_decrypt_success()
+                coordinator.note_background_decrypt_success()
             except Exception as err:  # noqa: BLE001 - never break the push path
                 _LOGGER.debug(
-                    "note_decrypt_success failed for entry %s: %s", entry_id, err
+                    "note_background_decrypt_success failed for entry %s: %s",
+                    entry_id,
+                    err,
                 )
 
     async def _decode_background_location_async(  # noqa: PLR0911

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -88,6 +88,7 @@ from custom_components.googlefindmy.exceptions import FatalRegistrationError
 from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     DecryptionError,
     StaleOwnerKeyError,
+    any_real_location_record,
     async_decrypt_location_response_locations,
 )
 from custom_components.googlefindmy.NovaApi.nova_request import (
@@ -3076,18 +3077,24 @@ class FcmReceiverHA:
             if not locations:
                 return {}
 
-            # Usable decrypted records: positive proof the account-wide shared key
-            # still works (mirrors the poll cycle's cycle_had_successful_decrypt
-            # gate). Clear the shared reauth budget so non-consecutive background
-            # failures interleaved with successful pushes cannot strand a healthy
-            # account at the reauth threshold.
+            # Clear the shared reauth budget only on positive proof: at least one
+            # *authenticated* coordinate report. Truthy-but-unauthenticated rows --
+            # a metadata_only sentinel (only secrets-bundle key material) or a
+            # SEMANTIC row (no decrypted coordinates) -- are non-empty but carry no
+            # successful decrypt, so they must NOT clear the budget -- otherwise
+            # report-less pushes interleaved with failures could keep a stale key
+            # below the reauth threshold. This mirrors the poll cycle's
+            # cycle_had_successful_decrypt gate, which excludes the same shapes,
+            # and lets non-consecutive background failures interleaved with genuine
+            # pushes avoid stranding a healthy account at the reauth threshold.
             # Keyed on the source entry_id -- the cache that actually performed
             # this decrypt -- and symmetric with the failure paths above. Routed
             # fan-out targets share the source's FCM registration token, hence the
             # same account-wide owner_key, so the source success already proves
             # their key; clearing the routed target set instead would break the
             # source entry's own reset invariant.
-            self._note_decrypt_success_for_entry(entry_id)
+            if any_real_location_record(locations):
+                self._note_decrypt_success_for_entry(entry_id)
 
             best_record: Mapping[str, Any] | None = None
             best_key: tuple[float, int, int] | None = None

--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
@@ -791,7 +791,15 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
         self.input_stream_id += 1
 
         if isinstance(msg, Close):
-            self._log_warn_with_limit("Server sent Close message; worker stopping")
+            # A server-initiated Close is a normal part of the MCS connection
+            # life-cycle (the endpoint periodically rotates long-lived streams).
+            # Log it at INFO, consistent with the other normal worker-stop paths
+            # below ("FCM stream ended" / "FCM read ended"); the supervisor will
+            # reconnect automatically. Emitting WARNING here produced a recurring
+            # false alarm in the Home Assistant log panel.
+            self.logger.info(
+                "FCM server sent Close; worker stopping (normal, supervisor will reconnect)"
+            )
             self.do_listen = False
             return
 

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -879,6 +879,52 @@ def _infer_report_hint(status_value: Any) -> str | None:
     return None
 
 
+def is_real_location_record(record: dict[str, Any] | None) -> bool:
+    """Return True only for an authenticated, decrypted *coordinate* report.
+
+    Clearing the shared decrypt-failure (reauth) budget requires positive proof
+    that the account-wide shared key still decrypts. Decrypted coordinates are
+    that proof: they are produced exclusively by the authenticated crypto path
+    (own/foreign AES-GCM decrypt, then lat/lon validation below). Requiring a real
+    coordinate pair is therefore an allowlist for genuine reports and rejects every
+    truthy-but-unauthenticated record shape, including:
+
+    - ``metadata_only=True`` sentinel rows -- only secrets-bundle key *material*,
+      emitted when no encrypted report decrypts (e.g. a phone without a fresh fix).
+    - ``SEMANTIC`` rows -- appended with ``decrypted_location=b""`` and ``continue``d
+      before the crypto path, so they carry a server-provided ``semantic_name`` and
+      a ``last_seen`` timestamp but ``latitude``/``longitude`` are ``None``.
+
+    Neither shape carries coordinates, so neither may clear the budget; a denylist
+    on a single known sentinel (``metadata_only``) would miss the others. ``is not
+    None`` (not truthiness) preserves legitimate ``0.0`` coordinates. The metadata
+    merges below only ever write key-material/date keys, never ``latitude``/
+    ``longitude``, so they cannot make a sentinel/SEMANTIC row look authenticated.
+    """
+    if not record:
+        return False
+    return record.get("latitude") is not None and record.get("longitude") is not None
+
+
+def any_real_location_record(records: list[dict[str, Any]] | None) -> bool:
+    """Return True if ANY record in a response authenticates a coordinate report.
+
+    The decrypt proof -- positive evidence that the account-wide shared key still
+    decrypts -- is a property of the WHOLE response, not of any single record. A
+    display selector that ranks by newest ``last_seen`` (see
+    ``api._select_best_location``) can hand back a report-less SEMANTIC/metadata
+    row even when a sibling coordinate report decrypted successfully in the same
+    response. Evaluating only that collapsed record would discard the proof and
+    let a later transient failure trip a spurious reauth. Both automatic paths
+    (poll and background push) must therefore run the FULL candidate list through
+    this one predicate so a hidden success is never lost. See
+    ``is_real_location_record`` for the per-record allowlist.
+    """
+    if not records:
+        return False
+    return any(is_real_location_record(record) for record in records)
+
+
 # ----------------------------- Main decryptor ---------------------------------
 async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
     device_update_protobuf: DeviceUpdateProto, *, cache: TokenCache

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -568,7 +568,12 @@ async def async_retrieve_identity_key(
         )
         raise
     except Exception as meta_exc:  # best-effort diagnostics
-        _LOGGER.warning(
+        # Downgraded to debug: this metadata fetch is a non-actionable,
+        # best-effort diagnostic aid. Its failure (e.g. transient network
+        # timeout or SSL teardown) is swallowed and the regular decrypt
+        # error path continues unaffected, so it must not surface as a
+        # user-facing WARNING.
+        _LOGGER.debug(
             "Failed to retrieve E2EE metadata for diagnostics: %s", meta_exc
         )
 

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -243,7 +243,59 @@ class DecryptionError(RuntimeError):
 
 
 class StaleOwnerKeyError(DecryptionError):
-    """Raised when the tracker was encrypted with an older owner key version."""
+    """Raised when the tracker was encrypted with an older owner key version.
+
+    Per-tracker condition: a single tracker still encrypts reports with an
+    owner-key version that is no longer current. An account-wide re-auth does NOT
+    fix it; the tracker must be removed and re-paired. Kept distinct from the
+    account-wide shared-key failures below so the coordinator can escalate each
+    differently (per-tracker repair issue vs. ConfigEntryAuthFailed).
+    """
+
+
+class SharedKeyMismatchError(DecryptionError):
+    """Raised when the shared key cannot decrypt the owner key (AES-GCM InvalidTag).
+
+    Account-wide: the bundle's shared key is stale or incompatible with the
+    server-side owner key. Only a fresh secrets.json obtained via the interactive
+    browser flow can fix this; force_refresh of the owner key cannot, because the
+    shared key itself is the wrong one.
+    """
+
+
+class SharedKeyMissingError(DecryptionError):
+    """Raised when the shared key is absent or empty (incomplete bundle import).
+
+    Account-wide: the secrets.json did not provide a usable shared key. A complete
+    re-import / fresh secrets.json is required.
+    """
+
+
+def _classify_owner_key_failure(exc: Exception, *, context: str) -> DecryptionError:
+    """Map a low-level owner-key lookup failure to a specific DecryptionError.
+
+    ``async_get_owner_key`` collapses distinct root causes into either an
+    ``InvalidTag`` (wrong/stale shared key) or a ``RuntimeError`` (missing/empty
+    shared key, or a generic failure). This helper restores the discriminator as a
+    typed subclass so the failure class name appears in logs and the coordinator
+    can pick the correct recovery path. The caller preserves the original error
+    via ``raise ... from exc``.
+    """
+    if isinstance(exc, InvalidTag):
+        return SharedKeyMismatchError(
+            f"Owner key decryption failed (InvalidTag) during {context}: the shared "
+            "key is stale or incompatible with this account. A fresh secrets.json "
+            "is required (re-authentication)."
+        )
+    if isinstance(exc, RuntimeError) and "missing or empty" in str(exc):
+        return SharedKeyMissingError(
+            f"Shared key is missing or empty during {context} (incomplete bundle). "
+            "Re-import a complete secrets.json."
+        )
+    return DecryptionError(
+        f"Owner key decryption failed during {context} (shared key may be stale). "
+        "Re-authenticate to refresh crypto keys."
+    )
 
 
 async def _unwrap_encrypted_identity_key(
@@ -378,10 +430,7 @@ async def async_retrieve_identity_key(
     try:
         owner_key_info: OwnerKeyInfo = await async_get_owner_key(cache=cache)
     except (InvalidTag, RuntimeError) as exc:
-        raise DecryptionError(
-            "Owner key decryption failed (shared key may be stale). "
-            "Re-authenticate with --reauth to refresh crypto keys."
-        ) from exc
+        raise _classify_owner_key_failure(exc, context="initial lookup") from exc
 
     # --- Proactive Owner Key Version Mismatch Check ---
     # If the tracker requires a newer owner key version than what we have cached,
@@ -403,10 +452,7 @@ async def async_retrieve_identity_key(
                 cache=cache, force_refresh=True
             )
         except (InvalidTag, RuntimeError) as exc:
-            raise DecryptionError(
-                "Owner key refresh failed (InvalidTag). "
-                "Re-authenticate with --reauth to refresh crypto keys."
-            ) from exc
+            raise _classify_owner_key_failure(exc, context="forced refresh") from exc
 
     # Build key sources list (matches eid_resolver pattern: try owner + shared)
     key_sources: list[tuple[str, bytes]] = [("owner", owner_key_info.key)]
@@ -841,6 +887,12 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
     - Robust against partial/invalid reports (log and continue).
     - No prints or process termination; errors bubble or are logged with context.
 
+    Raises:
+        DecryptionError: if the device has its own encrypted reports and every
+            one of them fails authentication (no own-report success). This is an
+            account-wide stale-key signal; foreign/crowdsourced failures and
+            report-less devices never raise (they return ``[]``/metadata-only).
+
     Args:
         device_update_protobuf: Raw protobuf payload containing encrypted locations.
         cache: Entry-scoped TokenCache forwarded to key/EID helpers.
@@ -1206,6 +1258,14 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
     wrapped: list[WrappedLocation] = []
     _auth_failures = 0  # Track MAC / InvalidTag failures across all reports
     _encrypted_report_count = 0  # Count non-SEMANTIC reports attempted
+    # Diff-Review #1: Own-report-only failure tracking. Unlike the mixed
+    # counters above (which include foreign/crowdsourced reports that legitimately
+    # fail when decrypted with another account's key), these track ONLY the
+    # device's own reports (public_key_random == b""). Exhausting every own report
+    # is the one account-wide auth signal that warrants reauth escalation.
+    _own_encrypted_report_count = 0  # Own (Owner-key) reports attempted
+    _own_auth_failures = 0  # Own-report MAC / InvalidTag failures
+    _own_report_success = False  # At least one own report authenticated OK
 
     # FIX #155: Prepare all identity key candidates for multi-candidate retry.
     # async_retrieve_identity_key can return multiple candidates (MCU bit-flip
@@ -1264,11 +1324,22 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
             public_key_random = enc.publicKeyRandom
 
             if public_key_random == b"":  # Own report
+                _own_encrypted_report_count += 1
                 if active_identity_key is None:
+                    # Unreachable in practice: a None identity_key already raised
+                    # DecryptionError at function entry, and active_identity_key
+                    # falls back to the non-None identity_key. Kept as a defensive
+                    # guard. Intentionally a ValueError (config error, not an auth
+                    # signal) so it is NOT counted as an own auth failure and does
+                    # not trigger stale-key reauth escalation.
                     raise ValueError("No identity key available for own-report decryption")
                 decrypted_location_raw = await _offload_decrypt_aes(
                     active_identity_key, encrypted_location
                 )
+                # Authentication passed: the cached identity key still matches the
+                # server's own reports. One success proves the key is healthy, so
+                # foreign-report failures must not trigger account-wide escalation.
+                _own_report_success = True
             else:
                 # FIX #155: Foreign/crowdsourced reports use ECDH + AES-EAX
                 # with a different key derivation path than own reports.
@@ -1341,6 +1412,8 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
         except InvalidTag:
             # InvalidTag means AES-GCM authentication failed during decryption.
             _auth_failures += 1
+            if public_key_random == b"":  # Own-report auth failure
+                _own_auth_failures += 1
             _LOGGER.warning(
                 "Decryption auth failed (InvalidTag) for %s report "
                 "(time_offset=%s, key_len=%s, candidates=%d): "
@@ -1358,6 +1431,8 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
             # meaning to InvalidTag from the cryptography library.
             if "mac" in str(ve).lower():
                 _auth_failures += 1
+                if public_key_random == b"":  # Own-report auth failure
+                    _own_auth_failures += 1
                 _LOGGER.warning(
                     "Decryption auth failed (MAC check) for %s report "
                     "(time_offset=%s, key_len=%s, candidates=%d): %s",
@@ -1413,6 +1488,25 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                 "derivation may be failing. Re-authenticate the account.",
                 _auth_failures,
             )
+
+    # Diff-Review #1: When the device HAS its own encrypted reports and EVERY
+    # one of them failed authentication (with not a single own-report success),
+    # the cached identity key no longer matches the server's reports. This is a
+    # genuine account-wide auth failure, distinct from the masked retrieve path
+    # above and from foreign/crowdsourced failures (which legitimately fail with
+    # other accounts' keys and must NOT escalate). Raise DecryptionError so the
+    # existing escalation machinery (coordinator poll/locate handlers and the FCM
+    # push handler, all gated by per-cycle counting + cooldown) can surface a
+    # reauth repair instead of silently returning empty every cycle.
+    if (
+        _own_encrypted_report_count > 0
+        and _own_auth_failures >= _own_encrypted_report_count
+        and not _own_report_success
+    ):
+        raise DecryptionError(
+            "All own-report decryptions failed; the cached identity key no "
+            "longer matches the server reports."
+        )
 
     if not wrapped:
         _LOGGER.info("[DecryptLocations] No locations found.")

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
@@ -604,6 +604,15 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
     except Exception as err:  # pragma: no cover - defensive logging
         _LOGGER.debug("Failed to persist contributor mode timestamp: %s", err)
 
+    # Bind the decryption exception type locally: this module imports
+    # decrypt_locations lazily (see _import_decrypt_locations_module) to avoid a
+    # heavy import cycle, so the name is not available at module scope. It is used
+    # below to surface an auth-fatal stale-key failure instead of swallowing it.
+    decrypt_module = _import_decrypt_locations_module()
+    DecryptionError = cast(
+        type[Exception], getattr(decrypt_module, "DecryptionError")
+    )
+
     try:
         # Generate request UUID
         request_uuid = generate_random_uuid()
@@ -715,6 +724,14 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
                 raise ctx.error
             if isinstance(ctx.error, SpotAuthPermanentError):
                 raise ctx.error
+            # A stale/incompatible shared key (SharedKeyMismatchError /
+            # SharedKeyMissingError) or a per-tracker stale owner key
+            # (StaleOwnerKeyError) is an auth-fatal crypto condition, not a
+            # transient miss. Surface it so the API layer and coordinator can
+            # escalate to a reauth flow (or a per-tracker repair issue) instead of
+            # silently returning no location. DecryptionError covers all subclasses.
+            if isinstance(ctx.error, DecryptionError):
+                raise ctx.error
 
         data = ctx.data or []
         if data and data[0].get("canonic_id", "").lower() == canonic_device_id.lower():
@@ -743,6 +760,12 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
     except NovaAuthError:
         # Re-raise auth errors (permanent or transient) so api.py can handle appropriately.
         # Transient errors will be tracked by the coordinator; permanent ones trigger reauth.
+        raise
+    except DecryptionError:
+        # Auth-fatal crypto failure surfaced from ctx.error above: must propagate so
+        # the coordinator can escalate (reauth or per-tracker repair). The broad
+        # `except Exception` below would otherwise swallow it back into an empty
+        # result -- that swallow is the original bug this fix removes.
         raise
     except Exception as e:
         _LOGGER.error("Error requesting location for %s: %s", name, e)

--- a/custom_components/googlefindmy/NovaApi/nova_request.py
+++ b/custom_components/googlefindmy/NovaApi/nova_request.py
@@ -1765,7 +1765,12 @@ async def async_nova_request(  # noqa: PLR0913,PLR0912,PLR0915
                     reached_wire = True
                 if retries_used < NOVA_MAX_RETRIES:
                     delay = _compute_delay(attempt, None)
-                    _LOGGER.warning(
+                    # Tiered severity, mirroring the HTTP-status retry path above:
+                    # a single transient network blip (attempt 1) is INFO, not log
+                    # noise; repeated failures (attempt 2+) escalate to WARNING;
+                    # exhaustion after all retries is ERROR (see the else branch).
+                    log_fn = _LOGGER.info if retries_used == 0 else _LOGGER.warning
+                    log_fn(
                         "Nova API request failed (Attempt %d/%d): %s for %s. Retrying in %.2f seconds...",
                         retries_used + 1,
                         NOVA_MAX_RETRIES + 1,

--- a/custom_components/googlefindmy/SpotApi/GetEidInfoForE2eeDevices/get_owner_key.py
+++ b/custom_components/googlefindmy/SpotApi/GetEidInfoForE2eeDevices/get_owner_key.py
@@ -195,11 +195,13 @@ async def _retrieve_owner_key(
         owner_key: Any = await _run_in_executor(
             decrypt_owner_key, shared_key, encrypted_owner_key
         )
-    except InvalidTag as exc:
-        raise RuntimeError(
-            "Owner key decryption failed (InvalidTag): the shared key may be "
-            "stale or incompatible. Try re-authenticating with --reauth."
-        ) from exc
+    except InvalidTag:
+        # Propagate InvalidTag unchanged. The caller (decrypt_locations) maps it to
+        # SharedKeyMismatchError to distinguish "shared key wrong/stale" from
+        # "shared key missing" (RuntimeError). Wrapping it into RuntimeError here
+        # would erase that discriminator and collapse both root causes into one
+        # opaque message, which is exactly what hid the real cause from users.
+        raise
     owner_key_version = getattr(metadata, "ownerKeyVersion", None)
 
     if not isinstance(owner_key, (bytes, bytearray)) or len(owner_key) == 0:

--- a/custom_components/googlefindmy/__init__.py
+++ b/custom_components/googlefindmy/__init__.py
@@ -6921,6 +6921,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: MyConfigEntry) -> bool:
         elif isinstance(raw_secrets, Mapping):
             secrets_bundle = dict(raw_secrets)
 
+        if secrets_bundle:  # pragma: no cover - legacy one-time migration path
+            # Legacy bundles (migrated from entry.data/file) may carry copy/paste
+            # whitespace in credential values; normalize before extraction and
+            # before this path persists the bundle to the cache. Idempotent.
+            # The decryption-critical normalization is also enforced downstream by
+            # _async_save_secrets_data (covered by tests); this is defense-in-depth
+            # on the legacy one-time migration branch, which the unit harness does
+            # not drive.
+            from .shared_helpers import normalize_secrets_bundle
+
+            secrets_bundle = normalize_secrets_bundle(secrets_bundle)
+
         oauth_token_maybe = entry.data.get(CONF_OAUTH_TOKEN)
         if not isinstance(oauth_token_maybe, str):
             oauth_token_maybe = secrets_bundle.get(CONF_OAUTH_TOKEN)
@@ -7672,6 +7684,15 @@ async def _async_save_secrets_data(
         - Store JSON-serializable values *as-is*. TokenCache validates and normalizes.
         - Uses the *entry-local* cache instance (no global facade).
     """
+    from .shared_helpers import normalize_secrets_bundle
+
+    # Defense-in-depth: the config flow already normalizes bundles on entry, but
+    # this is the universal cache-write choke point. A bundle persisted by an
+    # older version or migrated from a file may still carry copy/paste whitespace
+    # in credential values (a stray space in owner_key/shared_key breaks AES-GCM
+    # decryption). normalize_secrets_bundle is idempotent, so re-normalizing an
+    # already-clean bundle is a no-op.
+    secrets_data = normalize_secrets_bundle(dict(secrets_data))
     enhanced_data = dict(secrets_data)
 
     # Normalize username key across old/new secrets variants

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -44,6 +44,7 @@ from .const import (
     DEFAULT_CONTRIBUTOR_MODE,
 )
 from .NovaApi import nova_request
+from .NovaApi.ExecuteAction.LocateTracker.decrypt_locations import DecryptionError
 from .NovaApi.ExecuteAction.LocateTracker.location_request import (
     get_location_data_for_device,
 )
@@ -1335,6 +1336,15 @@ class GoogleFindMyAPI:
                 _short_err(err),
             )
             return {}
+
+        except DecryptionError:
+            # Audit finding A1: DecryptionError is a RuntimeError subclass, so the
+            # broad `except RuntimeError` / `except Exception` below would silently
+            # swallow an auth-fatal stale-shared-key failure into an empty result.
+            # Re-raise it so the coordinator can count it and escalate to a reauth
+            # flow (or per-tracker repair). This is the layer that must stay
+            # transparent for the location_request fix to have any effect.
+            raise
 
         except RuntimeError as err:
             # Startup safety net: during cold boot, the FCM provider may not yet be registered.

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -44,7 +44,10 @@ from .const import (
     DEFAULT_CONTRIBUTOR_MODE,
 )
 from .NovaApi import nova_request
-from .NovaApi.ExecuteAction.LocateTracker.decrypt_locations import DecryptionError
+from .NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    DecryptionError,
+    any_real_location_record,
+)
 from .NovaApi.ExecuteAction.LocateTracker.location_request import (
     get_location_data_for_device,
 )
@@ -1240,6 +1243,13 @@ class GoogleFindMyAPI:
                     device_name,
                     len(records),
                 )
+                # _select_best_location ranks by newest last_seen and may return a
+                # report-less SEMANTIC/metadata row, hiding a sibling coordinate
+                # report that decrypted successfully. Carry the FULL-list decrypt
+                # proof as an internal hint so the poll loop's reauth-budget gate
+                # is not fooled by the collapsed view (consumers pop it before
+                # caching, like _report_hint). See any_real_location_record.
+                best["_decrypt_proven"] = any_real_location_record(records)
                 return best
             _LOGGER.debug("API v3.0 Async: No location data for %s", device_name)
             return {}

--- a/custom_components/googlefindmy/config_flow.py
+++ b/custom_components/googlefindmy/config_flow.py
@@ -129,6 +129,7 @@ from .integration_modules import (
     import_integration_api_module,
     import_integration_package,
 )
+from .shared_helpers import normalize_secrets_bundle
 
 _ResolveEntryEmailCallable = Callable[[ConfigEntry], tuple[str | None, str | None]]
 _CoalesceCallable = Callable[
@@ -1417,6 +1418,7 @@ def _interpret_credentials_choice(
             parsed = json.loads(secrets_json)
             if not isinstance(parsed, dict):
                 raise TypeError()
+            parsed = normalize_secrets_bundle(parsed)
         except (json.JSONDecodeError, TypeError):
             return "secrets", None, None, "invalid_json"
 
@@ -1460,6 +1462,7 @@ def _interpret_reauth_choice(
             parsed = json.loads(secrets_raw)
             if not isinstance(parsed, dict):
                 raise TypeError()
+            parsed = normalize_secrets_bundle(parsed)
         except (json.JSONDecodeError, TypeError):
             return None, None, "invalid_json"
 
@@ -1677,7 +1680,7 @@ def _normalize_and_validate_discovery_payload(
     )
     if isinstance(secrets_raw, str):
         try:
-            secrets_raw = json.loads(secrets_raw)
+            secrets_raw = normalize_secrets_bundle(json.loads(secrets_raw))
         except json.JSONDecodeError as err:
             raise DiscoveryFlowError("invalid_discovery_info") from err
 
@@ -2836,7 +2839,7 @@ class ConfigFlow(
             try:
                 parsed_candidate = json.loads(raw)
                 if isinstance(parsed_candidate, dict):
-                    parsed_secrets = parsed_candidate
+                    parsed_secrets = normalize_secrets_bundle(parsed_candidate)
                 else:
                     raise TypeError()
             except (json.JSONDecodeError, TypeError):
@@ -5833,6 +5836,7 @@ class OptionsFlowHandler(OptionsFlowBase, _OptionsFlowMixin):  # type: ignore[mi
                                 parsed = json.loads(user_input["new_secrets_json"])
                                 if not isinstance(parsed, dict):
                                     raise TypeError()
+                                parsed = normalize_secrets_bundle(parsed)
                             except Exception:
                                 errors["new_secrets_json"] = "invalid_json"
                             else:
@@ -5899,7 +5903,9 @@ class OptionsFlowHandler(OptionsFlowBase, _OptionsFlowMixin):  # type: ignore[mi
                     except Exception as err2:  # noqa: BLE001
                         if _is_multi_entry_guard_error(err2):
                             entry = self.config_entry
-                            parsed = json.loads(user_input["new_secrets_json"])
+                            parsed = normalize_secrets_bundle(
+                                json.loads(user_input["new_secrets_json"])
+                            )
                             cands = _extract_oauth_candidates_from_secrets(parsed)
                             token_first = cands[0][1] if cands else ""
                             updated_data = {

--- a/custom_components/googlefindmy/config_flow.py
+++ b/custom_components/googlefindmy/config_flow.py
@@ -1680,12 +1680,17 @@ def _normalize_and_validate_discovery_payload(
     )
     if isinstance(secrets_raw, str):
         try:
-            secrets_raw = normalize_secrets_bundle(json.loads(secrets_raw))
+            secrets_raw = json.loads(secrets_raw)
         except json.JSONDecodeError as err:
             raise DiscoveryFlowError("invalid_discovery_info") from err
 
     if isinstance(secrets_raw, Mapping):
-        secrets_dict = dict(secrets_raw)
+        # Normalize whitespace here -- not only in the str-decode branch above --
+        # so already-parsed mapping payloads from in-repo cloud discovery
+        # (discovery.py forwards DATA_SECRET_BUNDLE as a dict) receive the same
+        # cleanup. A stray space in owner_key/shared_key breaks AES-GCM
+        # decryption. normalize_secrets_bundle is idempotent and copies its input.
+        secrets_dict = dict(normalize_secrets_bundle(secrets_raw))
         secrets_bundle = MappingProxyType(secrets_dict)
         email_from_secrets = _extract_email_from_secrets(secrets_dict)
         if email_from_secrets:

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -21,7 +21,7 @@ DATA_EID_RESOLVER: Final[Literal["eid_resolver"]] = "eid_resolver"
 # Latest config entry schema version handled by this integration.
 CONFIG_ENTRY_VERSION: int = 2
 # Keep the integration version aligned across the project (match manifest.json)
-INTEGRATION_VERSION: str = "1.7.1"
+INTEGRATION_VERSION: str = "1.7.2"
 
 # --------------------------------------------------------------------------------------
 # Shared textual constants

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -485,6 +485,9 @@ EVENT_AUTH_OK: str = f"{DOMAIN}.authentication_ok"
 # Translation key for the dedicated auth-status binary_sensor entity.
 TRANSLATION_KEY_AUTH_STATUS: str = "nova_auth_status"
 
+# Translation key for the dedicated encryption-key-status (ENUM) sensor entity.
+TRANSLATION_KEY_ENCRYPTION_KEY_STATUS: str = "encryption_key_status"
+
 # Issue key used for Repairs (translations use the same key).
 ISSUE_AUTH_EXPIRED_KEY: str = "auth_expired"
 
@@ -640,6 +643,7 @@ __all__ = [
     "EVENT_AUTH_ERROR",
     "EVENT_AUTH_OK",
     "TRANSLATION_KEY_AUTH_STATUS",
+    "TRANSLATION_KEY_ENCRYPTION_KEY_STATUS",
     "ISSUE_AUTH_EXPIRED_KEY",
     "ISSUE_MULTIPLE_CONFIG_ENTRIES",
     "TRANSLATION_KEY_CACHE_PURGED",

--- a/custom_components/googlefindmy/coordinator/__init__.py
+++ b/custom_components/googlefindmy/coordinator/__init__.py
@@ -35,6 +35,7 @@ from . import helpers
 # Re-export stats classes from helpers (commonly needed)
 from .helpers.stats import (
     ApiStatus,
+    CryptoStatus,
     DiagnosticsBuffer,
     FcmStatus,
     StatusSnapshot,
@@ -95,6 +96,7 @@ __all__ = [
     "_PREDICTION_BUFFER_S",
     # Stats classes
     "ApiStatus",
+    "CryptoStatus",
     "DiagnosticsBuffer",
     "FcmStatus",
     "StatusSnapshot",

--- a/custom_components/googlefindmy/coordinator/_mixin_typing.py
+++ b/custom_components/googlefindmy/coordinator/_mixin_typing.py
@@ -178,6 +178,9 @@ class _MixinBase:
     def note_decrypt_success(self) -> None:
         raise NotImplementedError
 
+    def note_background_decrypt_success(self) -> None:
+        raise NotImplementedError
+
     def _short_error_message(self, exc: Exception | str) -> str:
         raise NotImplementedError
 

--- a/custom_components/googlefindmy/coordinator/_mixin_typing.py
+++ b/custom_components/googlefindmy/coordinator/_mixin_typing.py
@@ -97,6 +97,10 @@ class _MixinBase:
     _fcm_defer_started_mono: float
     _consecutive_transient_auth_failures: int
     _last_transient_auth_error: str | None
+    _consecutive_decrypt_failures: int
+    _last_decrypt_reauth_monotonic: float | None
+    _last_decrypt_error: str | None
+    _monotonic: Callable[[], float]
 
     # Diagnostics / statistics
     stats: dict[str, int]
@@ -164,6 +168,11 @@ class _MixinBase:
     def _set_auth_state(
         self, *, failed: bool, reason: str | None = None
     ) -> None:
+        raise NotImplementedError
+
+    def note_decrypt_failure(
+        self, *, stale: bool, error: Exception, device: str | None = None
+    ) -> bool:
         raise NotImplementedError
 
     def _short_error_message(self, exc: Exception | str) -> str:

--- a/custom_components/googlefindmy/coordinator/_mixin_typing.py
+++ b/custom_components/googlefindmy/coordinator/_mixin_typing.py
@@ -175,6 +175,9 @@ class _MixinBase:
     ) -> bool:
         raise NotImplementedError
 
+    def note_decrypt_success(self) -> None:
+        raise NotImplementedError
+
     def _short_error_message(self, exc: Exception | str) -> str:
         raise NotImplementedError
 

--- a/custom_components/googlefindmy/coordinator/helpers/stats.py
+++ b/custom_components/googlefindmy/coordinator/helpers/stats.py
@@ -42,6 +42,35 @@ class FcmStatus:
     DISCONNECTED = "disconnected"
 
 
+class CryptoStatus:
+    """String constants describing end-to-end location decryption health.
+
+    These mirror the diagnostic enum sensor's ``options`` exactly (one Home
+    Assistant enum state per constant). The values are driven from a single
+    source -- the coordinator's ``note_decrypt_failure`` hook (failure states)
+    and the poll cycle's decrypt-clean outcome (``OK``) -- so the sensor never
+    drifts from the reauth escalation behaviour it visualizes.
+
+    States:
+        UNKNOWN: No decryption has been attempted yet (initial state).
+        OK: The most recent poll cycle decrypted without an account-wide failure.
+        SHARED_KEY_INVALID: The shared key no longer matches the server-side
+            owner key (``SharedKeyMismatchError`` / ``InvalidTag``); account-wide
+            reauthentication is required.
+        SHARED_KEY_MISSING: The pasted bundle is incomplete and lacks a usable
+            shared key (``SharedKeyMissingError``).
+        TRACKER_KEY_OUTDATED: A single tracker is encrypted with an outdated
+            owner-key version (``StaleOwnerKeyError``); re-pair that tracker. This
+            is per-tracker and never triggers an account-wide reauth.
+    """
+
+    UNKNOWN = "unknown"
+    OK = "ok"
+    SHARED_KEY_INVALID = "shared_key_invalid"
+    SHARED_KEY_MISSING = "shared_key_missing"
+    TRACKER_KEY_OUTDATED = "tracker_key_outdated"
+
+
 # ---------------------------------------------------------------------------
 # Status Snapshot
 # ---------------------------------------------------------------------------

--- a/custom_components/googlefindmy/coordinator/helpers/stats.py
+++ b/custom_components/googlefindmy/coordinator/helpers/stats.py
@@ -48,12 +48,15 @@ class CryptoStatus:
     These mirror the diagnostic enum sensor's ``options`` exactly (one Home
     Assistant enum state per constant). The values are driven from a single
     source -- the coordinator's ``note_decrypt_failure`` hook (failure states)
-    and the poll cycle's decrypt-clean outcome (``OK``) -- so the sensor never
-    drifts from the reauth escalation behaviour it visualizes.
+    and the decrypt-clean outcomes (``OK``: a poll cycle, or a proven
+    background-push decrypt that refutes an account-wide failure) -- so the
+    sensor never drifts from the reauth escalation behaviour it visualizes.
 
     States:
         UNKNOWN: No decryption has been attempted yet (initial state).
-        OK: The most recent poll cycle decrypted without an account-wide failure.
+        OK: The most recent poll cycle decrypted without an account-wide failure,
+            or a background push proved the account-wide shared key still works
+            and cleared a prior ``SHARED_KEY_INVALID`` / ``SHARED_KEY_MISSING``.
         SHARED_KEY_INVALID: The shared key no longer matches the server-side
             owner key (``SharedKeyMismatchError`` / ``InvalidTag``); account-wide
             reauthentication is required.

--- a/custom_components/googlefindmy/coordinator/locate.py
+++ b/custom_components/googlefindmy/coordinator/locate.py
@@ -25,6 +25,10 @@ from aiohttp import ClientConnectionError, ClientError
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 
 from ..const import DEFAULT_MIN_POLL_INTERVAL
+from ..NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    DecryptionError,
+    StaleOwnerKeyError,
+)
 from ..NovaApi.nova_request import (
     NovaAuthError,
     NovaHTTPError,
@@ -571,6 +575,69 @@ class LocateOperations(_MixinBase):
                 )
                 self.note_error(decode_err, where="async_locate_device", device=name)
                 return {}
+            except StaleOwnerKeyError as stale_err:
+                # Per-tracker outdated owner key: an account-wide reauth would not
+                # fix a single outdated tracker. Record it through the shared entry
+                # point (per-tracker log, no account counter) and return an empty
+                # result rather than a generic HomeAssistantError. Must precede the
+                # DecryptionError handler below -- it is a subclass.
+                self.note_decrypt_failure(stale=True, error=stale_err, device=name)
+                self.note_error(stale_err, where="async_locate_device", device=name)
+                return {}
+            except DecryptionError as dec_err:
+                # Account-wide stale/missing shared key. Feed the SAME escalation
+                # counter as the poll and push paths (single source of truth) so a
+                # user clicking "Locate" contributes to -- and can trigger -- the
+                # reauth flow instead of silently swallowing into a generic error.
+                # Below threshold: graceful empty result, like the poll path keeps
+                # polling. At threshold: start reauth (HA cannot refresh the shared
+                # key itself; the user must supply a fresh secrets.json).
+                #
+                # This path only advances the shared counter, never resets it: the
+                # authoritative reset is the poll loop's whole-cycle decrypt-clean
+                # gate. A manual locate cannot prove the key is healthy (an empty
+                # result means "no pending report", which decrypts nothing), so
+                # resetting here could mask a genuinely stale key. The next clean
+                # poll cycle reconciles the counter. Locate is an additional upward
+                # evidence source, not a reset surface.
+                should_reauth = self.note_decrypt_failure(
+                    stale=False, error=dec_err, device=name
+                )
+                self.note_error(dec_err, where="async_locate_device", device=name)
+                if not should_reauth:
+                    return {}
+                self._set_auth_state(
+                    failed=True,
+                    reason=(
+                        "Location decryption keeps failing during manual locate; "
+                        "the shared key is stale and a fresh secrets.json "
+                        "(re-authentication) is required"
+                    ),
+                )
+                entry = getattr(self, "config_entry", None)
+                reauth_started = False
+                if entry is not None:
+                    try:
+                        # async_start_reauth is a synchronous @callback returning
+                        # None (it schedules the flow); awaiting it would raise on
+                        # the None result. Call it without await, mirroring the
+                        # SpotAuthPermanentError handler above.
+                        entry.async_start_reauth(self.hass)
+                        reauth_started = True
+                    except Exception as reauth_err:  # pragma: no cover - defensive
+                        _LOGGER.debug(
+                            "Failed to start reauth flow after manual locate "
+                            "decryption failure: %s",
+                            reauth_err,
+                        )
+                message = (
+                    "Google Find My Device can no longer decrypt locations "
+                    "(the shared key is stale); re-authentication has been started."
+                    if reauth_started
+                    else "Google Find My Device can no longer decrypt locations "
+                    "(the shared key is stale); please re-authenticate."
+                )
+                raise HomeAssistantError(message) from dec_err
             except Exception as err:
                 short_err = self._short_error_message(err)
                 _LOGGER.error("Manual locate for %s failed: %s", name, short_err)

--- a/custom_components/googlefindmy/coordinator/locate.py
+++ b/custom_components/googlefindmy/coordinator/locate.py
@@ -323,6 +323,13 @@ class LocateOperations(_MixinBase):
                 if not location_data:
                     return {}
 
+                # Manual locate is upward-only for the reauth budget and never
+                # consumes the poll-only decrypt-proof hint; drop it here (after the
+                # empty guard, so location_data is a non-empty dict) so it cannot
+                # leak into the cached payload or the returned dict (mirrors the
+                # _report_hint stripping discipline).
+                location_data.pop("_decrypt_proven", None)
+
                 self._record_semantic_label(location_data, device_id=device_id)
 
                 cached_loc = self._device_location_data.get(device_id)

--- a/custom_components/googlefindmy/coordinator/main.py
+++ b/custom_components/googlefindmy/coordinator/main.py
@@ -86,6 +86,7 @@ from .helpers.geo import (
 )
 from .helpers.stats import (
     ApiStatus,
+    CryptoStatus,
     DiagnosticsBuffer,
     FcmStatus,
     format_recent_errors,
@@ -768,6 +769,12 @@ class GoogleFindMyCoordinator(
         self._fcm_status_state: str = FcmStatus.UNKNOWN
         self._fcm_status_reason: str | None = None
         self._fcm_status_changed_at: float | None = None
+        # End-to-end location decryption health (drives the diagnostic enum
+        # sensor and mirrors the reauth escalation; initial UNKNOWN -> HA renders
+        # "unknown" until the first decryption is attempted).
+        self._crypto_status_state: str = CryptoStatus.UNKNOWN
+        self._crypto_status_reason: str | None = None
+        self._crypto_status_changed_at: float | None = None
 
         # Performance metrics (timestamps, durations) & recent errors (bounded)
         self.performance_metrics: dict[str, float] = {}

--- a/custom_components/googlefindmy/coordinator/main.py
+++ b/custom_components/googlefindmy/coordinator/main.py
@@ -807,6 +807,25 @@ class GoogleFindMyCoordinator(
         self._consecutive_transient_auth_failures: int = 0
         self._last_transient_auth_error: str | None = None
 
+        # Stale/missing shared-key decryption failures escalate to a reauth flow
+        # only after several consecutive cycles, with a cooldown so the flow is not
+        # re-fired on every poll once it is already open. Mirrors the transient-auth
+        # counter above; the in-decrypt self-heal (force_refresh / blind refresh)
+        # gets the first chance to recover an owner-key version bump without reauth.
+        self._consecutive_decrypt_failures: int = 0
+        # None means "never escalated yet". A real monotonic timestamp is only
+        # recorded after the first escalation, so the cooldown gate is skipped
+        # entirely on the first one. Using 0.0 as the sentinel was a bug: it is a
+        # valid monotonic value, so on a freshly booted host (process uptime below
+        # the cooldown window) ``monotonic() - 0.0 < cooldown`` would wrongly
+        # suppress the very first reauth escalation for up to the cooldown period.
+        self._last_decrypt_reauth_monotonic: float | None = None
+        self._last_decrypt_error: str | None = None
+        # Injectable monotonic-clock seam. Defaults to ``time.monotonic`` in
+        # production; tests override it to drive the decrypt cooldown gate
+        # deterministically (no dependency on the host's process uptime).
+        self._monotonic: Callable[[], float] = time.monotonic
+
         # Reload guard: defer core subentry repairs once after reload-driven attach
         self._skip_repair_during_reload_refresh: bool = False
         self._reload_repair_skip_pending_release: bool = False

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -51,6 +51,10 @@ from ..const import (
     DOMAIN,
     POLL_DEVICE_OUTER_TIMEOUT_S,
 )
+from ..NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    DecryptionError,
+    StaleOwnerKeyError,
+)
 from ..NovaApi.nova_request import NovaAuthError, NovaAuthPermanentError
 from ..SpotApi.GetEidInfoForE2eeDevices.get_eid_info_request import (
     SpotApiEmptyResponseError,
@@ -127,6 +131,17 @@ _EMPTY_LIST_QUORUM = 2
 
 # Maximum number of transient auth failures before triggering re-auth
 _MAX_TRANSIENT_AUTH_FAILURES = 3
+
+# Maximum consecutive stale/missing shared-key decryption failures before
+# escalating to a reauth flow. Gives the in-decrypt self-heal (force_refresh /
+# blind refresh) a chance first; only a persistently un-decryptable shared key
+# escalates to ConfigEntryAuthFailed.
+_MAX_DECRYPT_FAILURES = 3
+
+# Cooldown between decrypt-triggered reauth escalations (seconds). Once the reauth
+# flow is open, the un-fixable condition persists every cycle; this prevents
+# re-firing the escalation on each poll until the user supplies a fresh bundle.
+_DECRYPT_REAUTH_COOLDOWN_S = 6 * 3600
 
 # FCM error retry threshold before triggering re-auth
 _FCM_ERROR_RETRY_THRESHOLD = 3
@@ -258,6 +273,94 @@ class PollingOperations(_MixinBase):
     def last_poll_result(self) -> str | None:
         """Return the last recorded poll result ("success"/"failed")."""
         return self._last_poll_result
+
+    def note_decrypt_failure(
+        self, *, stale: bool, error: Exception, device: str | None = None
+    ) -> bool:
+        """Record a location-decryption failure and decide whether to escalate.
+
+        Single entry point shared by the poll path and the FCM push path so a
+        push-only setup escalates identically (no second, divergent code path).
+
+        A stale/incompatible or missing shared key is an auth-fatal condition: the
+        bundle can no longer decrypt the server-side owner key, so every location
+        report fails. Home Assistant cannot refresh the shared key itself (it is
+        derived from the user's lock-screen knowledge factor via the interactive
+        browser flow), so the only correct automatic action is to open the reauth
+        flow and let the user supply a fresh secrets.json.
+
+        Args:
+            stale: True for a per-tracker ``StaleOwnerKeyError`` (owner-key version
+                mismatch). Such failures are NOT account-wide and must not drive
+                the account-wide reauth counter -- an account reauth would not fix a
+                single outdated tracker.
+            error: The decryption error, kept for diagnostics/logging.
+            device: Optional device name for log context.
+
+        Returns:
+            True if the caller should escalate to ``ConfigEntryAuthFailed`` now
+            (account-wide shared-key failure persisted past the threshold and the
+            cooldown allows a fresh escalation); False otherwise.
+        """
+        self._last_decrypt_error = f"{type(error).__name__}: {error}"
+
+        if stale:
+            # Per-tracker outdated owner key: log per occurrence, do not touch the
+            # account-wide counter, never escalate to reauth here. The full
+            # user-facing repair issue is added with the diagnostic sensor work.
+            _LOGGER.warning(
+                "Tracker %s is encrypted with an outdated owner key version (%s); "
+                "remove and re-pair this tracker. Other devices are unaffected.",
+                device or "?",
+                type(error).__name__,
+            )
+            return False
+
+        self._consecutive_decrypt_failures += 1
+        if self._consecutive_decrypt_failures < _MAX_DECRYPT_FAILURES:
+            # Below threshold: give the in-decrypt self-heal (force_refresh / blind
+            # refresh) another cycle before escalating to reauth.
+            _LOGGER.warning(
+                "Location decryption failed for %s (%d/%d): %s. Will retry on the "
+                "next cycle before any re-authentication.",
+                device or "?",
+                self._consecutive_decrypt_failures,
+                _MAX_DECRYPT_FAILURES,
+                error,
+            )
+            return False
+
+        now = self._monotonic()
+        last = self._last_decrypt_reauth_monotonic
+        if last is not None and (now - last) < _DECRYPT_REAUTH_COOLDOWN_S:
+            # A previous escalation exists and is still cooling down: keep logging
+            # but do not re-fire the reauth flow on every poll cycle. The first
+            # escalation (last is None) never enters this branch, so it can never
+            # be suppressed by the host's process uptime.
+            _LOGGER.debug(
+                "Decryption still failing for %s but reauth escalation is in "
+                "cooldown (%.0fs since last).",
+                device or "?",
+                now - last,
+            )
+            return False
+
+        self._last_decrypt_reauth_monotonic = now
+        self._consecutive_decrypt_failures = 0
+        self._set_auth_state(
+            failed=True,
+            reason=(
+                "Location decryption keeps failing; the shared key is stale and a "
+                "fresh secrets.json (re-authentication) is required"
+            ),
+        )
+        _LOGGER.error(
+            "Location decryption failed %d times in a row (%s); escalating to "
+            "re-authentication. A fresh secrets.json is required.",
+            _MAX_DECRYPT_FAILURES,
+            error,
+        )
+        return True
 
     def _is_on_hass_loop(self) -> bool:
         """Return True if currently executing on the HA event loop thread."""
@@ -1126,6 +1229,38 @@ class PollingOperations(_MixinBase):
             _LOGGER.exception("Unexpected error during coordinator update")
             raise UpdateFailed(f"{type(err).__name__}: {err}") from err
 
+    def _request_poll_reauth(self, reauth_exc: ConfigEntryAuthFailed) -> None:
+        """Start the config-entry reauth flow from the background poll cycle.
+
+        ``_async_start_poll_cycle`` runs via ``hass.async_create_task`` (fire and
+        forget), so a raised ``ConfigEntryAuthFailed`` never reaches the awaited
+        coordinator refresh and Home Assistant's automatic reauth
+        (``_async_refresh`` -> ``ConfigEntry.async_start_reauth``) is never
+        triggered. Start the entry-scoped reauth flow directly instead, mirroring
+        the manual-locate (``locate.py``) and FCM-receiver paths. The caller still
+        records ``reauth_exc`` as ``last_exception`` so the ``finally`` block marks
+        the update failed via ``async_set_update_error``.
+        """
+        entry = getattr(self, "config_entry", None)
+        if entry is None:
+            _LOGGER.debug(
+                "Cannot start reauth from poll cycle: no config entry bound."
+            )
+            return
+        try:
+            # ``ConfigEntry.async_start_reauth`` is a synchronous @callback that
+            # returns None and schedules the flow itself; awaiting it would raise
+            # TypeError. Call it without await (mirrors locate.py and
+            # fcm_receiver_ha.py).
+            entry.async_start_reauth(self.hass)
+            _LOGGER.warning(
+                "Poll cycle triggered re-authentication: %s", reauth_exc
+            )
+        except Exception as reauth_err:  # pragma: no cover - defensive
+            _LOGGER.debug(
+                "Failed to start reauth flow from poll cycle: %s", reauth_err
+            )
+
     # ---------------------------- Polling Cycle -----------------------------
     async def _async_start_poll_cycle(
         self,
@@ -1187,6 +1322,17 @@ class PollingOperations(_MixinBase):
             _any_device_got_data = False
             try:
                 cycle_failed = False
+                # First account-wide decryption error seen this cycle (None == the
+                # cycle was decrypt-clean). The account-wide failure counter is a
+                # per-cycle quantity: it is advanced exactly once after the device
+                # loop, never per device. In a multi-device account a single healthy
+                # tracker must not mask a persistently un-decryptable shared key on
+                # the others, so both the escalation and the reset gate are
+                # cycle-scoped. Consequence (deliberate): in the escalation cycle the
+                # whole device loop runs to completion before the single escalation
+                # fires, so the remaining trackers still get one (failing) Nova call.
+                # That is the rare end-state cost of per-cycle counting.
+                cycle_decrypt_error: DecryptionError | None = None
                 for idx, dev in enumerate(devices):
                     dev_id = dev["id"]
                     dev_name = dev.get("name", dev_id)
@@ -1460,7 +1606,7 @@ class PollingOperations(_MixinBase):
                                     f"Location request timed out for {dev_name}"
                                 )
                                 last_exception.__cause__ = terr
-                    except SpotAuthPermanentError as auth_err:
+                    except SpotAuthPermanentError:
                         _LOGGER.warning(
                             "Authentication failed for %s; triggering reauth flow.",
                             dev_name,
@@ -1476,7 +1622,8 @@ class PollingOperations(_MixinBase):
                             "Google session invalid; re-authentication required"
                         )
                         last_exception = reauth_exc
-                        raise reauth_exc from auth_err
+                        self._request_poll_reauth(reauth_exc)
+                        return
                     except SpotApiEmptyResponseError:
                         _LOGGER.warning(
                             "Authentication failed for %s; triggering reauth flow.",
@@ -1493,7 +1640,8 @@ class PollingOperations(_MixinBase):
                             "Google session invalid; re-authentication required"
                         )
                         last_exception = reauth_exc
-                        raise reauth_exc
+                        self._request_poll_reauth(reauth_exc)
+                        return
                     except NovaAuthPermanentError as perm_err:
                         # Permanent auth failure (AAS token invalid) - immediate reauth
                         _LOGGER.error(
@@ -1513,7 +1661,8 @@ class PollingOperations(_MixinBase):
                             "Google credentials invalid; re-authentication required"
                         )
                         last_exception = reauth_exc
-                        raise reauth_exc from perm_err
+                        self._request_poll_reauth(reauth_exc)
+                        return
                     except NovaAuthError as transient_err:
                         # Transient auth failure - may self-heal in subsequent poll cycles.
                         # Only trigger reauth after multiple consecutive failures.
@@ -1542,7 +1691,8 @@ class PollingOperations(_MixinBase):
                                 f"Authentication failed after {self._consecutive_transient_auth_failures} attempts; re-authentication required"
                             )
                             last_exception = reauth_exc
-                            raise reauth_exc from transient_err
+                            self._request_poll_reauth(reauth_exc)
+                            return
 
                         # Not yet at threshold - log warning and continue to next device
                         _LOGGER.warning(
@@ -1558,7 +1708,14 @@ class PollingOperations(_MixinBase):
                             last_exception = transient_err
                         continue  # Try next device instead of aborting entire cycle
                     except ConfigEntryAuthFailed as auth_exc:
-                        # Mark auth failures to HA; abort remaining devices by re-raising.
+                        # A pre-converted ConfigEntryAuthFailed (e.g. raised directly
+                        # by api.async_get_device_location on HTTP 401/403 or a
+                        # permanent Nova auth failure) reaches here without going
+                        # through the typed SpotAuth/NovaAuth handlers above. Mark
+                        # auth failed and abort remaining devices. Start reauth
+                        # directly instead of re-raising: this poll cycle runs as a
+                        # fire-and-forget task, so a re-raise would never reach the
+                        # awaited coordinator refresh and HA's reauth would not fire.
                         self._set_auth_state(
                             failed=True,
                             reason=f"Auth failed during poll for {dev_name}: {auth_exc}",
@@ -1567,7 +1724,37 @@ class PollingOperations(_MixinBase):
                         self._last_poll_result = "failed"
                         self._consecutive_timeouts = 0
                         last_exception = auth_exc
-                        raise
+                        self._request_poll_reauth(auth_exc)
+                        return
+                    except StaleOwnerKeyError as stale_err:
+                        # Per-tracker owner-key version mismatch (D2): an account-wide
+                        # reauth would not help -- only this tracker is outdated. Log
+                        # and keep polling other devices; do NOT touch the
+                        # account-wide decrypt counter (no reauth storm).
+                        self.note_decrypt_failure(
+                            stale=True, error=stale_err, device=dev_name
+                        )
+                        cycle_failed = True
+                        self._consecutive_timeouts = 0
+                        if last_exception is None:
+                            last_exception = stale_err
+                        continue
+                    except DecryptionError as dec_err:
+                        # Account-wide stale/missing shared key. Only FLAG the cycle
+                        # here -- the account-wide failure counter is advanced exactly
+                        # once per cycle after the device loop (see below). Counting
+                        # per device would let a multi-device account cross
+                        # _MAX_DECRYPT_FAILURES within a single cycle and escalate on
+                        # the first poll, defeating the documented "consecutive
+                        # cycles" budget that gives the in-decrypt self-heal a few
+                        # cycles to recover an owner-key bump.
+                        self._consecutive_timeouts = 0
+                        cycle_failed = True
+                        if cycle_decrypt_error is None:
+                            cycle_decrypt_error = dec_err
+                        if last_exception is None:
+                            last_exception = dec_err
+                        continue
                     except Exception as err:
                         _LOGGER.error(
                             "Failed to get location for %s: %s", dev_name, err
@@ -1583,6 +1770,41 @@ class PollingOperations(_MixinBase):
                         await asyncio.sleep(self.device_poll_delay)
 
                 _LOGGER.debug("Completed polling cycle for %d devices", len(devices))
+                if cycle_decrypt_error is not None:
+                    # Account-wide decrypt failure persisted this cycle: advance the
+                    # consecutive-cycle counter exactly ONCE (not once per device)
+                    # and escalate to a reauth flow when it crosses the threshold
+                    # (with cooldown). Counting once per cycle keeps a multi-device
+                    # account on the same "N consecutive cycles" budget as a
+                    # single-device account. Raised here (still inside the outer
+                    # try, before its finally) so it propagates exactly like the
+                    # former in-loop raise.
+                    if self.note_decrypt_failure(
+                        stale=False, error=cycle_decrypt_error, device=None
+                    ):
+                        cycle_failed = True
+                        self._last_poll_result = "failed"
+                        reauth_exc = ConfigEntryAuthFailed(
+                            "Location decryption keeps failing: the shared key "
+                            "is stale; a fresh secrets.json (re-authentication) "
+                            "is required"
+                        )
+                        last_exception = reauth_exc
+                        self._request_poll_reauth(reauth_exc)
+                        return
+                elif self._consecutive_decrypt_failures > 0:
+                    # Whole cycle was decrypt-clean: clear the consecutive-decrypt
+                    # counter so a recovered/healthy shared key (or a successful
+                    # self-heal) does not later trip a spurious reauth. Gated on the
+                    # entire cycle -- one healthy tracker must not mask a
+                    # persistently stale account-wide shared key on the others.
+                    _LOGGER.info(
+                        "Location decryption succeeded for all devices; clearing "
+                        "%d decrypt failure(s).",
+                        self._consecutive_decrypt_failures,
+                    )
+                    self._consecutive_decrypt_failures = 0
+                    self._last_decrypt_error = None
             finally:
                 # Update scheduling baseline and clear flag, then push end snapshot.
                 # Always advance the poll baseline to prevent high-frequency

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -53,6 +53,7 @@ from ..const import (
 )
 from ..NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     DecryptionError,
+    SharedKeyMissingError,
     StaleOwnerKeyError,
 )
 from ..NovaApi.nova_request import NovaAuthError, NovaAuthPermanentError
@@ -62,7 +63,7 @@ from ..SpotApi.GetEidInfoForE2eeDevices.get_eid_info_request import (
 from ..SpotApi.spot_request import SpotAuthPermanentError
 from ._mixin_typing import _MixinBase
 from .helpers.cache import sanitize_decoder_row as _sanitize_decoder_row
-from .helpers.stats import ApiStatus, FcmStatus, StatusSnapshot
+from .helpers.stats import ApiStatus, CryptoStatus, FcmStatus, StatusSnapshot
 from .helpers.subentry import normalize_epoch_seconds as _normalize_epoch_seconds
 from .helpers.update import (
     calculate_presence_ttl as _calculate_presence_ttl_impl,
@@ -169,6 +170,9 @@ class PollingOperations(_MixinBase):
     _fcm_status_state: str
     _fcm_status_reason: str | None
     _fcm_status_changed_at: float | None
+    _crypto_status_state: str
+    _crypto_status_reason: str | None
+    _crypto_status_changed_at: float | None
     _force_device_list_reason: str | None
     _short_retry_cancel: Callable[[], None] | None
     _fcm_error_count: int
@@ -210,6 +214,29 @@ class PollingOperations(_MixinBase):
         except Exception:
             pass
 
+    def _set_crypto_status(
+        self, status: str, *, reason: str | None = None
+    ) -> None:
+        """Update the location-decryption status while avoiding noisy churn.
+
+        Mirrors ``_set_fcm_status`` exactly. This is the single writer for the
+        diagnostic encryption-key sensor: failure states come from
+        ``note_decrypt_failure`` (one mapping for poll, push and manual locate),
+        the ``OK`` state from a decrypt-clean poll cycle. Keeping one writer
+        guarantees the sensor never diverges from the reauth escalation.
+        """
+        if status == self._crypto_status_state and reason == self._crypto_status_reason:
+            return
+
+        self._crypto_status_state = status
+        self._crypto_status_reason = reason
+        self._crypto_status_changed_at = time.time()
+
+        try:
+            self.async_set_updated_data(self.data)
+        except Exception:
+            pass
+
     @property
     def api_status(self) -> StatusSnapshot:
         """Return a snapshot describing the current API polling health."""
@@ -226,6 +253,15 @@ class PollingOperations(_MixinBase):
             state=self._fcm_status_state,
             reason=self._fcm_status_reason,
             changed_at=self._fcm_status_changed_at,
+        )
+
+    @property
+    def crypto_status(self) -> StatusSnapshot:
+        """Return a snapshot describing end-to-end location decryption health."""
+        return StatusSnapshot(
+            state=self._crypto_status_state,
+            reason=self._crypto_status_reason,
+            changed_at=self._crypto_status_changed_at,
         )
 
     @property
@@ -308,6 +344,7 @@ class PollingOperations(_MixinBase):
             # Per-tracker outdated owner key: log per occurrence, do not touch the
             # account-wide counter, never escalate to reauth here. The full
             # user-facing repair issue is added with the diagnostic sensor work.
+            self._set_crypto_status(CryptoStatus.TRACKER_KEY_OUTDATED)
             _LOGGER.warning(
                 "Tracker %s is encrypted with an outdated owner key version (%s); "
                 "remove and re-pair this tracker. Other devices are unaffected.",
@@ -315,6 +352,15 @@ class PollingOperations(_MixinBase):
                 type(error).__name__,
             )
             return False
+
+        # Account-wide shared-key failure: map the concrete error to the
+        # diagnostic state from the SAME signal that drives the escalation below
+        # (D6, single source -- no second, divergent state for the sensor).
+        self._set_crypto_status(
+            CryptoStatus.SHARED_KEY_MISSING
+            if isinstance(error, SharedKeyMissingError)
+            else CryptoStatus.SHARED_KEY_INVALID
+        )
 
         self._consecutive_decrypt_failures += 1
         if self._consecutive_decrypt_failures < _MAX_DECRYPT_FAILURES:
@@ -1333,6 +1379,16 @@ class PollingOperations(_MixinBase):
                 # fires, so the remaining trackers still get one (failing) Nova call.
                 # That is the rare end-state cost of per-cycle counting.
                 cycle_decrypt_error: DecryptionError | None = None
+                # True if any device hit a per-tracker StaleOwnerKeyError this
+                # cycle. Such cycles must NOT be reported as crypto OK even when
+                # the account-wide key is healthy, so the diagnostic sensor does
+                # not flicker away the tracker_key_outdated state.
+                cycle_had_stale_key = False
+                # True once a device returns usable location data without a
+                # DecryptionError: positive proof the shared key works. Crypto OK
+                # requires this proof, not merely the absence of a decrypt error
+                # (a cycle of pure timeouts must not flicker a stale key to OK).
+                cycle_had_successful_decrypt = False
                 for idx, dev in enumerate(devices):
                     dev_id = dev["id"]
                     dev_name = dev.get("name", dev_id)
@@ -1379,6 +1435,11 @@ class PollingOperations(_MixinBase):
                                 dev_id, dev_name, source="empty-result"
                             )
                             continue
+
+                        # A device returned usable location data without raising a
+                        # DecryptionError: positive proof the account-wide shared
+                        # key still decrypts. Gate the crypto OK state on this.
+                        cycle_had_successful_decrypt = True
 
                         self._record_semantic_label(location, device_id=dev_id)
                         raw_semantic_name = (
@@ -1735,6 +1796,7 @@ class PollingOperations(_MixinBase):
                             stale=True, error=stale_err, device=dev_name
                         )
                         cycle_failed = True
+                        cycle_had_stale_key = True
                         self._consecutive_timeouts = 0
                         if last_exception is None:
                             last_exception = stale_err
@@ -1792,19 +1854,30 @@ class PollingOperations(_MixinBase):
                         last_exception = reauth_exc
                         self._request_poll_reauth(reauth_exc)
                         return
-                elif self._consecutive_decrypt_failures > 0:
-                    # Whole cycle was decrypt-clean: clear the consecutive-decrypt
-                    # counter so a recovered/healthy shared key (or a successful
-                    # self-heal) does not later trip a spurious reauth. Gated on the
-                    # entire cycle -- one healthy tracker must not mask a
-                    # persistently stale account-wide shared key on the others.
-                    _LOGGER.info(
-                        "Location decryption succeeded for all devices; clearing "
-                        "%d decrypt failure(s).",
-                        self._consecutive_decrypt_failures,
-                    )
-                    self._consecutive_decrypt_failures = 0
-                    self._last_decrypt_error = None
+                else:
+                    # Whole cycle finished without an account-wide decrypt failure.
+                    if cycle_had_successful_decrypt and not cycle_had_stale_key:
+                        # At least one device actually decrypted location data this
+                        # cycle (positive proof, not just the absence of an error)
+                        # and no per-tracker stale key was seen: the account-wide
+                        # shared key is healthy. Reflect that into the diagnostic
+                        # sensor (D6 OK source, single writer). A cycle of pure
+                        # timeouts/transient errors leaves the prior state intact
+                        # rather than flickering a stale key to OK.
+                        self._set_crypto_status(CryptoStatus.OK)
+                    if self._consecutive_decrypt_failures > 0:
+                        # Clear the consecutive-decrypt counter so a recovered/
+                        # healthy shared key (or a successful self-heal) does not
+                        # later trip a spurious reauth. Gated on the entire cycle --
+                        # one healthy tracker must not mask a persistently stale
+                        # account-wide shared key on the others.
+                        _LOGGER.info(
+                            "Location decryption succeeded for all devices; clearing "
+                            "%d decrypt failure(s).",
+                            self._consecutive_decrypt_failures,
+                        )
+                        self._consecutive_decrypt_failures = 0
+                        self._last_decrypt_error = None
             finally:
                 # Update scheduling baseline and clear flag, then push end snapshot.
                 # Always advance the poll baseline to prevent high-frequency

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -408,6 +408,40 @@ class PollingOperations(_MixinBase):
         )
         return True
 
+    def note_decrypt_success(self) -> None:
+        """Record a proven location decryption and clear the reauth budget.
+
+        Shared success entry point that mirrors :meth:`note_decrypt_failure`. The
+        account-wide ``_consecutive_decrypt_failures`` counter is *fed* from more
+        than one source -- the poll cycle and the FCM background-push decode both
+        increment it through ``note_decrypt_failure`` -- so the symmetric clear
+        must be reachable from every automatic source that can observe positive
+        proof the shared key still decrypts. A successful own/crowd location
+        decrypt is exactly that proof, so it resets the counter that drives
+        ``ConfigEntryAuthFailed`` escalation; otherwise non-consecutive failures
+        from one source accumulate to the threshold and trip a spurious reauth.
+        Idempotent and cheap when the counter is already zero.
+
+        Intentionally touches ONLY the account-wide counter, not the diagnostic
+        sensor surface (:class:`CryptoStatus` and ``_last_decrypt_error``): those
+        are owned by the poll cycle, whose OK transition is additionally gated on
+        the absence of a per-tracker stale key so it never flickers
+        ``tracker_key_outdated`` -- nor the error class behind it -- away. A
+        per-tracker ``StaleOwnerKeyError`` records ``_last_decrypt_error`` for the
+        sensor while deliberately leaving this counter at zero, so clearing that
+        field here would erase a still-relevant diagnostic on the very cycle a
+        sibling tracker decrypts. A single background decode likewise has no
+        cross-tracker cycle view, so it only clears the account-wide reauth budget
+        here and leaves the sensor (status and error class together) to the poll
+        loop.
+        """
+        if self._consecutive_decrypt_failures > 0:
+            _LOGGER.info(
+                "Location decryption succeeded; clearing %d decrypt failure(s).",
+                self._consecutive_decrypt_failures,
+            )
+            self._consecutive_decrypt_failures = 0
+
     def _is_on_hass_loop(self) -> bool:
         """Return True if currently executing on the HA event loop thread."""
         loop = self.hass.loop
@@ -1865,19 +1899,40 @@ class PollingOperations(_MixinBase):
                         # timeouts/transient errors leaves the prior state intact
                         # rather than flickering a stale key to OK.
                         self._set_crypto_status(CryptoStatus.OK)
-                    if self._consecutive_decrypt_failures > 0:
-                        # Clear the consecutive-decrypt counter so a recovered/
-                        # healthy shared key (or a successful self-heal) does not
-                        # later trip a spurious reauth. Gated on the entire cycle --
-                        # one healthy tracker must not mask a persistently stale
-                        # account-wide shared key on the others.
-                        _LOGGER.info(
-                            "Location decryption succeeded for all devices; clearing "
-                            "%d decrypt failure(s).",
-                            self._consecutive_decrypt_failures,
-                        )
-                        self._consecutive_decrypt_failures = 0
+                        # Clear the diagnostic error class together with the OK
+                        # status: both are the same sensor surface and must move
+                        # as one. Gating it on the same ``not cycle_had_stale_key``
+                        # condition keeps a per-tracker StaleOwnerKeyError's error
+                        # class intact while its tracker_key_outdated status
+                        # persists -- note_decrypt_success() no longer wipes this
+                        # field blindly from the shared (poll + push) entry point.
                         self._last_decrypt_error = None
+                    if cycle_had_successful_decrypt:
+                        # Clear the consecutive-decrypt counter only on POSITIVE
+                        # proof that the account-wide shared key works (at least one
+                        # device decrypted this cycle), mirroring the CryptoStatus.OK
+                        # gate above. An idle cycle that only saw empty/no-reporter
+                        # results (cycle_had_successful_decrypt == False) must NOT
+                        # reset the counter: intermittently reporting BLE trackers
+                        # would otherwise let idle cycles between two failing decrypt
+                        # cycles perpetually clear the budget, so the reauth threshold
+                        # could never be reached and the user would stay stuck with a
+                        # stale key and no reauth prompt.
+                        #
+                        # Unlike the OK gate this intentionally does NOT also require
+                        # ``not cycle_had_stale_key``: this counter tracks the
+                        # account-wide shared key, while a per-tracker outdated owner
+                        # key (cycle_had_stale_key) is a separate, device-local
+                        # concern that never advances this counter (see
+                        # note_decrypt_failure(stale=True)). Proof that the account
+                        # key works must be allowed to clear it even when one tracker
+                        # still carries an outdated key.
+                        #
+                        # Clear via the shared success entry point so this poll path
+                        # and the FCM background-push decode cannot drift apart again:
+                        # both sources feed the counter, both must be able to clear it
+                        # (the asymmetry that previously stranded a healthy account).
+                        self.note_decrypt_success()
             finally:
                 # Update scheduling baseline and clear flag, then push end snapshot.
                 # Always advance the poll baseline to prevent high-frequency

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -55,6 +55,7 @@ from ..NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     DecryptionError,
     SharedKeyMissingError,
     StaleOwnerKeyError,
+    is_real_location_record,
 )
 from ..NovaApi.nova_request import NovaAuthError, NovaAuthPermanentError
 from ..SpotApi.GetEidInfoForE2eeDevices.get_eid_info_request import (
@@ -1470,10 +1471,28 @@ class PollingOperations(_MixinBase):
                             )
                             continue
 
-                        # A device returned usable location data without raising a
-                        # DecryptionError: positive proof the account-wide shared
-                        # key still decrypts. Gate the crypto OK state on this.
-                        cycle_had_successful_decrypt = True
+                        # A device returned an authenticated coordinate report
+                        # without raising a DecryptionError: positive proof the
+                        # account-wide shared key still decrypts. Gate the crypto OK
+                        # state on this. Truthy-but-unauthenticated rows -- a
+                        # metadata_only sentinel (secrets-bundle key material) or a
+                        # SEMANTIC row (no decrypted coordinates) -- prove nothing, so
+                        # one report-less device must not mask another device's stale
+                        # key for the whole cycle.
+                        #
+                        # The proof is a property of the WHOLE response, but
+                        # api.async_get_device_location collapses it to a single
+                        # display record (newest last_seen) that can be a report-less
+                        # SEMANTIC row even when a sibling coordinate report decrypted.
+                        # It therefore carries the full-list verdict in the internal
+                        # _decrypt_proven hint; pop it here (leak-safe, like
+                        # _report_hint) and prefer it. Fall back to the collapsed
+                        # record only when the hint is absent (legacy/mocked stubs).
+                        decrypt_proven = location.pop("_decrypt_proven", None)
+                        if decrypt_proven is None:
+                            decrypt_proven = is_real_location_record(location)
+                        if decrypt_proven:
+                            cycle_had_successful_decrypt = True
 
                         self._record_semantic_label(location, device_id=dev_id)
                         raw_semantic_name = (

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -223,7 +223,9 @@ class PollingOperations(_MixinBase):
         Mirrors ``_set_fcm_status`` exactly. This is the single writer for the
         diagnostic encryption-key sensor: failure states come from
         ``note_decrypt_failure`` (one mapping for poll, push and manual locate),
-        the ``OK`` state from a decrypt-clean poll cycle. Keeping one writer
+        the ``OK`` state from a decrypt-clean poll cycle or a proven
+        background-push decrypt (``note_background_decrypt_success``, account-wide
+        states only). Keeping one writer
         guarantees the sensor never diverges from the reauth escalation.
         """
         if status == self._crypto_status_state and reason == self._crypto_status_reason:
@@ -432,9 +434,10 @@ class PollingOperations(_MixinBase):
         sensor while deliberately leaving this counter at zero, so clearing that
         field here would erase a still-relevant diagnostic on the very cycle a
         sibling tracker decrypts. A single background decode likewise has no
-        cross-tracker cycle view, so it only clears the account-wide reauth budget
-        here and leaves the sensor (status and error class together) to the poll
-        loop.
+        cross-tracker cycle view, so this shared entry point only clears the
+        account-wide reauth budget and leaves the per-tracker sensor surface to
+        the poll loop. The push path heals the *account-wide* failure states via
+        :meth:`note_background_decrypt_success`, which wraps this method.
         """
         if self._consecutive_decrypt_failures > 0:
             _LOGGER.info(
@@ -442,6 +445,38 @@ class PollingOperations(_MixinBase):
                 self._consecutive_decrypt_failures,
             )
             self._consecutive_decrypt_failures = 0
+
+    def note_background_decrypt_success(self) -> None:
+        """Clear the reauth budget and heal the account-wide sensor from a push.
+
+        Called only from the FCM background-push decode on positive proof of an
+        authenticated coordinate (see ``_note_decrypt_success_for_entry``). It
+        first clears the shared reauth budget via :meth:`note_decrypt_success`,
+        then lifts the diagnostic encryption-key sensor out of the *account-wide*
+        failure states (``SHARED_KEY_INVALID`` / ``SHARED_KEY_MISSING``) that the
+        proof refutes: a successful decrypt with the account owner key proves the
+        shared key works regardless of any single cycle's cross-tracker view, so
+        push-only setups whose scheduled polls stay idle no longer leave the
+        sensor stuck on a stale-key status the account has already recovered from.
+
+        It deliberately does NOT touch ``TRACKER_KEY_OUTDATED``: a single
+        background decode cannot prove a per-tracker outdated owner key has been
+        re-paired (no cross-tracker view), so that per-tracker state -- and its
+        error class -- stays owned by the poll cycle, which alone observes the
+        absence of a stale key across all trackers. ``UNKNOWN`` is left untouched
+        too: there is no failure to heal and the OK semantics stay anchored to
+        observed account-wide proof, not fabricated before the first real signal.
+        Routes through the single ``_set_crypto_status`` writer, so the sensor
+        never diverges from the reauth escalation it visualizes.
+        """
+        self.note_decrypt_success()
+        if self._crypto_status_state in (
+            CryptoStatus.SHARED_KEY_INVALID,
+            CryptoStatus.SHARED_KEY_MISSING,
+        ):
+            # Move status and error class together: they are one sensor surface.
+            self._set_crypto_status(CryptoStatus.OK)
+            self._last_decrypt_error = None
 
     def _is_on_hass_loop(self) -> bool:
         """Return True if currently executing on the HA event loop thread."""

--- a/custom_components/googlefindmy/icons.json
+++ b/custom_components/googlefindmy/icons.json
@@ -60,6 +60,9 @@
       "semantic_labels": {
         "default": "mdi:format-list-text"
       },
+      "encryption_key_status": {
+        "default": "mdi:key-alert"
+      },
       "stat_background_updates": {
         "default": "mdi:cloud-download"
       },

--- a/custom_components/googlefindmy/manifest.json
+++ b/custom_components/googlefindmy/manifest.json
@@ -35,5 +35,5 @@
     "selenium>=4.25.0",
     "undetected_chromedriver>=3.5.5"
   ],
-  "version": "1.7.1"
+  "version": "1.7.2"
 }

--- a/custom_components/googlefindmy/sensor.py
+++ b/custom_components/googlefindmy/sensor.py
@@ -42,8 +42,10 @@ from .const import (
     SUBENTRY_TYPE_SERVICE,
     SUBENTRY_TYPE_TRACKER,
     TRACKER_SUBENTRY_KEY,
+    TRANSLATION_KEY_ENCRYPTION_KEY_STATUS,
 )
 from .coordinator import (
+    CryptoStatus,
     GoogleFindMyCoordinator,
     SemanticLabelRecord,
     _as_ha_attributes,
@@ -93,6 +95,24 @@ SEMANTIC_LABEL_DESCRIPTION = SensorEntityDescription(
     translation_key="semantic_labels",
     icon="mdi:format-list-text",
 )
+
+ENCRYPTION_KEY_STATUS_DESCRIPTION = SensorEntityDescription(
+    key=TRANSLATION_KEY_ENCRYPTION_KEY_STATUS,
+    translation_key=TRANSLATION_KEY_ENCRYPTION_KEY_STATUS,
+    device_class=SensorDeviceClass.ENUM,
+    icon="mdi:key-alert",
+)
+
+# The concrete enum states exposed by the encryption-key-status sensor. HA
+# requires ``native_value`` to be one of ``options`` or ``None``; CryptoStatus
+# UNKNOWN is deliberately omitted because it maps to HA's "unknown" (None), not
+# an explicit option. Single source for the sensor and its tests.
+ENCRYPTION_KEY_STATUS_OPTIONS: list[str] = [
+    CryptoStatus.OK,
+    CryptoStatus.SHARED_KEY_INVALID,
+    CryptoStatus.SHARED_KEY_MISSING,
+    CryptoStatus.TRACKER_KEY_OUTDATED,
+]
 
 BLE_BATTERY_DESCRIPTION = SensorEntityDescription(
     key="ble_battery",
@@ -345,6 +365,24 @@ async def async_setup_entry(
             if isinstance(semantic_unique_id, str):
                 added_unique_ids.add(semantic_unique_id)
             service_entities.append(semantic_sensor)
+
+        # Third diagnostic axis (E2EE key health). Always created alongside the
+        # semantic-label sensor, independent of the stats toggle, because the
+        # encryption-key status is a core diagnostic like Nova auth / FCM
+        # connectivity, not an optional counter.
+        crypto_sensor = GoogleFindMyEncryptionKeyStatusSensor(
+            coordinator,
+            subentry_key=scope.subentry_key,
+            subentry_identifier=identifier,
+        )
+        crypto_unique_id = getattr(crypto_sensor, "unique_id", None)
+        if not isinstance(crypto_unique_id, str) or (
+            isinstance(crypto_unique_id, str)
+            and crypto_unique_id not in added_unique_ids
+        ):
+            if isinstance(crypto_unique_id, str):
+                added_unique_ids.add(crypto_unique_id)
+            service_entities.append(crypto_sensor)
 
         if not enable_stats:
             _schedule_service_entities(service_entities, True)
@@ -900,6 +938,97 @@ class GoogleFindMySemanticLabelSensor(GoogleFindMyEntity, SensorEntity):
             )
 
         return {"labels": [item["label"] for item in attrs], "observations": attrs}
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Attach to the service device for diagnostic grouping."""
+
+        return self.service_device_info(include_subentry_identifier=True)
+
+
+class GoogleFindMyEncryptionKeyStatusSensor(GoogleFindMyEntity, SensorEntity):
+    """Diagnostic ENUM sensor exposing end-to-end location decryption health.
+
+    This is the third diagnostic axis next to Nova auth (outgoing) and the FCM
+    connection (incoming): the E2EE key used to decrypt location reports. Its
+    state is read straight from ``coordinator.crypto_status``, which the poll,
+    push and manual-locate paths all feed through the single
+    ``note_decrypt_failure`` writer, so the sensor never diverges from the reauth
+    escalation behaviour it visualizes. Lives on the per-entry service device
+    (account-wide, like the shared key it reflects).
+    """
+
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_options = ENCRYPTION_KEY_STATUS_OPTIONS
+    entity_description = ENCRYPTION_KEY_STATUS_DESCRIPTION
+
+    def __init__(
+        self,
+        coordinator: GoogleFindMyCoordinator,
+        *,
+        subentry_key: str,
+        subentry_identifier: str,
+    ) -> None:
+        """Initialize the encryption-key-status sensor."""
+
+        super().__init__(
+            coordinator,
+            subentry_key=subentry_key,
+            subentry_identifier=subentry_identifier,
+        )
+        entry_id = self.entry_id or "default"
+        self._attr_unique_id = self.build_unique_id(
+            DOMAIN,
+            entry_id,
+            subentry_identifier,
+            TRANSLATION_KEY_ENCRYPTION_KEY_STATUS,
+            separator="_",
+        )
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the current decryption state, or None for HA's "unknown".
+
+        HA's ENUM device class requires the value to be one of ``_attr_options``
+        or ``None``. CryptoStatus.UNKNOWN (no decryption attempted yet) is mapped
+        to ``None`` so HA renders the native "unknown" state instead of a fifth
+        explicit option.
+        """
+
+        snapshot = getattr(self.coordinator, "crypto_status", None)
+        state = getattr(snapshot, "state", None)
+        if not isinstance(state, str) or state == CryptoStatus.UNKNOWN:
+            return None
+        return state
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Expose how close the account is to a decrypt-driven reauth.
+
+        Sourced from the same coordinator fields that drive the escalation, so
+        there is no second, divergent state. ``threshold`` is intentionally not
+        exposed here to avoid coupling the entity to a private coordinator
+        constant; ``consecutive_decrypt_failures`` already shows the progress.
+        """
+
+        attributes: dict[str, Any] = {}
+
+        snapshot = getattr(self.coordinator, "crypto_status", None)
+        changed_at = getattr(snapshot, "changed_at", None)
+        if isinstance(changed_at, (int, float)):
+            attributes["changed_at"] = changed_at
+
+        failures = getattr(self.coordinator, "_consecutive_decrypt_failures", None)
+        if isinstance(failures, int):
+            attributes["consecutive_decrypt_failures"] = failures
+
+        last_error = getattr(self.coordinator, "_last_decrypt_error", None)
+        if isinstance(last_error, str) and last_error:
+            # Stored as "ClassName: message"; expose just the class for triage.
+            attributes["last_decrypt_error_class"] = last_error.split(":", 1)[0]
+
+        return attributes or None
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/googlefindmy/shared_helpers.py
+++ b/custom_components/googlefindmy/shared_helpers.py
@@ -110,6 +110,68 @@ def safe_fcm_health_snapshots(receiver: Any) -> dict[str, dict[str, Any]]:
         return {}
 
 
+# Credential keys whose values are base64 / base64url / hex / JWT tokens.
+# Those alphabets never contain a legitimate space, so ALL whitespace (including
+# interior characters introduced by a line-wrapped copy/paste) is stripped from
+# their values. Every other key keeps interior whitespace and is only trimmed at
+# the edges, so values that may legitimately contain spaces (display names,
+# email addresses) are never corrupted.
+_SECRET_WHITELIST_KEYS: frozenset[str] = frozenset(
+    {
+        "owner_key",
+        "shared_key",
+        "aas_token",
+        "oauth_token",
+        "oauthToken",
+        "OAuthToken",
+        "access_token",
+        "token",
+        "adm_token",
+        "admToken",
+        "Auth",
+    }
+)
+
+
+def _normalize_secret_value(key: str, value: str) -> str:
+    """Normalize one string value from a secrets bundle.
+
+    Whitelisted credential keys have *all* whitespace removed; any other key is
+    only stripped of leading/trailing whitespace. See ``_SECRET_WHITELIST_KEYS``
+    for the security rationale behind the asymmetry.
+    """
+    if key in _SECRET_WHITELIST_KEYS:
+        return "".join(value.split())
+    return value.strip()
+
+
+def normalize_secrets_bundle(data: Any) -> Any:
+    """Return a whitespace-normalized deep copy of a secrets.json bundle.
+
+    Copy/paste of ``secrets.json`` into the config flow can inject stray
+    whitespace into credential values (a single space in ``owner_key`` breaks
+    AES-GCM decryption). This walks the bundle recursively and normalizes every
+    string value via :func:`_normalize_secret_value`, descending into nested
+    dicts (e.g. ``fcm_credentials``) and lists.
+
+    The function is idempotent and never mutates its input, so it is safe to
+    apply to ``MappingProxyType``-wrapped structures. Non-string scalars are
+    returned unchanged.
+    """
+    if isinstance(data, Mapping):
+        return {
+            key: (
+                _normalize_secret_value(key, value)
+                if isinstance(value, str)
+                else normalize_secrets_bundle(value)
+            )
+            for key, value in data.items()
+        }
+    if isinstance(data, list):
+        return [normalize_secrets_bundle(item) for item in data]
+    return data
+
+
 def normalize_fcm_entry_snapshot(entry_id: str, snap: dict[str, Any]) -> dict[str, Any]:
     """Normalize a single FCM health snapshot entry.
 

--- a/custom_components/googlefindmy/shared_helpers.py
+++ b/custom_components/googlefindmy/shared_helpers.py
@@ -110,12 +110,14 @@ def safe_fcm_health_snapshots(receiver: Any) -> dict[str, dict[str, Any]]:
         return {}
 
 
-# Credential keys whose values are base64 / base64url / hex / JWT tokens.
-# Those alphabets never contain a legitimate space, so ALL whitespace (including
-# interior characters introduced by a line-wrapped copy/paste) is stripped from
-# their values. Every other key keeps interior whitespace and is only trimmed at
-# the edges, so values that may legitimately contain spaces (display names,
-# email addresses) are never corrupted.
+# Credential keys whose values are base64 / base64url / hex / JWT tokens, or the
+# numeric GCM identity material (``android_id`` / ``security_token``, both parsed
+# via ``int(...)`` on the FCM login path). Those alphabets never contain a
+# legitimate space, so ALL whitespace (including interior characters introduced
+# by a line-wrapped copy/paste) is stripped from their values. Every other key
+# keeps interior whitespace and is only trimmed at the edges, so values that may
+# legitimately contain spaces (display names, email addresses) are never
+# corrupted.
 _SECRET_WHITELIST_KEYS: frozenset[str] = frozenset(
     {
         "owner_key",
@@ -129,6 +131,11 @@ _SECRET_WHITELIST_KEYS: frozenset[str] = frozenset(
         "adm_token",
         "admToken",
         "Auth",
+        # GCM device identity under ``fcm_credentials.gcm`` -- numeric values fed
+        # to ``int(android_id)`` / ``int(security_token)`` during push
+        # registration; an interior space from a wrapped paste breaks login.
+        "android_id",
+        "security_token",
     }
 )
 

--- a/custom_components/googlefindmy/strings.json
+++ b/custom_components/googlefindmy/strings.json
@@ -452,7 +452,7 @@
         "name": "Polling"
       },
       "connectivity": {
-        "name": "Connection Status",
+        "name": "FCM Connection Status",
         "state_attributes": {
           "last_poll_result": {
             "name": "Last poll result"
@@ -666,6 +666,15 @@
       },
       "semantic_labels": {
         "name": "Semantic labels"
+      },
+      "encryption_key_status": {
+        "name": "Encryption Key Status",
+        "state": {
+          "ok": "OK",
+          "shared_key_invalid": "Invalid (re-authentication required)",
+          "shared_key_missing": "Missing (incomplete bundle)",
+          "tracker_key_outdated": "Tracker key outdated"
+        }
       },
       "stat_background_updates": {
         "name": "Background updates"

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -452,7 +452,7 @@
         "name": "Abfrage aktiv"
       },
       "connectivity": {
-        "name": "Verbindungsstatus",
+        "name": "FCM-Verbindungsstatus",
         "state_attributes": {
           "last_poll_result": {
             "name": "Letztes Abfrageergebnis"
@@ -666,6 +666,15 @@
       },
       "semantic_labels": {
         "name": "Semantische Bezeichnungen"
+      },
+      "encryption_key_status": {
+        "name": "Status des Verschlüsselungsschlüssels",
+        "state": {
+          "ok": "OK",
+          "shared_key_invalid": "Ungültig (Neuanmeldung nötig)",
+          "shared_key_missing": "Fehlt (unvollständiges Bundle)",
+          "tracker_key_outdated": "Tracker-Schlüssel veraltet"
+        }
       },
       "stat_background_updates": {
         "name": "Hintergrund-Aktualisierungen"

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -452,7 +452,7 @@
         "name": "Polling"
       },
       "connectivity": {
-        "name": "Connection Status",
+        "name": "FCM Connection Status",
         "state_attributes": {
           "last_poll_result": {
             "name": "Last poll result"
@@ -666,6 +666,15 @@
       },
       "semantic_labels": {
         "name": "Semantic labels"
+      },
+      "encryption_key_status": {
+        "name": "Encryption Key Status",
+        "state": {
+          "ok": "OK",
+          "shared_key_invalid": "Invalid (re-authentication required)",
+          "shared_key_missing": "Missing (incomplete bundle)",
+          "tracker_key_outdated": "Tracker key outdated"
+        }
       },
       "stat_background_updates": {
         "name": "Background updates"

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -452,7 +452,7 @@
         "name": "Sondeo"
       },
       "connectivity": {
-        "name": "Estado de conexión",
+        "name": "Estado de conexión FCM",
         "state_attributes": {
           "last_poll_result": {
             "name": "Resultado de la última consulta"
@@ -666,6 +666,15 @@
       },
       "semantic_labels": {
         "name": "Etiquetas semánticas"
+      },
+      "encryption_key_status": {
+        "name": "Estado de la clave de cifrado",
+        "state": {
+          "ok": "OK",
+          "shared_key_invalid": "No válida (se requiere reautenticación)",
+          "shared_key_missing": "Ausente (paquete incompleto)",
+          "tracker_key_outdated": "Clave del rastreador obsoleta"
+        }
       },
       "stat_background_updates": {
         "name": "Actualizaciones en segundo plano"

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -452,7 +452,7 @@
         "name": "Interrogation"
       },
       "connectivity": {
-        "name": "État de connexion",
+        "name": "État de connexion FCM",
         "state_attributes": {
           "last_poll_result": {
             "name": "Résultat du dernier sondage"
@@ -666,6 +666,15 @@
       },
       "semantic_labels": {
         "name": "Étiquettes sémantiques"
+      },
+      "encryption_key_status": {
+        "name": "État de la clé de chiffrement",
+        "state": {
+          "ok": "OK",
+          "shared_key_invalid": "Invalide (ré-authentification requise)",
+          "shared_key_missing": "Manquante (lot incomplet)",
+          "tracker_key_outdated": "Clé du traceur obsolète"
+        }
       },
       "stat_background_updates": {
         "name": "Mises à jour en arrière-plan"

--- a/custom_components/googlefindmy/translations/he.json
+++ b/custom_components/googlefindmy/translations/he.json
@@ -452,7 +452,7 @@
         "name": "סריקה פעילה"
       },
       "connectivity": {
-        "name": "מצב חיבור",
+        "name": "מצב חיבור FCM",
         "state_attributes": {
           "last_poll_result": {
             "name": "תוצאת סריקה אחרונה"
@@ -666,6 +666,15 @@
       },
       "semantic_labels": {
         "name": "תוויות סמנטיות"
+      },
+      "encryption_key_status": {
+        "name": "סטטוס מפתח ההצפנה",
+        "state": {
+          "ok": "תקין",
+          "shared_key_invalid": "לא תקף (נדרש אימות מחדש)",
+          "shared_key_missing": "חסר (חבילה לא שלמה)",
+          "tracker_key_outdated": "מפתח העוקב מיושן"
+        }
       },
       "stat_background_updates": {
         "name": "עדכונים ברקע"

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -452,7 +452,7 @@
         "name": "Interrogazione"
       },
       "connectivity": {
-        "name": "Stato della connessione",
+        "name": "Stato della connessione FCM",
         "state_attributes": {
           "last_poll_result": {
             "name": "Risultato dell'ultimo sondaggio"
@@ -666,6 +666,15 @@
       },
       "semantic_labels": {
         "name": "Etichette semantiche"
+      },
+      "encryption_key_status": {
+        "name": "Stato della chiave di crittografia",
+        "state": {
+          "ok": "OK",
+          "shared_key_invalid": "Non valida (riautenticazione necessaria)",
+          "shared_key_missing": "Mancante (bundle incompleto)",
+          "tracker_key_outdated": "Chiave del tracker obsoleta"
+        }
       },
       "stat_background_updates": {
         "name": "Aggiornamenti in background"

--- a/custom_components/googlefindmy/translations/nl.json
+++ b/custom_components/googlefindmy/translations/nl.json
@@ -452,7 +452,7 @@
         "name": "Polling"
       },
       "connectivity": {
-        "name": "Verbindingsstatus",
+        "name": "FCM-verbindingsstatus",
         "state_attributes": {
           "last_poll_result": {
             "name": "Laatste pollresultaat"
@@ -666,6 +666,15 @@
       },
       "semantic_labels": {
         "name": "Semantische labels"
+      },
+      "encryption_key_status": {
+        "name": "Status versleutelingssleutel",
+        "state": {
+          "ok": "OK",
+          "shared_key_invalid": "Ongeldig (herauthenticatie vereist)",
+          "shared_key_missing": "Ontbreekt (onvolledige bundel)",
+          "tracker_key_outdated": "Trackersleutel verouderd"
+        }
       },
       "stat_background_updates": {
         "name": "Achtergrondupdates"

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -452,7 +452,7 @@
         "name": "Odpytywanie"
       },
       "connectivity": {
-        "name": "Status połączenia",
+        "name": "Status połączenia FCM",
         "state_attributes": {
           "last_poll_result": {
             "name": "Wynik ostatniego odpytywania"
@@ -666,6 +666,15 @@
       },
       "semantic_labels": {
         "name": "Etykiety semantyczne"
+      },
+      "encryption_key_status": {
+        "name": "Stan klucza szyfrowania",
+        "state": {
+          "ok": "OK",
+          "shared_key_invalid": "Nieprawidłowy (wymagane ponowne uwierzytelnienie)",
+          "shared_key_missing": "Brak (niekompletny pakiet)",
+          "tracker_key_outdated": "Nieaktualny klucz lokalizatora"
+        }
       },
       "stat_background_updates": {
         "name": "Aktualizacje w tle"

--- a/custom_components/googlefindmy/translations/pt-BR.json
+++ b/custom_components/googlefindmy/translations/pt-BR.json
@@ -452,7 +452,7 @@
         "name": "Consulta"
       },
       "connectivity": {
-        "name": "Status da conexão",
+        "name": "Status da conexão FCM",
         "state_attributes": {
           "last_poll_result": {
             "name": "Resultado da última sondagem"
@@ -666,6 +666,15 @@
       },
       "semantic_labels": {
         "name": "Rótulos semânticos"
+      },
+      "encryption_key_status": {
+        "name": "Status da chave de criptografia",
+        "state": {
+          "ok": "OK",
+          "shared_key_invalid": "Inválida (reautenticação necessária)",
+          "shared_key_missing": "Ausente (pacote incompleto)",
+          "tracker_key_outdated": "Chave do rastreador desatualizada"
+        }
       },
       "stat_background_updates": {
         "name": "Atualizações em segundo plano"

--- a/custom_components/googlefindmy/translations/pt.json
+++ b/custom_components/googlefindmy/translations/pt.json
@@ -452,7 +452,7 @@
         "name": "Consulta"
       },
       "connectivity": {
-        "name": "Status de conexão",
+        "name": "Status de conexão FCM",
         "state_attributes": {
           "last_poll_result": {
             "name": "Resultado da última consulta"
@@ -666,6 +666,15 @@
       },
       "semantic_labels": {
         "name": "Rótulos semânticos"
+      },
+      "encryption_key_status": {
+        "name": "Estado da chave de encriptação",
+        "state": {
+          "ok": "OK",
+          "shared_key_invalid": "Inválida (reautenticação necessária)",
+          "shared_key_missing": "Em falta (pacote incompleto)",
+          "tracker_key_outdated": "Chave do localizador desatualizada"
+        }
       },
       "stat_background_updates": {
         "name": "Atualizações em segundo plano"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -347,7 +347,9 @@ skip_covered = true
 # local full run measured 68.33 % scoped (3696 passed); floor = floor(68) - 1 Pp
 # jitter margin, clamped to [63, CI total]. Three local entity tests error on a
 # root-owned .storage path that CI does not hit, so CI total is >= 68.33 %.
-fail_under = 67
+# Raised to 69 after the crypto-audit test suite (PR #1111) lifted CI total to
+# 69.14 % (measured 2026-06-16); floor tracks the new CI total to lock the gain.
+fail_under = 69
 exclude_lines = [
     "if __name__ == \"__main__\":",
     "pragma: no cover",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1816,6 +1816,7 @@ def _stub_homeassistant() -> None:
     class SensorDeviceClass:  # pragma: no cover - stub values
         TIMESTAMP = "timestamp"
         BATTERY = "battery"
+        ENUM = "enum"
 
     class SensorStateClass:  # pragma: no cover - stub values
         TOTAL_INCREASING = "total_increasing"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,6 +142,62 @@ def disable_http_server() -> Iterable[None]:
         yield
 
 
+@pytest.hookimpl(trylast=True)
+def pytest_runtest_teardown() -> None:
+    """Heal the lazy ``GoogleFindMyCoordinator`` symbol after each test.
+
+    The integration package binds ``GoogleFindMyCoordinator`` lazily: it starts
+    as a placeholder class and ``_ensure_runtime_imports()`` swaps in the real
+    class while flipping ``_RUNTIME_IMPORTS_LOADED`` to ``True`` (a direct global
+    assignment, invisible to ``monkeypatch``). Several tests ``monkeypatch`` that
+    symbol while it is still the placeholder; if real runtime imports run during
+    the test, teardown restores the *placeholder* as the symbol's value while
+    ``_RUNTIME_IMPORTS_LOADED`` stays ``True``. The guard then never rebinds the
+    real class, so every later ``isinstance(obj, GoogleFindMyCoordinator)`` check
+    silently fails. Under xdist this leaks across tests in a worker and breaks
+    unrelated ones (observed: ``test_device_identifier_normalization`` skipping
+    its purge_device branch).
+
+    This runs as a ``trylast`` teardown hook (not a fixture) so it executes after
+    every fixture finalizer, in particular after ``monkeypatch`` has restored the
+    placeholder. It detects the inconsistent state (guard set, yet any lazily
+    bound symbol is still a placeholder) and clears the guard so the next
+    ``_ensure_runtime_imports()`` rebinds the real classes. All four lazily bound
+    classes are checked, not only the coordinator, because the same monkeypatch
+    trap applies symmetrically to ``DiscoveryManager`` and the two map views.
+    """
+
+    integration = sys.modules.get("custom_components.googlefindmy")
+    if integration is None:
+        return
+    if not getattr(integration, "_RUNTIME_IMPORTS_LOADED", False):
+        return
+
+    lazy_symbols = (
+        "GoogleFindMyCoordinator",
+        "DiscoveryManager",
+        "GoogleFindMyMapView",
+        "GoogleFindMyMapRedirectView",
+    )
+    any_placeholder = any(
+        "Placeholder" in getattr(getattr(integration, name, None), "__name__", "")
+        for name in lazy_symbols
+    )
+    if not any_placeholder:
+        return
+
+    # Open the guard so the real classes get rebound. If rebinding fails (e.g. a
+    # test left an incomplete submodule stub in sys.modules), the state stays
+    # {loaded=False, placeholder}, which is consistent and self-heals on the next
+    # _ensure_runtime_imports() call; swallowing avoids reddening an unrelated
+    # test's teardown over that benign, recoverable condition.
+    integration._RUNTIME_IMPORTS_LOADED = False
+    try:
+        integration._ensure_runtime_imports()
+    except Exception:  # noqa: BLE001 - see comment above; left state is consistent
+        integration._RUNTIME_IMPORTS_LOADED = False
+
+
 _CONST_MODULE = load_googlefindmy_const_module()
 _SERVICE_DEVICE_NAME: str = getattr(
     _CONST_MODULE, "SERVICE_DEVICE_NAME", "Google Find My Integration"

--- a/tests/helpers/fcm_handle_stub.py
+++ b/tests/helpers/fcm_handle_stub.py
@@ -112,3 +112,31 @@ class FcmHandleSlim:
     _handle_data_message = FcmPushClient._handle_data_message  # type: ignore[assignment]
     _app_data_by_key = FcmPushClient._app_data_by_key  # type: ignore[assignment]
     _extract_header_param = staticmethod(FcmPushClient._extract_header_param)
+
+
+class FcmMessageSlim:
+    """Composition stub binding the real async ``_handle_message``.
+
+    Mirrors only the attributes the ``Close`` branch of ``_handle_message``
+    touches: ``last_message_time``/``input_stream_id`` (the unconditional
+    preamble), ``logger`` (the INFO emission under test), ``do_listen`` (the
+    worker-stop signal) and ``_log_warn_with_limit`` (must NOT be called on
+    this path after the WARNING -> INFO downgrade). Same additive-composition
+    discipline as ``FcmHandleSlim``: the real unbound method runs without the
+    heavy production constructor.
+    """
+
+    def __init__(self) -> None:
+        self.logger = logging.getLogger(__name__ + ".FcmMessageSlim")
+        self.logger.propagate = True
+        self.last_message_time: float = 0.0
+        self.input_stream_id = 0
+        self.do_listen = True
+        # Records any rate-limited warning; the Close path must leave it empty.
+        self.warnings: list[str] = []
+
+    def _log_warn_with_limit(self, msg: str, *args: object) -> None:
+        self.warnings.append(msg)
+        self.logger.warning(msg, *args)
+
+    _handle_message = FcmPushClient._handle_message  # type: ignore[assignment]

--- a/tests/helpers/homeassistant.py
+++ b/tests/helpers/homeassistant.py
@@ -9,6 +9,7 @@ from collections.abc import Awaitable, Callable, Iterable, Mapping
 from dataclasses import FrozenInstanceError, dataclass, field
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import Mock
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import Platform
@@ -166,6 +167,7 @@ class GoogleFindMyConfigEntryStub:
         "source",
         "version",
         "minor_version",
+        "async_start_reauth",
         "_unload_callbacks",
     )
 
@@ -205,6 +207,10 @@ class GoogleFindMyConfigEntryStub:
         self.source = source
         self.version = 1
         self.minor_version = 1
+        # Mirror the real ``ConfigEntry.async_start_reauth`` (synchronous @callback
+        # returning None). A Mock lets poll-cycle tests assert the reauth flow was
+        # started; tests may also re-assign their own Mock to this slot.
+        self.async_start_reauth = Mock()
         self._unload_callbacks: list[Callable[[], None]] = []
 
     def async_on_unload(self, callback: Callable[[], None]) -> None:

--- a/tests/helpers/polling_mixin_stub.py
+++ b/tests/helpers/polling_mixin_stub.py
@@ -31,6 +31,7 @@ from unittest.mock import MagicMock
 
 from custom_components.googlefindmy.coordinator.helpers.stats import (
     ApiStatus,
+    CryptoStatus,
     FcmStatus,
 )
 from custom_components.googlefindmy.coordinator.polling import PollingOperations
@@ -83,6 +84,9 @@ class PollingStub(PollingOperations):
         self._fcm_status_state: str = FcmStatus.UNKNOWN
         self._fcm_status_reason: str | None = None
         self._fcm_status_changed_at: float | None = None
+        self._crypto_status_state: str = CryptoStatus.UNKNOWN
+        self._crypto_status_reason: str | None = None
+        self._crypto_status_changed_at: float | None = None
 
         self._consecutive_timeouts: int = 0
         self._last_poll_result: str | None = None

--- a/tests/test_api_basics.py
+++ b/tests/test_api_basics.py
@@ -40,6 +40,11 @@ from custom_components.googlefindmy.const import (
     DEFAULT_CONTRIBUTOR_MODE,
 )
 from custom_components.googlefindmy.exceptions import MissingTokenCacheError
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    DecryptionError,
+    SharedKeyMismatchError,
+    StaleOwnerKeyError,
+)
 from custom_components.googlefindmy.NovaApi.nova_request import (
     NovaAuthError,
     NovaError,
@@ -1110,6 +1115,26 @@ class TestAsyncDeviceLocationErrorMapping:
         self._patch_request(monkeypatch, RuntimeError("other"))
         api = _make_api_with_session()
         assert run_coro(api.async_get_device_location("d", "name")) == {}
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            SharedKeyMismatchError("stale shared key"),
+            StaleOwnerKeyError("tracker key outdated"),
+            DecryptionError("generic decrypt failure"),
+        ],
+    )
+    def test_decryption_error_is_reraised_not_swallowed(
+        self, monkeypatch: pytest.MonkeyPatch, exc: DecryptionError
+    ) -> None:
+        """Audit finding A1: ``DecryptionError`` is a ``RuntimeError`` subclass, so the
+        broad ``except RuntimeError`` / ``except Exception`` handlers would otherwise
+        swallow an auth-fatal stale-shared-key failure into an empty dict. It must
+        propagate instead so the coordinator can escalate to a reauth flow."""
+        self._patch_request(monkeypatch, exc)
+        api = _make_api_with_session()
+        with pytest.raises(DecryptionError):
+            run_coro(api.async_get_device_location("d", "name"))
 
     def test_unexpected_exception_returns_empty_dict(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_api_fcm_token_scoping.py
+++ b/tests/test_api_fcm_token_scoping.py
@@ -266,8 +266,20 @@ def test_async_get_device_location_uses_scoped_cache(
         loc1 = await api_entry_1.async_get_device_location("device-1", "Device 1")
         loc2 = await api_entry_2.async_get_device_location("device-2", "Device 2")
 
-        assert loc1 == {"canonic_id": "device-1", "latitude": 1}
-        assert loc2 == {"canonic_id": "device-2", "latitude": 1}
+        # async_get_device_location annotates the returned record with the
+        # internal full-list decrypt-proof hint (False here: latitude only, no
+        # longitude, so no authenticated coordinate report). Consumers pop it
+        # before caching, like _report_hint.
+        assert loc1 == {
+            "canonic_id": "device-1",
+            "latitude": 1,
+            "_decrypt_proven": False,
+        }
+        assert loc2 == {
+            "canonic_id": "device-2",
+            "latitude": 1,
+            "_decrypt_proven": False,
+        }
 
     asyncio.run(_exercise())
 

--- a/tests/test_api_location_selection.py
+++ b/tests/test_api_location_selection.py
@@ -160,18 +160,18 @@ def test_sync_wrappers_execute_without_running_loop() -> None:
     ]
 
 
-def test_sync_wrappers_guard_when_loop_running() -> None:
+async def test_sync_wrappers_guard_when_loop_running() -> None:
     """Sync helpers refuse to run when an event loop is already active."""
 
     api = _SyncHarness()
 
-    async def _runner() -> None:
-        assert api.get_basic_device_list() == []
-        assert api.get_device_location("dev-1", "Device 1") == {}
-        assert api.play_sound("dev-2") is False
-        assert api.stop_sound("dev-3") is False
+    # Running inside pytest-asyncio's managed loop is exactly the guarded
+    # condition: the sync wrappers must detect the active loop and refuse.
+    assert api.get_basic_device_list() == []
+    assert api.get_device_location("dev-1", "Device 1") == {}
+    assert api.play_sound("dev-2") is False
+    assert api.stop_sound("dev-3") is False
 
-    asyncio.run(_runner())
     assert api.calls == []
 
 
@@ -247,7 +247,7 @@ def test_process_device_list_response_deduplicates_canonic_ids(
     ]
 
 
-def test_api_forwards_contributor_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_api_forwards_contributor_mode(monkeypatch: pytest.MonkeyPatch) -> None:
     """Contributor mode settings are passed to the location request helper."""
 
     captured: dict[str, Any] = {}
@@ -272,16 +272,78 @@ def test_api_forwards_contributor_mode(monkeypatch: pytest.MonkeyPatch) -> None:
         fake_get_location_data_for_device,
     )
 
-    async def _run() -> None:
-        api = GoogleFindMyAPI(
-            cache=_StubCache(),
-            contributor_mode="high_traffic",
-            contributor_mode_switch_epoch=1_700_000_000,
-        )
+    api = GoogleFindMyAPI(
+        cache=_StubCache(),
+        contributor_mode="high_traffic",
+        contributor_mode_switch_epoch=1_700_000_000,
+    )
 
-        await api.async_get_device_location("dev-1", "Tracker")
-
-    asyncio.run(_run())
+    await api.async_get_device_location("dev-1", "Tracker")
 
     assert captured["mode"] == "high_traffic"
     assert captured["switch"] == 1_700_000_000
+
+
+async def test_async_get_device_location_marks_decrypt_proof_hidden_by_semantic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A coordinate fix hidden behind a newer SEMANTIC row still proves the key.
+
+    ``_select_best_location`` ranks by newest ``last_seen``, so a report-less
+    SEMANTIC row outranks an older coordinate report and becomes the returned
+    record. The full-list decrypt proof must survive that collapse via the internal
+    ``_decrypt_proven`` hint, otherwise the poll loop would miss the successful
+    decrypt and let a later transient failure trip a spurious reauth.
+    """
+
+    async def fake_get_location_data_for_device(
+        device_id: str,
+        device_name: str,
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        return [
+            # Older coordinate report: a genuine decrypted fix.
+            {"last_seen": 100.0, "latitude": 1.0, "longitude": 2.0},
+            # Newer SEMANTIC row: outranks the fix in the selector, no coordinates.
+            {"last_seen": 200.0, "semantic_name": "Home", "latitude": None},
+        ]
+
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.api.get_location_data_for_device",
+        fake_get_location_data_for_device,
+    )
+
+    api = GoogleFindMyAPI(cache=_StubCache())
+    best = await api.async_get_device_location("dev-1", "Tracker")
+
+    # The display selector returned the newer, report-less SEMANTIC row...
+    assert best.get("semantic_name") == "Home"
+    assert best.get("latitude") is None
+    # ...but the full-list proof was carried, so the budget can still be cleared.
+    assert best.get("_decrypt_proven") is True
+
+
+async def test_async_get_device_location_marks_no_proof_for_reportless_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A response without any coordinate report carries a False decrypt proof."""
+
+    async def fake_get_location_data_for_device(
+        device_id: str,
+        device_name: str,
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        return [
+            {"last_seen": 100.0, "metadata_only": True, "owner_key_version": 7},
+            {"last_seen": 200.0, "semantic_name": "Home", "latitude": None},
+        ]
+
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.api.get_location_data_for_device",
+        fake_get_location_data_for_device,
+    )
+
+    api = GoogleFindMyAPI(cache=_StubCache())
+    best = await api.async_get_device_location("dev-1", "Tracker")
+
+    assert best.get("_decrypt_proven") is False

--- a/tests/test_config_flow_discovery.py
+++ b/tests/test_config_flow_discovery.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
 import types
 from collections.abc import Callable, Mapping
 from typing import Any
@@ -49,6 +50,67 @@ def test_normalize_and_validate_discovery_payload() -> None:
     assert "aas_et/DISCOVERY" in tokens
     assert "manually/PERSIST" in tokens
     assert result.secrets_bundle is not None
+
+
+def test_discovery_mapping_payload_normalizes_credential_whitespace() -> None:
+    """Already-parsed mapping discovery payloads must normalize credential whitespace.
+
+    In-repo cloud discovery (discovery.py) forwards the secrets bundle as an
+    already-parsed dict via ``DATA_SECRET_BUNDLE``, so it never passes through the
+    str-decode branch. A stray space in ``owner_key``/``shared_key`` breaks
+    AES-GCM decryption, so the mapping branch must apply the same whitespace
+    normalization as the string branch.
+    """
+
+    payload = {
+        DATA_SECRET_BUNDLE: {
+            "google_email": "DiscoveryUser@example.com",
+            "aas_token": "aas_et/DISCOVERY",
+            "owner_key": "AAAA BBBB",
+            # Tab and newline reproduce a line-wrapped copy/paste, the real
+            # trigger for whitespace-broken credential material.
+            "shared_key": "CC\tCC\nDD DD",
+        }
+    }
+
+    result = config_flow._normalize_and_validate_discovery_payload(payload)
+
+    assert result.secrets_bundle is not None
+    assert result.secrets_bundle["owner_key"] == "AAAABBBB"
+    assert result.secrets_bundle["shared_key"] == "CCCCDDDD"
+
+
+def test_discovery_string_payload_still_normalizes_after_refactor() -> None:
+    """String secrets payloads must keep normalizing after the chokepoint move.
+
+    Normalization moved out of the str-decode branch into the shared mapping
+    branch. This guards that a JSON-string bundle (the manual-paste shape) still
+    gets credential whitespace stripped, so the refactor is behavior-preserving.
+    """
+
+    payload = {
+        "secrets_json": json.dumps(
+            {
+                "google_email": "DiscoveryUser@example.com",
+                "aas_token": "aas_et/DISCOVERY",
+                "owner_key": "EEEE FFFF",
+            }
+        )
+    }
+
+    result = config_flow._normalize_and_validate_discovery_payload(payload)
+
+    assert result.secrets_bundle is not None
+    assert result.secrets_bundle["owner_key"] == "EEEEFFFF"
+
+
+def test_discovery_invalid_json_secrets_still_raises() -> None:
+    """A malformed JSON-string bundle must still raise after the chokepoint move."""
+
+    payload = {"secrets_json": "{not-valid-json"}
+
+    with pytest.raises(config_flow.DiscoveryFlowError):
+        config_flow._normalize_and_validate_discovery_payload(payload)
 
 
 def test_async_step_discovery_new_entry(

--- a/tests/test_config_flow_secrets_normalization.py
+++ b/tests/test_config_flow_secrets_normalization.py
@@ -71,6 +71,29 @@ def test_nested_fcm_token_normalized() -> None:
     assert result["fcm_credentials"]["fcm"]["registration"]["token"] == "registration"
 
 
+def test_nested_gcm_identity_normalized() -> None:
+    """The numeric GCM identity (android_id / security_token under
+    fcm_credentials.gcm) loses ALL whitespace: both are fed to int() on the FCM
+    login path, so an interior space from a wrapped paste would break push
+    registration (Codex finding on PR #182)."""
+    bundle = {
+        "fcm_credentials": {
+            "gcm": {
+                "android_id": "1234 5678 9012 3456",
+                "security_token": " 9876\n543210 ",
+                "app_id": "app-1",
+            }
+        }
+    }
+    result = normalize_secrets_bundle(bundle)
+    gcm = result["fcm_credentials"]["gcm"]
+    assert gcm["android_id"] == "1234567890123456"
+    assert gcm["security_token"] == "9876543210"
+    # app_id is a structured identifier (not numeric/token credential material)
+    # and is not in the whitelist: only edge-trimmed, interior preserved.
+    assert gcm["app_id"] == "app-1"
+
+
 def test_idempotent() -> None:
     """Applying the normalization twice yields the same result."""
     bundle = {

--- a/tests/test_config_flow_secrets_normalization.py
+++ b/tests/test_config_flow_secrets_normalization.py
@@ -1,0 +1,214 @@
+# tests/test_config_flow_secrets_normalization.py
+"""Tests for whitespace normalization of pasted secrets.json bundles.
+
+Copy/paste of a ``secrets.json`` into the config flow can inject stray
+whitespace into credential values. A single space inside ``owner_key`` breaks
+AES-GCM owner-key decryption ("Owner key decryption failed"), and the user had
+to delete that space manually. ``normalize_secrets_bundle`` removes whitespace
+from credential values while preserving interior spaces in free-text fields.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from typing import Any
+
+import pytest
+from homeassistant.helpers import frame
+
+from custom_components.googlefindmy import config_flow
+from custom_components.googlefindmy.const import (
+    CONF_GOOGLE_EMAIL,
+    CONF_OAUTH_TOKEN,
+    DATA_SECRET_BUNDLE,
+)
+from custom_components.googlefindmy.shared_helpers import normalize_secrets_bundle
+from tests.helpers.config_flow import (
+    ConfigEntriesDomainUniqueIdLookupMixin,
+    attach_config_entries_flow_manager,
+    prepare_flow_hass_config_entries,
+    set_config_flow_unique_id,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("AABBCC", "AABBCC"),  # already clean -> unchanged
+        (" AABBCC", "AABBCC"),  # leading space
+        ("AABBCC ", "AABBCC"),  # trailing space
+        ("AA BB CC", "AABBCC"),  # interior spaces (wrapped paste)
+        ("AA\nBB\tCC", "AABBCC"),  # interior newline/tab
+        ("  AA BB  ", "AABB"),  # combined leading/trailing/interior
+    ],
+)
+def test_credential_value_all_whitespace_removed(raw: str, expected: str) -> None:
+    """Whitelisted credential keys lose ALL whitespace, including interior."""
+    assert normalize_secrets_bundle({"owner_key": raw})["owner_key"] == expected
+    assert normalize_secrets_bundle({"shared_key": raw})["shared_key"] == expected
+
+
+def test_non_credential_value_only_edge_trimmed() -> None:
+    """Free-text fields keep interior spaces and are only edge-trimmed."""
+    result = normalize_secrets_bundle(
+        {"username": "  Jane Doe  ", "Email": " a b@x.io "}
+    )
+    assert result["username"] == "Jane Doe"
+    assert result["Email"] == "a b@x.io"
+
+
+def test_nested_fcm_token_normalized() -> None:
+    """Whitelisted keys nested under fcm_credentials are normalized too."""
+    bundle = {
+        "fcm_credentials": {
+            "installation": {"token": " inst alled "},
+            "fcm": {"registration": {"token": "reg\nistration"}},
+        }
+    }
+    result = normalize_secrets_bundle(bundle)
+    assert result["fcm_credentials"]["installation"]["token"] == "installed"
+    assert result["fcm_credentials"]["fcm"]["registration"]["token"] == "registration"
+
+
+def test_idempotent() -> None:
+    """Applying the normalization twice yields the same result."""
+    bundle = {
+        "owner_key": " AA BB ",
+        "username": "  Jane Doe  ",
+        "fcm_credentials": {"installation": {"token": " t ok "}},
+    }
+    once = normalize_secrets_bundle(bundle)
+    assert normalize_secrets_bundle(once) == once
+
+
+def test_input_not_mutated() -> None:
+    """The input mapping is never mutated (safe for MappingProxyType)."""
+    bundle = {"owner_key": " AA BB ", "nested": {"aas_token": " x y "}}
+    normalize_secrets_bundle(bundle)
+    assert bundle["owner_key"] == " AA BB "
+    assert bundle["nested"]["aas_token"] == " x y "
+
+
+def test_list_values_recursed() -> None:
+    """Lists are walked element-wise, dicts inside them are normalized."""
+    bundle = {"items": [{"token": " a b "}, {"username": "  keep me  "}]}
+    result = normalize_secrets_bundle(bundle)
+    assert result["items"][0]["token"] == "ab"
+    assert result["items"][1]["username"] == "keep me"
+
+
+def test_non_string_scalars_unchanged() -> None:
+    """Non-string scalar values pass through unchanged."""
+    bundle = {"count": 3, "enabled": True, "missing": None, "owner_key": " A B "}
+    result = normalize_secrets_bundle(bundle)
+    assert result["count"] == 3
+    assert result["enabled"] is True
+    assert result["missing"] is None
+    assert result["owner_key"] == "AB"
+
+
+def test_non_mapping_input_returned_unchanged() -> None:
+    """A non-mapping top-level value is returned unchanged."""
+    assert normalize_secrets_bundle("plain") == "plain"
+    assert normalize_secrets_bundle(None) is None
+
+
+@pytest.mark.asyncio
+async def test_config_flow_round_trip_strips_owner_key_space(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: a pasted owner_key with a stray space is persisted clean.
+
+    This is the regression guard for the reported bug: the user pasted a valid
+    secrets.json but a copy/paste space inside owner_key broke decryption. The
+    persisted secrets bundle must contain the whitespace-free owner_key.
+    """
+    secrets_payload = {
+        "google_email": "user@example.com",
+        "aas_token": "aas_et/FROM_SECRETS",
+        "owner_key": "AA BB\nCC ",
+        "shared_key": " DD EE ",
+        "username": "  Keep Me  ",
+    }
+
+    async def _fake_pick(
+        hass: Any,
+        email: str,
+        candidates: list[tuple[str, str]],
+        *,
+        secrets_bundle: dict[str, Any] | None = None,
+    ) -> str | None:
+        # The bundle handed downstream is already normalized.
+        assert secrets_bundle is not None
+        assert secrets_bundle["owner_key"] == "AABBCC"
+        return candidates[0][1]
+
+    monkeypatch.setattr(config_flow, "async_pick_working_token", _fake_pick)
+
+    class _ConfigEntries(ConfigEntriesDomainUniqueIdLookupMixin):
+        def __init__(self) -> None:
+            attach_config_entries_flow_manager(self)
+
+        def async_entries(self, domain: str) -> list[Any]:
+            assert domain == config_flow.DOMAIN
+            return []
+
+    class _FlowHass:
+        def __init__(self) -> None:
+            prepare_flow_hass_config_entries(
+                self,
+                _ConfigEntries,
+                frame_module=frame,
+            )
+
+    captured: dict[str, Any] = {}
+
+    async def _create_entry(
+        *,
+        title: str,
+        data: dict[str, Any],
+        options: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        captured["result"] = {"title": title, "data": data, "options": options}
+        return {"type": "create_entry", "title": title, "data": data}
+
+    hass = _FlowHass()
+    flow = config_flow.ConfigFlow()
+    flow.hass = hass  # type: ignore[assignment]
+    flow.context = {}
+    flow._available_devices = [("Device", "device-id")]  # type: ignore[attr-defined]
+    set_config_flow_unique_id(flow, None)
+
+    async def _set_unique_id(value: str, *, raise_on_progress: bool = False) -> None:
+        set_config_flow_unique_id(flow, value)
+
+    flow.async_set_unique_id = _set_unique_id  # type: ignore[assignment]
+    flow._abort_if_unique_id_configured = lambda **_: None  # type: ignore[attr-defined]
+    flow.async_create_entry = _create_entry  # type: ignore[assignment]
+
+    first = await flow.async_step_secrets_json(
+        {"secrets_json": json.dumps(secrets_payload)}
+    )
+    if inspect.isawaitable(first):
+        first = await first
+    assert isinstance(first, dict)
+    assert first.get("type") == "form"
+
+    final = await flow.async_step_device_selection({})
+    if inspect.isawaitable(final):
+        final = await final
+    assert isinstance(final, dict)
+    assert final.get("type") == "create_entry"
+
+    payload = captured.get("result")
+    assert payload, "Expected config entry payload to be captured"
+    data = payload["data"]
+    bundle = data[DATA_SECRET_BUNDLE]
+    assert bundle["owner_key"] == "AABBCC"
+    assert bundle["shared_key"] == "DDEE"
+    # Free-text field keeps interior spaces, only edge-trimmed.
+    assert bundle["username"] == "Keep Me"
+    # Token persisted from the (clean) aas_token.
+    assert data[CONF_OAUTH_TOKEN] == "aas_et/FROM_SECRETS"
+    assert data[CONF_GOOGLE_EMAIL] == "user@example.com"

--- a/tests/test_coordinator_decrypt_reauth_escalation.py
+++ b/tests/test_coordinator_decrypt_reauth_escalation.py
@@ -18,8 +18,11 @@ through CI: a 0.0 sentinel made the first escalation uptime-dependent).
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from unittest.mock import MagicMock
+
+import pytest
 
 from custom_components.googlefindmy.coordinator import polling as polling_mod
 from custom_components.googlefindmy.coordinator.polling import (
@@ -88,8 +91,11 @@ def test_t5_success_reset_prevents_premature_escalation() -> None:
     stub.note_decrypt_failure(stale=False, error=err)
     stub.note_decrypt_failure(stale=False, error=err)
     assert stub._consecutive_decrypt_failures == 2
-    stub._consecutive_decrypt_failures = 0  # success path reset
-    stub._last_decrypt_error = None
+    stub.note_decrypt_success()  # the real success path reset
+    assert stub._consecutive_decrypt_failures == 0
+    # The shared entry point clears only the account-wide counter; the diagnostic
+    # error class is owned by the poll loop's OK gate, so it survives this call.
+    assert stub._last_decrypt_error is not None
 
     # Two fresh failures must NOT escalate (threshold is 3, not 1).
     assert stub.note_decrypt_failure(stale=False, error=err) is False
@@ -163,3 +169,48 @@ def test_t9_first_escalation_is_independent_of_process_uptime() -> None:
     stub._set_auth_state.assert_called_once()
     # The escalation timestamp is now recorded (no longer the None sentinel).
     assert stub._last_decrypt_reauth_monotonic == fresh_boot_clock
+
+
+def test_note_decrypt_success_clears_accumulated_failures(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The shared success entry point clears a partial decrypt-failure budget.
+
+    This is the symmetric counterpart of ``note_decrypt_failure`` that both the
+    poll cycle and the FCM background-push decode call on a proven decrypt. Two
+    non-escalating failures leave the counter at 2; a single success must reset
+    it to 0, so a later failure starts the threshold count fresh instead of
+    escalating one step early. The diagnostic ``_last_decrypt_error`` is NOT
+    cleared here: it is part of the sensor surface owned by the poll loop's OK
+    gate (which alone knows whether a per-tracker stale key must keep it), so
+    this shared entry point leaves it intact.
+    """
+    stub = _make_stub()
+    err = DecryptionError("boom")
+    stub.note_decrypt_failure(stale=False, error=err)
+    stub.note_decrypt_failure(stale=False, error=err)
+    assert stub._consecutive_decrypt_failures == 2
+    assert stub._last_decrypt_error is not None
+
+    with caplog.at_level(logging.INFO, logger=polling_mod.__name__):
+        stub.note_decrypt_success()
+
+    assert stub._consecutive_decrypt_failures == 0
+    # Counter cleared, diagnostic preserved (owned by the poll OK gate).
+    assert stub._last_decrypt_error is not None
+    assert "clearing 2 decrypt failure(s)" in caplog.text
+
+
+def test_note_decrypt_success_is_idempotent_when_no_failures(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """With an empty budget the success entry point is a cheap no-op: it clears
+    nothing and stays silent (no misleading "clearing 0 failure(s)" log)."""
+    stub = _make_stub()
+
+    with caplog.at_level(logging.INFO, logger=polling_mod.__name__):
+        stub.note_decrypt_success()
+
+    assert stub._consecutive_decrypt_failures == 0
+    assert stub._last_decrypt_error is None
+    assert "clearing" not in caplog.text

--- a/tests/test_coordinator_decrypt_reauth_escalation.py
+++ b/tests/test_coordinator_decrypt_reauth_escalation.py
@@ -1,0 +1,165 @@
+# tests/test_coordinator_decrypt_reauth_escalation.py
+"""Decrypt-failure escalation in the polling coordinator.
+
+These tests prove the bug fix for the "stale shared key" condition: repeated
+location-decryption failures must escalate to a Home Assistant reauth flow
+(``ConfigEntryAuthFailed``) after ``_MAX_DECRYPT_FAILURES`` consecutive cycles,
+while a single transient failure or a successful self-heal must NOT trigger it.
+
+The escalation decision lives in ``PollingOperations.note_decrypt_failure`` (a
+synchronous, side-effect-light method), so it is exercised directly via the
+``PollingStub`` mixin harness. Cross-mixin ``_set_auth_state`` is mocked.
+
+The cooldown gate reads the clock through the injectable ``_monotonic`` seam
+instead of the ambient ``time.monotonic``; tests drive it deterministically so
+the outcome never depends on the host's process uptime (the bug that slipped
+through CI: a 0.0 sentinel made the first escalation uptime-dependent).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from unittest.mock import MagicMock
+
+from custom_components.googlefindmy.coordinator import polling as polling_mod
+from custom_components.googlefindmy.coordinator.polling import (
+    _MAX_DECRYPT_FAILURES,
+)
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    DecryptionError,
+    SharedKeyMismatchError,
+    SharedKeyMissingError,
+    StaleOwnerKeyError,
+)
+
+from .helpers.polling_mixin_stub import PollingStub
+
+
+def _make_stub(monotonic: Callable[[], float] | None = None) -> PollingStub:
+    """Return a PollingStub seeded with the decrypt-escalation state fields.
+
+    Args:
+        monotonic: Optional clock callable for the cooldown gate. Defaults to a
+            fixed value far past any cooldown so the threshold is the only gate;
+            pass a mutable clock to exercise the cooldown window itself.
+    """
+    stub = PollingStub()
+    stub._consecutive_decrypt_failures = 0
+    # None == "never escalated yet"; the first escalation must never consult the
+    # cooldown gate (and therefore never depend on the clock value).
+    stub._last_decrypt_reauth_monotonic = None
+    stub._last_decrypt_error = None
+    stub._monotonic = monotonic if monotonic is not None else (lambda: 1_000_000.0)
+    stub._set_auth_state = MagicMock()
+    return stub
+
+
+def test_t4_escalates_after_threshold_consecutive_failures() -> None:
+    """T4: the Nth consecutive account-wide decrypt failure escalates to reauth.
+
+    Failures 1..N-1 only warn and return False (keep polling, let self-heal try);
+    failure N returns True and marks the auth state as failed so the caller raises
+    ConfigEntryAuthFailed.
+    """
+    stub = _make_stub()
+    err = SharedKeyMismatchError("stale shared key")
+
+    # Below threshold: no escalation, no auth-state change.
+    for attempt in range(1, _MAX_DECRYPT_FAILURES):
+        assert stub.note_decrypt_failure(stale=False, error=err, device="dev") is False
+        assert stub._consecutive_decrypt_failures == attempt
+    stub._set_auth_state.assert_not_called()
+
+    # Threshold reached: escalate.
+    assert stub.note_decrypt_failure(stale=False, error=err, device="dev") is True
+    stub._set_auth_state.assert_called_once()
+    assert stub._set_auth_state.call_args.kwargs.get("failed") is True
+    # Counter resets after escalation so it does not grow unbounded.
+    assert stub._consecutive_decrypt_failures == 0
+
+
+def test_t5_success_reset_prevents_premature_escalation() -> None:
+    """T5: a reset (successful cycle) clears the counter, so later failures must
+    again reach the full threshold before escalating."""
+    stub = _make_stub()
+    err = DecryptionError("boom")
+
+    # Two failures, then a reset (what the success path does).
+    stub.note_decrypt_failure(stale=False, error=err)
+    stub.note_decrypt_failure(stale=False, error=err)
+    assert stub._consecutive_decrypt_failures == 2
+    stub._consecutive_decrypt_failures = 0  # success path reset
+    stub._last_decrypt_error = None
+
+    # Two fresh failures must NOT escalate (threshold is 3, not 1).
+    assert stub.note_decrypt_failure(stale=False, error=err) is False
+    assert stub.note_decrypt_failure(stale=False, error=err) is False
+    stub._set_auth_state.assert_not_called()
+
+
+def test_t6_stale_owner_key_does_not_escalate() -> None:
+    """T6: a per-tracker StaleOwnerKeyError never drives the account-wide counter
+    and never escalates to an account reauth (it needs a per-tracker re-pair)."""
+    stub = _make_stub()
+    stale = StaleOwnerKeyError("tracker v1 < v2")
+
+    for _ in range(_MAX_DECRYPT_FAILURES + 2):
+        assert stub.note_decrypt_failure(stale=True, error=stale, device="tag") is False
+
+    assert stub._consecutive_decrypt_failures == 0
+    stub._set_auth_state.assert_not_called()
+
+
+def test_t8_cooldown_suppresses_refire() -> None:
+    """T8: once escalated, the reauth flow is not re-fired on every poll while the
+    cooldown window is open (the un-fixable condition persists each cycle)."""
+    clock = {"now": 1_000_000.0}
+    stub = _make_stub(lambda: clock["now"])
+    err = SharedKeyMissingError("missing")
+
+    # Reach the threshold -> first escalation.
+    for _ in range(_MAX_DECRYPT_FAILURES):
+        result = stub.note_decrypt_failure(stale=False, error=err)
+    assert result is True
+    assert stub._set_auth_state.call_count == 1
+
+    # Immediately hit the threshold again within the cooldown window: no re-fire.
+    for _ in range(_MAX_DECRYPT_FAILURES):
+        result = stub.note_decrypt_failure(stale=False, error=err)
+    assert result is False
+    assert stub._set_auth_state.call_count == 1  # unchanged
+
+    # The counter keeps growing while suppressed (it is not reset in the cooldown
+    # branch), so once the cooldown window elapses the very next failure -- already
+    # past the threshold -- escalates again. This yields "at most one escalation
+    # per cooldown window".
+    clock["now"] += polling_mod._DECRYPT_REAUTH_COOLDOWN_S + 1.0
+    assert stub.note_decrypt_failure(stale=False, error=err) is True
+    assert stub._set_auth_state.call_count == 2
+
+
+def test_t9_first_escalation_is_independent_of_process_uptime() -> None:
+    """T9 (regression): the first escalation must fire on a freshly booted host.
+
+    Reproduces the CI flake/production bug: with a 0.0 sentinel the cooldown gate
+    computed ``monotonic() - 0.0 < cooldown`` and, while process uptime was below
+    the cooldown window, wrongly suppressed the very first reauth escalation. With
+    the None sentinel the first escalation skips the cooldown gate entirely, so a
+    low monotonic value (simulated fresh boot) must still escalate.
+    """
+    # Monotonic far below the 6h cooldown window -> a fresh-boot runner.
+    fresh_boot_clock = 100.0
+    assert fresh_boot_clock < polling_mod._DECRYPT_REAUTH_COOLDOWN_S
+    stub = _make_stub(lambda: fresh_boot_clock)
+    err = SharedKeyMismatchError("stale shared key")
+
+    results = [
+        stub.note_decrypt_failure(stale=False, error=err, device="dev")
+        for _ in range(_MAX_DECRYPT_FAILURES)
+    ]
+
+    # Failures 1..N-1 hold, failure N escalates -- regardless of the low clock.
+    assert results == [False] * (_MAX_DECRYPT_FAILURES - 1) + [True]
+    stub._set_auth_state.assert_called_once()
+    # The escalation timestamp is now recorded (no longer the None sentinel).
+    assert stub._last_decrypt_reauth_monotonic == fresh_boot_clock

--- a/tests/test_coordinator_decrypt_reauth_escalation.py
+++ b/tests/test_coordinator_decrypt_reauth_escalation.py
@@ -25,6 +25,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from custom_components.googlefindmy.coordinator import polling as polling_mod
+from custom_components.googlefindmy.coordinator.helpers.stats import CryptoStatus
 from custom_components.googlefindmy.coordinator.polling import (
     _MAX_DECRYPT_FAILURES,
 )
@@ -214,3 +215,67 @@ def test_note_decrypt_success_is_idempotent_when_no_failures(
     assert stub._consecutive_decrypt_failures == 0
     assert stub._last_decrypt_error is None
     assert "clearing" not in caplog.text
+
+
+@pytest.mark.parametrize(
+    "account_wide_failure",
+    [CryptoStatus.SHARED_KEY_INVALID, CryptoStatus.SHARED_KEY_MISSING],
+)
+def test_note_background_decrypt_success_heals_account_wide_failure(
+    account_wide_failure: str,
+) -> None:
+    """A proven background push heals the sensor out of an account-wide failure.
+
+    On push-only setups whose scheduled polls stay idle, the diagnostic
+    encryption-key sensor would otherwise stick on a stale ``shared_key_invalid``
+    / ``shared_key_missing`` status even though real pushes keep decrypting. The
+    background success entry point lifts the account-wide failure to ``OK`` and
+    moves the error class with it (one sensor surface), and still clears the
+    shared reauth budget.
+    """
+    stub = _make_stub()
+    stub._crypto_status_state = account_wide_failure
+    stub._last_decrypt_error = "SharedKeyMismatchError: stale"
+    stub._consecutive_decrypt_failures = 2
+
+    stub.note_background_decrypt_success()
+
+    assert stub._crypto_status_state == CryptoStatus.OK
+    assert stub._last_decrypt_error is None
+    assert stub._consecutive_decrypt_failures == 0
+
+
+def test_note_background_decrypt_success_preserves_tracker_key_outdated() -> None:
+    """A single background decode must NOT wipe a per-tracker stale-key diagnostic.
+
+    A push proves the account-wide shared key, not that a per-tracker outdated
+    owner key has been re-paired (it has no cross-tracker view). So when the
+    sensor reports ``tracker_key_outdated`` the heal must leave both the status
+    and its error class untouched, while still clearing the account-wide budget.
+    This is the anti-widening guard for the round-5 diagnostic invariant.
+    """
+    stub = _make_stub()
+    stub._crypto_status_state = CryptoStatus.TRACKER_KEY_OUTDATED
+    stub._last_decrypt_error = "StaleOwnerKeyError: tracker v1 < v2"
+    stub._consecutive_decrypt_failures = 0
+
+    stub.note_background_decrypt_success()
+
+    assert stub._crypto_status_state == CryptoStatus.TRACKER_KEY_OUTDATED
+    assert stub._last_decrypt_error == "StaleOwnerKeyError: tracker v1 < v2"
+
+
+def test_note_background_decrypt_success_leaves_unknown_untouched() -> None:
+    """With no failure to heal, the push success does not fabricate an ``OK``.
+
+    ``UNKNOWN`` is the initial state before any decrypt signal; the OK semantics
+    stay anchored to an observed account-wide failure being refuted, so a push
+    must not flip a never-failed sensor to OK ahead of the first real proof.
+    """
+    stub = _make_stub()
+    assert stub._crypto_status_state == CryptoStatus.UNKNOWN
+
+    stub.note_background_decrypt_success()
+
+    assert stub._crypto_status_state == CryptoStatus.UNKNOWN
+    assert stub._last_decrypt_error is None

--- a/tests/test_coordinator_locate_basics.py
+++ b/tests/test_coordinator_locate_basics.py
@@ -14,10 +14,17 @@ from __future__ import annotations
 
 import asyncio
 import math
+from unittest.mock import MagicMock
 
 import pytest
+from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.googlefindmy.const import DEFAULT_MIN_POLL_INTERVAL
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    DecryptionError,
+    SharedKeyMismatchError,
+    StaleOwnerKeyError,
+)
 from tests.helpers.config_entries_stub import make_config_entry
 from tests.helpers.locate_mixin_stub import LocateStub
 
@@ -252,6 +259,77 @@ class TestAsyncLocateDeviceGating:
         }
         result = await coord.async_locate_device("dev-1")
         assert result == {}
+
+
+class TestAsyncLocateDeviceDecryptFailure:
+    """Codex P2: manual locate must handle stale/missing shared-key failures the
+    same way the poll path does (feed the shared escalation counter, start reauth),
+    not swallow ``DecryptionError`` into a generic ``HomeAssistantError``."""
+
+    @pytest.fixture(autouse=True)
+    def _pass_cooldown(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Move the clock past every cooldown gate so the Nova call is reached."""
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+            lambda: 1000.0,
+        )
+
+    async def test_stale_owner_key_records_per_tracker_no_reauth(
+        self, coord: LocateStub
+    ) -> None:
+        """A per-tracker StaleOwnerKeyError feeds note_decrypt_failure(stale=True),
+        never starts an account reauth, and returns an empty result."""
+        coord.note_decrypt_failure = MagicMock(return_value=False)
+        coord.config_entry.async_start_reauth = MagicMock()
+        coord.api.async_get_device_location.side_effect = StaleOwnerKeyError(
+            "tracker v1 < v2"
+        )
+
+        result = await coord.async_locate_device("dev-1")
+
+        assert result == {}
+        coord.note_decrypt_failure.assert_called_once()
+        assert coord.note_decrypt_failure.call_args.kwargs.get("stale") is True
+        coord.config_entry.async_start_reauth.assert_not_called()
+
+    async def test_decrypt_failure_below_threshold_returns_empty(
+        self, coord: LocateStub
+    ) -> None:
+        """Below the escalation threshold the manual locate degrades gracefully to
+        an empty result (mirrors the poll path that keeps polling), and must not
+        start a reauth flow."""
+        coord.note_decrypt_failure = MagicMock(return_value=False)
+        coord.config_entry.async_start_reauth = MagicMock()
+        coord.api.async_get_device_location.side_effect = SharedKeyMismatchError(
+            "stale shared key"
+        )
+
+        result = await coord.async_locate_device("dev-1")
+
+        assert result == {}
+        coord.note_decrypt_failure.assert_called_once()
+        assert coord.note_decrypt_failure.call_args.kwargs.get("stale") is False
+        coord.config_entry.async_start_reauth.assert_not_called()
+
+    async def test_decrypt_failure_at_threshold_starts_reauth(
+        self, coord: LocateStub
+    ) -> None:
+        """When the shared counter says escalate (note_decrypt_failure True), manual
+        locate marks the auth state failed, starts the reauth flow, and surfaces a
+        user-facing HomeAssistantError instead of an empty result."""
+        coord.note_decrypt_failure = MagicMock(return_value=True)
+        coord.config_entry.async_start_reauth = MagicMock()
+        coord.api.async_get_device_location.side_effect = DecryptionError(
+            "shared key gone"
+        )
+
+        with pytest.raises(HomeAssistantError) as excinfo:
+            await coord.async_locate_device("dev-1")
+
+        assert "re-authentication has been started" in str(excinfo.value)
+        coord._set_auth_state.assert_called_once()
+        assert coord._set_auth_state.call_args.kwargs.get("failed") is True
+        coord.config_entry.async_start_reauth.assert_called_once()
 
 
 class TestAsyncPlaySoundGating:

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -397,7 +397,11 @@ class _DecryptThenSucceedAPI:
         self.calls += 1
         if self.calls <= self._fail:
             raise self._exc
-        return {}  # success with no decryptable report (still clears the counter)
+        # A genuinely decryptable report: positive proof the account-wide shared
+        # key works again. Only such a real decrypt clears the counter -- an empty
+        # / no-reporter response (falsy) is an idle outcome and must NOT (see
+        # test_poll_cycle_idle_does_not_reset_decrypt_counter).
+        return {"latitude": 1.0, "longitude": 2.0, "accuracy": 5.0}
 
 
 @pytest.mark.asyncio
@@ -417,6 +421,56 @@ async def test_poll_cycle_decrypt_counter_resets_on_success() -> None:
     # A successful cycle resets the counter back to zero.
     await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
     assert coordinator._consecutive_decrypt_failures == 0
+    # No per-tracker stale key was seen, so the OK gate also clears the diagnostic
+    # error class (status and error class move together). Mutation guard: dropping
+    # the OK-gate ``_last_decrypt_error = None`` leaves the stale class behind.
+    assert coordinator._last_decrypt_error is None
+    assert coordinator.crypto_status.state == CryptoStatus.OK
+
+
+class _DecryptThenIdleAPI:
+    """Raises a decryption error for the first ``fail_times`` calls, then returns
+    an empty (no-reporter) result.
+
+    Models an intermittently reporting BLE tracker: failing decrypt cycles are
+    interleaved with idle cycles that simply return no location data. Such idle
+    cycles carry no positive proof the shared key recovered and must therefore
+    NOT clear the accumulated decrypt-failure counter.
+    """
+
+    def __init__(self, exc: Exception, fail_times: int) -> None:
+        self._exc = exc
+        self._fail = fail_times
+        self.calls = 0
+
+    async def async_get_device_location(self, *_args: Any, **_kwargs: Any) -> list[Any]:
+        self.calls += 1
+        if self.calls <= self._fail:
+            raise self._exc
+        return []  # idle: no reporter in range, nothing decrypted this cycle
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_idle_does_not_reset_decrypt_counter() -> None:
+    """An idle cycle (empty/no-reporter result) must NOT clear accumulated decrypt
+    failures: without a real successful decrypt there is no proof the stale shared
+    key recovered. Otherwise an intermittently reporting BLE tracker would let idle
+    cycles perpetually reset the counter, so the reauth threshold is never reached
+    and the user stays stuck with no location updates and no reauth prompt
+    (Codex finding on PR #182)."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptThenIdleAPI(
+        SharedKeyMismatchError("transient stale"), fail_times=_MAX_DECRYPT_FAILURES - 1
+    )
+
+    # Below-threshold failing cycles accumulate the counter without escalating.
+    for _ in range(_MAX_DECRYPT_FAILURES - 1):
+        await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    assert coordinator._consecutive_decrypt_failures == _MAX_DECRYPT_FAILURES - 1
+
+    # An idle cycle in between must leave the counter intact (not reset to zero).
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    assert coordinator._consecutive_decrypt_failures == _MAX_DECRYPT_FAILURES - 1
 
 
 class _PerDeviceDecryptAPI:
@@ -679,3 +733,36 @@ async def test_poll_cycle_mixed_stale_and_success_keeps_tracker_outdated() -> No
     )
 
     assert coordinator.crypto_status.state == CryptoStatus.TRACKER_KEY_OUTDATED
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_mixed_stale_and_success_keeps_last_decrypt_error() -> None:
+    """The stale-key diagnostic must survive a sibling's successful decrypt.
+
+    Same mixed cycle as above, but asserting the *error class* the encryption-key
+    status sensor exposes (``last_decrypt_error_class`` from ``_last_decrypt_error``).
+    The successful sibling clears the account-wide reauth budget via the shared
+    success entry point, yet the per-tracker StaleOwnerKeyError diagnostic must
+    stay so the sensor can still report which class is outdated.
+
+    Regression guard for the Codex finding: clearing ``_last_decrypt_error``
+    unconditionally in ``note_decrypt_success()`` (or gating it only on the
+    counter) wipes this on the very cycle a sibling decrypts and turns this red.
+    """
+
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _MixedDecryptAPI(
+        "dev-stale",
+        StaleOwnerKeyError("tracker v1 < v2"),
+        {"latitude": 1.0, "longitude": 2.0, "last_seen": 100},
+    )
+    coordinator._set_auth_state = lambda **_kwargs: None
+
+    await coordinator._async_start_poll_cycle(
+        [{"id": "dev-stale", "name": "Old"}, {"id": "dev-ok", "name": "Hub"}]
+    )
+
+    # Status stays outdated AND the error class behind it survives for triage.
+    assert coordinator.crypto_status.state == CryptoStatus.TRACKER_KEY_OUTDATED
+    assert coordinator._last_decrypt_error is not None
+    assert coordinator._last_decrypt_error.split(":", 1)[0] == "StaleOwnerKeyError"

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -473,6 +473,168 @@ async def test_poll_cycle_idle_does_not_reset_decrypt_counter() -> None:
     assert coordinator._consecutive_decrypt_failures == _MAX_DECRYPT_FAILURES - 1
 
 
+class _DecryptThenMetadataOnlyAPI:
+    """Raises a decryption error for the first ``fail_times`` calls, then returns a
+    ``metadata_only`` sentinel row.
+
+    Models a device whose secrets bundle still yields key *material* (so a
+    metadata_only row is emitted) while no encrypted report decrypts. The sentinel
+    is truthy but proves nothing about the shared key, so such a cycle must NOT
+    clear the accumulated decrypt-failure counter (Codex finding on PR #182).
+    """
+
+    def __init__(self, exc: Exception, fail_times: int) -> None:
+        self._exc = exc
+        self._fail = fail_times
+        self.calls = 0
+
+    async def async_get_device_location(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        self.calls += 1
+        if self.calls <= self._fail:
+            raise self._exc
+        # metadata_only sentinel: key material from the secrets bundle, no decrypt.
+        return {"metadata_only": True, "owner_key_version": 7}
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_metadata_only_does_not_reset_decrypt_counter() -> None:
+    """A metadata_only cycle must NOT clear accumulated decrypt failures: the
+    sentinel row carries key material from the secrets bundle, not an authenticated
+    decrypt, so it is no proof the stale shared key recovered. Otherwise a
+    report-less device emitting metadata_only could let such cycles perpetually
+    reset the counter, the reauth threshold is never reached, and the user stays
+    stuck with no location updates and no reauth prompt (Codex finding on PR
+    #182)."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptThenMetadataOnlyAPI(
+        SharedKeyMismatchError("transient stale"), fail_times=_MAX_DECRYPT_FAILURES - 1
+    )
+
+    # Below-threshold failing cycles accumulate the counter without escalating.
+    for _ in range(_MAX_DECRYPT_FAILURES - 1):
+        await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    assert coordinator._consecutive_decrypt_failures == _MAX_DECRYPT_FAILURES - 1
+
+    # A metadata_only cycle in between must leave the counter intact (not reset).
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    assert coordinator._consecutive_decrypt_failures == _MAX_DECRYPT_FAILURES - 1
+
+
+class _DecryptThenSemanticAPI:
+    """Raises a decryption error for the first ``fail_times`` calls, then returns a
+    SEMANTIC-shaped record (no coordinates).
+
+    Models a device whose server response is a semantic location ("Home") rather
+    than an encrypted fix. The decode layer appends SEMANTIC rows with
+    ``decrypted_location=b""`` and skips the crypto path, so the record carries a
+    ``semantic_name`` and ``last_seen`` but ``latitude``/``longitude`` are ``None``
+    and no ``metadata_only`` flag. It is truthy yet authenticates nothing, so such a
+    cycle must NOT clear the accumulated decrypt-failure counter (Codex finding on
+    PR #182): a denylist on ``metadata_only`` alone would let it through.
+    """
+
+    def __init__(self, exc: Exception, fail_times: int) -> None:
+        self._exc = exc
+        self._fail = fail_times
+        self.calls = 0
+
+    async def async_get_device_location(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        self.calls += 1
+        if self.calls <= self._fail:
+            raise self._exc
+        return {
+            "last_seen": 123.0,
+            "semantic_name": "Home",
+            "status": "semantic",
+            "latitude": None,
+            "longitude": None,
+        }
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_semantic_only_does_not_reset_decrypt_counter() -> None:
+    """A SEMANTIC-only cycle must NOT clear accumulated decrypt failures: the row
+    skips the crypto path (``decrypted_location=b""``) and carries no coordinates,
+    so it is no proof the stale shared key recovered. It also lacks the
+    ``metadata_only`` flag, so the previous denylist predicate would have wrongly
+    reset the counter and could strand a stale key below the reauth threshold
+    (Codex finding on PR #182)."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptThenSemanticAPI(
+        SharedKeyMismatchError("transient stale"), fail_times=_MAX_DECRYPT_FAILURES - 1
+    )
+
+    # Below-threshold failing cycles accumulate the counter without escalating.
+    for _ in range(_MAX_DECRYPT_FAILURES - 1):
+        await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    assert coordinator._consecutive_decrypt_failures == _MAX_DECRYPT_FAILURES - 1
+
+    # A SEMANTIC-only cycle in between must leave the counter intact (not reset).
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    assert coordinator._consecutive_decrypt_failures == _MAX_DECRYPT_FAILURES - 1
+
+
+class _DecryptThenHiddenProofAPI:
+    """Raises a decryption error for the first ``fail_times`` calls, then returns a
+    SEMANTIC-shaped record that still carries the full-list decrypt proof.
+
+    Models the Codex round-8 finding: the same Nova response decrypted a real
+    coordinate report, but ``api._select_best_location`` ranked a newer report-less
+    SEMANTIC row first and returned it. ``async_get_device_location`` preserves the
+    full-list verdict in the internal ``_decrypt_proven`` hint, so even though the
+    visible record has no coordinates the cycle DID prove the shared key and the
+    accumulated decrypt-failure counter must reset.
+    """
+
+    def __init__(self, exc: Exception, fail_times: int) -> None:
+        self._exc = exc
+        self._fail = fail_times
+        self.calls = 0
+
+    async def async_get_device_location(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        self.calls += 1
+        if self.calls <= self._fail:
+            raise self._exc
+        # Display-selected SEMANTIC row (newest last_seen, no coordinates) but the
+        # response decrypted a sibling coordinate fix -> hint records the proof.
+        return {
+            "last_seen": 200.0,
+            "semantic_name": "Home",
+            "status": "semantic",
+            "latitude": None,
+            "longitude": None,
+            "_decrypt_proven": True,
+        }
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_hidden_decrypt_proof_resets_counter() -> None:
+    """A real decrypt hidden behind a newer SEMANTIC row still clears the budget.
+
+    The display selector collapses the response to a report-less SEMANTIC record,
+    but the full-list ``_decrypt_proven`` hint shows a coordinate report decrypted.
+    The cycle must therefore reset the consecutive-decrypt-failure counter; without
+    carrying the full-list proof the success would be lost and a later transient
+    failure could trip a spurious reauth (Codex finding on PR #182)."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptThenHiddenProofAPI(
+        SharedKeyMismatchError("transient stale"), fail_times=_MAX_DECRYPT_FAILURES - 1
+    )
+
+    # Below-threshold failing cycles accumulate the counter without escalating.
+    for _ in range(_MAX_DECRYPT_FAILURES - 1):
+        await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    assert coordinator._consecutive_decrypt_failures == _MAX_DECRYPT_FAILURES - 1
+
+    # The hidden-proof cycle resets the counter back to zero.
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    assert coordinator._consecutive_decrypt_failures == 0
+    # The internal hint must not leak into the cached payload.
+    cached = coordinator._device_location_data.get("dev-1")
+    if isinstance(cached, dict):
+        assert "_decrypt_proven" not in cached
+
+
 class _PerDeviceDecryptAPI:
     """Raises a decryption error for one device id, succeeds (empty) for others."""
 

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -9,7 +9,10 @@ import pytest
 from homeassistant.config_entries import ConfigEntryAuthFailed
 
 from custom_components.googlefindmy.const import OPT_SEMANTIC_LOCATIONS
-from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
+from custom_components.googlefindmy.coordinator import (
+    CryptoStatus,
+    GoogleFindMyCoordinator,
+)
 from custom_components.googlefindmy.coordinator.polling import (
     _MAX_DECRYPT_FAILURES,
     _MAX_TRANSIENT_AUTH_FAILURES,
@@ -92,6 +95,9 @@ def _base_coordinator(
     coordinator._consecutive_decrypt_failures = 0
     coordinator._last_decrypt_reauth_monotonic = None
     coordinator._last_decrypt_error = None
+    coordinator._crypto_status_state = CryptoStatus.UNKNOWN
+    coordinator._crypto_status_reason = None
+    coordinator._crypto_status_changed_at = None
     # Deliberately low monotonic value: simulates a freshly booted runner (process
     # uptime below the reauth cooldown). With the None sentinel the first escalation
     # must fire regardless, so this pins the whole loop-test class against the
@@ -566,3 +572,110 @@ async def test_poll_cycle_direct_config_entry_auth_failed_starts_reauth() -> Non
 
     coordinator.config_entry.async_start_reauth.assert_called_once_with(coordinator.hass)
     assert any(kw.get("failed") for kw in auth_calls)
+
+
+class _MixedDecryptAPI:
+    """API stub that fails for one device id and returns a payload for others.
+
+    Drives a single poll cycle that contains both a per-tracker stale key and a
+    healthy, decrypting device, to prove the crypto sensor does not flicker the
+    tracker_key_outdated state to OK when a sibling decrypts successfully.
+    """
+
+    def __init__(self, fail_id: str, exc: Exception, ok_payload: dict[str, Any]) -> None:
+        self._fail_id = fail_id
+        self._exc = exc
+        self._ok_payload = ok_payload
+
+    async def async_get_device_location(
+        self, device_id: str, *_args: Any, **_kwargs: Any
+    ) -> dict[str, Any]:
+        if device_id == self._fail_id:
+            raise self._exc
+        return dict(self._ok_payload)
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_successful_decrypt_sets_crypto_ok() -> None:
+    """A cycle that decrypts usable location data reports crypto OK (D6 source)."""
+
+    coordinator = _polling_coordinator(
+        {}, _TrackingFilter(), {"latitude": 1.0, "longitude": 2.0, "last_seen": 100}
+    )
+
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+
+    assert coordinator.crypto_status.state == CryptoStatus.OK
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_shared_key_failure_sets_crypto_invalid() -> None:
+    """An account-wide SharedKeyMismatchError surfaces as shared_key_invalid."""
+
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptFailAPI(SharedKeyMismatchError("stale shared key"))
+    coordinator._set_auth_state = lambda **_kwargs: None
+
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+
+    assert coordinator.crypto_status.state == CryptoStatus.SHARED_KEY_INVALID
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_stale_key_sets_tracker_outdated() -> None:
+    """A per-tracker StaleOwnerKeyError surfaces as tracker_key_outdated."""
+
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptFailAPI(StaleOwnerKeyError("tracker v1 < v2"))
+    coordinator._set_auth_state = lambda **_kwargs: None
+
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+
+    assert coordinator.crypto_status.state == CryptoStatus.TRACKER_KEY_OUTDATED
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_timeout_only_does_not_clear_prior_failure() -> None:
+    """A cycle without any successful decrypt must NOT downgrade a prior
+    shared_key_invalid to OK -- absence of an error is not proof of health.
+
+    Mutation guard for the ``cycle_had_successful_decrypt`` gate: replacing it
+    with the weaker ``devices`` condition turns the second assertion red.
+    """
+
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator._set_auth_state = lambda **_kwargs: None
+
+    # Cycle 1: account-wide failure -> shared_key_invalid (below threshold).
+    coordinator.api = _DecryptFailAPI(SharedKeyMismatchError("stale shared key"))
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    assert coordinator.crypto_status.state == CryptoStatus.SHARED_KEY_INVALID
+
+    # Cycle 2: idle (empty location, no successful decrypt) -> state unchanged.
+    coordinator.api = _DummyAPI({})
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    assert coordinator.crypto_status.state == CryptoStatus.SHARED_KEY_INVALID
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_mixed_stale_and_success_keeps_tracker_outdated() -> None:
+    """A healthy sibling in a cycle that also hit a stale key must NOT flicker the
+    sensor to OK.
+
+    Mutation guard for the ``not cycle_had_stale_key`` gate: dropping it lets the
+    successful sibling overwrite tracker_key_outdated with OK and turns this red.
+    """
+
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _MixedDecryptAPI(
+        "dev-stale",
+        StaleOwnerKeyError("tracker v1 < v2"),
+        {"latitude": 1.0, "longitude": 2.0, "last_seen": 100},
+    )
+    coordinator._set_auth_state = lambda **_kwargs: None
+
+    await coordinator._async_start_poll_cycle(
+        [{"id": "dev-stale", "name": "Old"}, {"id": "dev-ok", "name": "Hub"}]
+    )
+
+    assert coordinator.crypto_status.state == CryptoStatus.TRACKER_KEY_OUTDATED

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -3,11 +3,25 @@ from __future__ import annotations
 import asyncio
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
+from homeassistant.config_entries import ConfigEntryAuthFailed
 
 from custom_components.googlefindmy.const import OPT_SEMANTIC_LOCATIONS
 from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
+from custom_components.googlefindmy.coordinator.polling import (
+    _MAX_DECRYPT_FAILURES,
+    _MAX_TRANSIENT_AUTH_FAILURES,
+)
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    SharedKeyMismatchError,
+    StaleOwnerKeyError,
+)
+from custom_components.googlefindmy.NovaApi.nova_request import (
+    NovaAuthError,
+    NovaAuthPermanentError,
+)
 from tests.helpers.homeassistant import GoogleFindMyConfigEntryStub
 
 
@@ -75,6 +89,14 @@ def _base_coordinator(
     coordinator._consecutive_timeouts = 0
     coordinator._consecutive_transient_auth_failures = 0
     coordinator._last_transient_auth_error = None
+    coordinator._consecutive_decrypt_failures = 0
+    coordinator._last_decrypt_reauth_monotonic = None
+    coordinator._last_decrypt_error = None
+    # Deliberately low monotonic value: simulates a freshly booted runner (process
+    # uptime below the reauth cooldown). With the None sentinel the first escalation
+    # must fire regardless, so this pins the whole loop-test class against the
+    # uptime-dependent flake that slipped through CI.
+    coordinator._monotonic = lambda: 100.0
     coordinator.location_poll_interval = 0
     coordinator.data = []
     coordinator._last_device_list = []
@@ -289,3 +311,258 @@ async def test_semantic_labels_are_recorded_with_device_ids() -> None:
     observations = coordinator.get_observed_semantic_labels()
     assert [obs.label for obs in observations] == ["Lobby"]
     assert observations[0].devices == {"dev-3"}
+
+
+class _DecryptFailAPI:
+    """API stub whose location lookup always raises the given decryption error.
+
+    Used to drive the coordinator poll loop through the decrypt-failure handlers
+    end to end (the isolated escalation logic is unit-tested separately in
+    tests/test_coordinator_decrypt_reauth_escalation.py).
+    """
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+        self.calls = 0
+
+    async def async_get_device_location(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        self.calls += 1
+        raise self._exc
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_escalates_persistent_decrypt_failure_to_reauth() -> None:
+    """End-to-end: a persistent account-wide stale shared key escalates the poll
+    loop to ConfigEntryAuthFailed after _MAX_DECRYPT_FAILURES cycles, so Home
+    Assistant shows the reauth card. The cycles before the threshold must NOT
+    escalate (self-heal still gets a chance)."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptFailAPI(SharedKeyMismatchError("stale shared key"))
+    auth_calls: list[dict[str, Any]] = []
+    coordinator._set_auth_state = lambda **kwargs: auth_calls.append(kwargs)
+
+    # Below threshold: keep polling, no reauth escalation yet.
+    for _ in range(_MAX_DECRYPT_FAILURES - 1):
+        await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    assert not any(kw.get("failed") for kw in auth_calls)
+    assert coordinator._consecutive_decrypt_failures == _MAX_DECRYPT_FAILURES - 1
+
+    # Threshold cycle: escalate to a reauth flow. The poll cycle runs as a
+    # fire-and-forget task, so it starts the entry reauth flow directly rather
+    # than raising (a raised ConfigEntryAuthFailed would never reach the awaited
+    # coordinator refresh and HA's automatic reauth would never fire).
+    coordinator.config_entry.async_start_reauth = MagicMock()
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    coordinator.config_entry.async_start_reauth.assert_called_once_with(coordinator.hass)
+    assert any(kw.get("failed") for kw in auth_calls)
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_stale_owner_key_never_escalates() -> None:
+    """End-to-end: a per-tracker StaleOwnerKeyError must never escalate to an
+    account-wide reauth (an account reauth would not fix one outdated tracker) and
+    must not drive the account-wide decrypt counter."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptFailAPI(StaleOwnerKeyError("tracker v1 < v2"))
+    auth_calls: list[dict[str, Any]] = []
+    coordinator._set_auth_state = lambda **kwargs: auth_calls.append(kwargs)
+
+    for _ in range(_MAX_DECRYPT_FAILURES + 2):
+        await coordinator._async_start_poll_cycle([{"id": "tag", "name": "Tag"}])
+
+    assert coordinator._consecutive_decrypt_failures == 0
+    assert not any(kw.get("failed") for kw in auth_calls)
+
+
+class _DecryptThenSucceedAPI:
+    """Raises a decryption error for the first ``fail_times`` calls, then succeeds.
+
+    Used to prove the consecutive-decrypt-failure counter resets on a successful
+    cycle (self-heal / recovered shared key), so a later isolated failure does not
+    trip a premature reauth.
+    """
+
+    def __init__(self, exc: Exception, fail_times: int) -> None:
+        self._exc = exc
+        self._fail = fail_times
+        self.calls = 0
+
+    async def async_get_device_location(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        self.calls += 1
+        if self.calls <= self._fail:
+            raise self._exc
+        return {}  # success with no decryptable report (still clears the counter)
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_decrypt_counter_resets_on_success() -> None:
+    """A successful poll cycle clears the consecutive-decrypt-failure counter, so a
+    recovered shared key (or self-heal) does not later trip a spurious reauth."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptThenSucceedAPI(
+        SharedKeyMismatchError("transient stale"), fail_times=_MAX_DECRYPT_FAILURES - 1
+    )
+
+    # Below-threshold failing cycles raise no reauth and accumulate the counter.
+    for _ in range(_MAX_DECRYPT_FAILURES - 1):
+        await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    assert coordinator._consecutive_decrypt_failures == _MAX_DECRYPT_FAILURES - 1
+
+    # A successful cycle resets the counter back to zero.
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    assert coordinator._consecutive_decrypt_failures == 0
+
+
+class _PerDeviceDecryptAPI:
+    """Raises a decryption error for one device id, succeeds (empty) for others."""
+
+    def __init__(self, exc: Exception, failing_id: str) -> None:
+        self._exc = exc
+        self._failing = failing_id
+
+    async def async_get_device_location(
+        self, device_id: str, _device_name: str, *_args: Any, **_kwargs: Any
+    ) -> dict[str, Any]:
+        if device_id == self._failing:
+            raise self._exc
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_partial_decrypt_failure_still_escalates() -> None:
+    """Multi-device: one tracker decrypts fine while another keeps failing with a
+    stale account-wide shared key. A per-device reset would null the counter every
+    cycle (one healthy tracker masking the others) and never escalate; the
+    cycle-gated reset preserves the count so escalation still fires after the
+    threshold. Regression guard for the independent-review finding."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _PerDeviceDecryptAPI(
+        SharedKeyMismatchError("stale shared key"), failing_id="bad"
+    )
+    auth_calls: list[dict[str, Any]] = []
+    coordinator._set_auth_state = lambda **kwargs: auth_calls.append(kwargs)
+    devices = [{"id": "good", "name": "Good"}, {"id": "bad", "name": "Bad"}]
+
+    for _ in range(_MAX_DECRYPT_FAILURES - 1):
+        await coordinator._async_start_poll_cycle(devices)
+    # The healthy device must NOT have reset the account-wide counter.
+    assert coordinator._consecutive_decrypt_failures == _MAX_DECRYPT_FAILURES - 1
+
+    coordinator.config_entry.async_start_reauth = MagicMock()
+    await coordinator._async_start_poll_cycle(devices)
+    coordinator.config_entry.async_start_reauth.assert_called_once_with(coordinator.hass)
+    assert any(kw.get("failed") for kw in auth_calls)
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_counts_multi_device_decrypt_failure_once() -> None:
+    """Codex P2 regression: one poll cycle in which several trackers all hit the
+    same account-wide stale shared key must advance the consecutive-failure counter
+    exactly ONCE, not once per device.
+
+    Counting per device let a multi-device account cross _MAX_DECRYPT_FAILURES
+    within the first cycle and escalate to reauth immediately, defeating the
+    documented "N consecutive cycles" budget that gives the in-decrypt self-heal a
+    few cycles before re-authentication."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptFailAPI(SharedKeyMismatchError("stale shared key"))
+    auth_calls: list[dict[str, Any]] = []
+    coordinator._set_auth_state = lambda **kwargs: auth_calls.append(kwargs)
+    # More failing trackers in a single cycle than the escalation threshold: a
+    # per-device counter would already escalate here.
+    devices = [
+        {"id": "dev-1", "name": "One"},
+        {"id": "dev-2", "name": "Two"},
+        {"id": "dev-3", "name": "Three"},
+    ]
+    assert len(devices) >= _MAX_DECRYPT_FAILURES
+
+    # First cycle: counter advances by one, no escalation despite 3 failing devices.
+    await coordinator._async_start_poll_cycle(devices)
+    assert coordinator._consecutive_decrypt_failures == 1
+    assert not any(kw.get("failed") for kw in auth_calls)
+
+    # Second cycle: still below threshold (2/3).
+    await coordinator._async_start_poll_cycle(devices)
+    assert coordinator._consecutive_decrypt_failures == _MAX_DECRYPT_FAILURES - 1
+    assert not any(kw.get("failed") for kw in auth_calls)
+
+    # Third consecutive cycle reaches the threshold -> escalate exactly once.
+    coordinator.config_entry.async_start_reauth = MagicMock()
+    await coordinator._async_start_poll_cycle(devices)
+    coordinator.config_entry.async_start_reauth.assert_called_once_with(coordinator.hass)
+    assert any(kw.get("failed") for kw in auth_calls)
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_nova_permanent_auth_starts_reauth() -> None:
+    """A permanent Nova auth failure in the background poll cycle starts the entry
+    reauth flow directly. The cycle runs as a fire-and-forget task
+    (``hass.async_create_task``), so a raised ConfigEntryAuthFailed would never reach
+    the awaited coordinator refresh and HA's automatic reauth would never fire."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptFailAPI(NovaAuthPermanentError(401, "perm"))
+    auth_calls: list[dict[str, Any]] = []
+    coordinator._set_auth_state = lambda **kwargs: auth_calls.append(kwargs)
+    coordinator.config_entry.async_start_reauth = MagicMock()
+
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+
+    coordinator.config_entry.async_start_reauth.assert_called_once_with(coordinator.hass)
+    assert any(kw.get("failed") for kw in auth_calls)
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_transient_nova_auth_starts_reauth_after_threshold() -> None:
+    """A transient Nova auth failure escalates only after
+    _MAX_TRANSIENT_AUTH_FAILURES consecutive cycles, then starts the entry reauth
+    flow directly (the fire-and-forget poll task cannot raise into HA)."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptFailAPI(NovaAuthError(401, "transient"))
+    coordinator.config_entry.async_start_reauth = MagicMock()
+
+    # Below threshold: keep polling, no reauth escalation yet.
+    for _ in range(_MAX_TRANSIENT_AUTH_FAILURES - 1):
+        await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    coordinator.config_entry.async_start_reauth.assert_not_called()
+
+    # Threshold cycle escalates exactly once.
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    coordinator.config_entry.async_start_reauth.assert_called_once_with(coordinator.hass)
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_reauth_noop_without_config_entry() -> None:
+    """Defensive guard: with no config entry bound the poll cycle cannot start
+    reauth, but it must not crash (``_request_poll_reauth`` no-entry branch)."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptFailAPI(SharedKeyMismatchError("stale shared key"))
+    auth_calls: list[dict[str, Any]] = []
+    coordinator._set_auth_state = lambda **kwargs: auth_calls.append(kwargs)
+    coordinator.config_entry = None
+
+    # Drive to the escalation threshold; the helper hits its no-entry guard.
+    for _ in range(_MAX_DECRYPT_FAILURES):
+        await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+
+    # No crash, and the auth state was still flagged at the threshold cycle.
+    assert any(kw.get("failed") for kw in auth_calls)
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_direct_config_entry_auth_failed_starts_reauth() -> None:
+    """A ConfigEntryAuthFailed raised directly by the API (e.g. HTTP 401/403 in
+    async_get_device_location) reaches the poll loop's ConfigEntryAuthFailed handler
+    without passing through the typed SpotAuth/NovaAuth handlers. It must start the
+    entry reauth flow directly rather than re-raising into the fire-and-forget poll
+    task, where the exception would never reach HA."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptFailAPI(ConfigEntryAuthFailed("session expired"))
+    auth_calls: list[dict[str, Any]] = []
+    coordinator._set_auth_state = lambda **kwargs: auth_calls.append(kwargs)
+    coordinator.config_entry.async_start_reauth = MagicMock()
+
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+
+    coordinator.config_entry.async_start_reauth.assert_called_once_with(coordinator.hass)
+    assert any(kw.get("failed") for kw in auth_calls)

--- a/tests/test_coordinator_timeout.py
+++ b/tests/test_coordinator_timeout.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import time
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from homeassistant.config_entries import ConfigEntryAuthFailed
@@ -147,7 +147,11 @@ def test_poll_auth_failure_raises_auth_failed(monkeypatch: pytest.MonkeyPatch) -
 
     coordinator = GoogleFindMyCoordinator(hass, cache=_DummyCache())
     coordinator.config_entry = SimpleNamespace(
-        entry_id="entry-id", options={}, data={}, title="Test Entry"
+        entry_id="entry-id",
+        options={},
+        data={},
+        title="Test Entry",
+        async_start_reauth=Mock(),
     )
     coordinator.api = _AuthFailureAPI()
     coordinator._get_google_home_filter = lambda: None
@@ -171,16 +175,20 @@ def test_poll_auth_failure_raises_auth_failed(monkeypatch: pytest.MonkeyPatch) -
     coordinator.async_set_update_error = _set_update_error
     coordinator.async_set_updated_data = _set_updated_data
 
-    with pytest.raises(ConfigEntryAuthFailed):
-        try:
-            loop.run_until_complete(
-                coordinator._async_start_poll_cycle(
-                    [{"id": "dev-1", "name": "Device"}], force=True
-                )
+    # The poll cycle runs as a fire-and-forget task, so it starts the entry reauth
+    # flow directly rather than raising (a raised ConfigEntryAuthFailed would never
+    # reach the awaited coordinator refresh). It still records last_exception so the
+    # finally block marks the update failed.
+    try:
+        loop.run_until_complete(
+            coordinator._async_start_poll_cycle(
+                [{"id": "dev-1", "name": "Device"}], force=True
             )
-        finally:
-            drain_loop(loop)
+        )
+    finally:
+        drain_loop(loop)
 
+    coordinator.config_entry.async_start_reauth.assert_called_once_with(coordinator.hass)
     assert coordinator.last_update_success is False
     assert isinstance(coordinator.last_exception, ConfigEntryAuthFailed)
 

--- a/tests/test_decrypt_locations.py
+++ b/tests/test_decrypt_locations.py
@@ -7,6 +7,7 @@ import asyncio
 import logging
 
 import pytest
+from cryptography.exceptions import InvalidTag
 
 from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker import (
     decrypt_locations,
@@ -396,3 +397,277 @@ async def test_pair_date_microseconds_normalization_and_future_rejection(
     )
 
     assert future_pair_date is None
+
+
+# ---------------------------------------------------------------------------
+# Diff-Review #1 (Variant C): own-report exhaustion escalates to DecryptionError,
+# while foreign-only failures and report-less devices never escalate.
+# ---------------------------------------------------------------------------
+
+
+def _valid_location_bytes() -> bytes:
+    """Serialize a small, in-bounds Location proto for a successful decrypt."""
+
+    loc = DeviceUpdate_pb2.Location()
+    loc.latitude = int(48.0 * 1e7)
+    loc.longitude = int(11.0 * 1e7)
+    loc.altitude = ALTITUDE_METERS
+    return loc.SerializeToString()
+
+
+def _add_report(
+    update: DeviceUpdate_pb2.DeviceUpdate,
+    *,
+    public_key_random: bytes,
+    encrypted_location: bytes,
+    is_own_report: bool,
+    base_now: float,
+) -> None:
+    """Append one encrypted report; empty public_key_random marks an own report."""
+
+    reports = (
+        update.deviceMetadata.information.locationInformation.reports.recentLocationAndNetworkLocations
+    )
+    network_location = reports.networkLocations.add()
+    network_location.status = Common_pb2.Status.LAST_KNOWN
+    network_location.geoLocation.accuracy = ACCURACY_METERS
+    enc = network_location.geoLocation.encryptedReport
+    enc.publicKeyRandom = public_key_random
+    enc.encryptedLocation = encrypted_location
+    enc.isOwnReport = is_own_report
+    # A matching timestamp is required, otherwise the report is dropped before
+    # the decrypt attempt (zip_longest pads missing timestamps with None).
+    reports.networkLocationTimestamps.add().seconds = int(base_now - 10)
+
+
+async def test_all_own_reports_failing_auth_raises_decryption_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T-D1: every own report fails authentication → escalate via DecryptionError.
+
+    This is the account-wide stale-key signal: the cached identity key no longer
+    matches the server's own reports, so the function must raise instead of
+    silently returning empty (which the coordinator would never escalate).
+    """
+
+    base_now = 1_700_000_000.0
+    monkeypatch.setattr(decrypt_locations.time, "time", lambda: base_now)
+
+    async def fake_identity_key(*_args: object, **_kwargs: object) -> list[bytes]:
+        return [b"\x42" * 32]
+
+    async def fake_offload_aes(*_args: object, **_kwargs: object) -> bytes:
+        raise InvalidTag
+
+    monkeypatch.setattr(
+        decrypt_locations, "async_retrieve_identity_key", fake_identity_key
+    )
+    monkeypatch.setattr(decrypt_locations, "_offload_decrypt_aes", fake_offload_aes)
+
+    update = DeviceUpdate_pb2.DeviceUpdate()
+    update.deviceMetadata.information.deviceRegistration.SetInParent()
+    _add_report(
+        update,
+        public_key_random=b"",
+        encrypted_location=b"own-ciphertext",
+        is_own_report=True,
+        base_now=base_now,
+    )
+
+    with pytest.raises(decrypt_locations.DecryptionError):
+        await decrypt_locations.async_decrypt_location_response_locations(
+            update, cache=object()
+        )
+
+
+async def test_foreign_failures_with_own_success_do_not_escalate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T-D2: own report succeeds, foreign reports fail → no escalation.
+
+    Foreign/crowdsourced reports legitimately fail with another account's key.
+    A single own-report success proves the key is healthy, so they must not
+    raise an account-wide DecryptionError (regression guard for Befund #2/#4).
+    """
+
+    base_now = 1_700_000_500.0
+    monkeypatch.setattr(decrypt_locations.time, "time", lambda: base_now)
+    monkeypatch.setattr(decrypt_locations, "is_mcu_tracker", lambda *_a: False)
+
+    async def fake_identity_key(*_args: object, **_kwargs: object) -> list[bytes]:
+        return [b"\x42" * 32]
+
+    async def fake_offload_aes(*_args: object, **_kwargs: object) -> bytes:
+        return _valid_location_bytes()
+
+    async def fake_offload_foreign(*_args: object, **_kwargs: object) -> bytes:
+        raise ValueError("MAC check failed")
+
+    monkeypatch.setattr(
+        decrypt_locations, "async_retrieve_identity_key", fake_identity_key
+    )
+    monkeypatch.setattr(decrypt_locations, "_offload_decrypt_aes", fake_offload_aes)
+    monkeypatch.setattr(
+        decrypt_locations, "_offload_decrypt_foreign", fake_offload_foreign
+    )
+
+    update = DeviceUpdate_pb2.DeviceUpdate()
+    update.deviceMetadata.information.deviceRegistration.SetInParent()
+    _add_report(
+        update,
+        public_key_random=b"",
+        encrypted_location=b"own-ok",
+        is_own_report=True,
+        base_now=base_now,
+    )
+    _add_report(
+        update,
+        public_key_random=b"\x10\x11\x12\x13",
+        encrypted_location=b"foreign-bad",
+        is_own_report=False,
+        base_now=base_now,
+    )
+
+    result = await decrypt_locations.async_decrypt_location_response_locations(
+        update, cache=object()
+    )
+
+    # Own report decoded; no exception despite the foreign auth failure.
+    assert any(entry.get("metadata_only") is not True for entry in result)
+
+
+async def test_foreign_only_failure_does_not_escalate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T-D3: device with no own reports → never escalate, even if foreign fails.
+
+    With ``_own_encrypted_report_count == 0`` the own-exhaustion gate is closed,
+    so a failing foreign-only report returns gracefully instead of raising.
+    """
+
+    base_now = 1_700_001_000.0
+    monkeypatch.setattr(decrypt_locations.time, "time", lambda: base_now)
+    monkeypatch.setattr(decrypt_locations, "is_mcu_tracker", lambda *_a: False)
+
+    async def fake_identity_key(*_args: object, **_kwargs: object) -> list[bytes]:
+        return [b"\x42" * 32]
+
+    async def fake_offload_foreign(*_args: object, **_kwargs: object) -> bytes:
+        raise ValueError("MAC check failed")
+
+    monkeypatch.setattr(
+        decrypt_locations, "async_retrieve_identity_key", fake_identity_key
+    )
+    monkeypatch.setattr(
+        decrypt_locations, "_offload_decrypt_foreign", fake_offload_foreign
+    )
+
+    update = DeviceUpdate_pb2.DeviceUpdate()
+    update.deviceMetadata.information.deviceRegistration.SetInParent()
+    _add_report(
+        update,
+        public_key_random=b"\x20\x21\x22\x23",
+        encrypted_location=b"foreign-bad",
+        is_own_report=False,
+        base_now=base_now,
+    )
+
+    # Must not raise: no own reports means no account-wide signal.
+    result = await decrypt_locations.async_decrypt_location_response_locations(
+        update, cache=object()
+    )
+    assert isinstance(result, list)
+
+
+async def test_partial_own_success_self_heals_without_escalation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T-D4: one own report fails but another succeeds → no escalation.
+
+    A single own-report success means the key still works, so a transient
+    per-report failure must self-heal rather than escalate.
+    """
+
+    base_now = 1_700_001_500.0
+    monkeypatch.setattr(decrypt_locations.time, "time", lambda: base_now)
+
+    calls = {"n": 0}
+
+    async def fake_identity_key(*_args: object, **_kwargs: object) -> list[bytes]:
+        return [b"\x42" * 32]
+
+    async def fake_offload_aes(*_args: object, **_kwargs: object) -> bytes:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise InvalidTag
+        return _valid_location_bytes()
+
+    monkeypatch.setattr(
+        decrypt_locations, "async_retrieve_identity_key", fake_identity_key
+    )
+    monkeypatch.setattr(decrypt_locations, "_offload_decrypt_aes", fake_offload_aes)
+
+    update = DeviceUpdate_pb2.DeviceUpdate()
+    update.deviceMetadata.information.deviceRegistration.SetInParent()
+    _add_report(
+        update,
+        public_key_random=b"",
+        encrypted_location=b"own-bad",
+        is_own_report=True,
+        base_now=base_now,
+    )
+    _add_report(
+        update,
+        public_key_random=b"",
+        encrypted_location=b"own-ok",
+        is_own_report=True,
+        base_now=base_now,
+    )
+
+    result = await decrypt_locations.async_decrypt_location_response_locations(
+        update, cache=object()
+    )
+
+    # The successful own report suppresses escalation entirely.
+    assert any(entry.get("metadata_only") is not True for entry in result)
+
+
+async def test_own_report_mac_valueerror_counts_as_own_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T-D5: an own-report MAC ValueError counts as an own failure and escalates.
+
+    Own reports use AES-GCM (which raises InvalidTag), but the MAC-ValueError
+    handler is mirrored defensively for any future own-report path that surfaces
+    a PyCryptodome-style ``ValueError("MAC check failed")``. This guards that the
+    defensive symmetry still feeds the own-only escalation counter.
+    """
+
+    base_now = 1_700_002_000.0
+    monkeypatch.setattr(decrypt_locations.time, "time", lambda: base_now)
+
+    async def fake_identity_key(*_args: object, **_kwargs: object) -> list[bytes]:
+        return [b"\x42" * 32]
+
+    async def fake_offload_aes(*_args: object, **_kwargs: object) -> bytes:
+        raise ValueError("MAC check failed")
+
+    monkeypatch.setattr(
+        decrypt_locations, "async_retrieve_identity_key", fake_identity_key
+    )
+    monkeypatch.setattr(decrypt_locations, "_offload_decrypt_aes", fake_offload_aes)
+
+    update = DeviceUpdate_pb2.DeviceUpdate()
+    update.deviceMetadata.information.deviceRegistration.SetInParent()
+    _add_report(
+        update,
+        public_key_random=b"",
+        encrypted_location=b"own-mac-fail",
+        is_own_report=True,
+        base_now=base_now,
+    )
+
+    with pytest.raises(decrypt_locations.DecryptionError):
+        await decrypt_locations.async_decrypt_location_response_locations(
+            update, cache=object()
+        )

--- a/tests/test_decrypt_locations.py
+++ b/tests/test_decrypt_locations.py
@@ -671,3 +671,80 @@ async def test_own_report_mac_valueerror_counts_as_own_failure(
         await decrypt_locations.async_decrypt_location_response_locations(
             update, cache=object()
         )
+
+
+@pytest.mark.parametrize(
+    ("record", "expected"),
+    [
+        # Authenticated coordinate report -> positive proof of the shared key.
+        ({"last_seen": 123.0, "latitude": 1.0, "longitude": 2.0}, True),
+        # Coordinates win regardless of an explicit metadata_only=False flag.
+        ({"latitude": 1.0, "longitude": 2.0, "metadata_only": False}, True),
+        # 0.0 coordinates are valid (is-None check, not truthiness).
+        ({"latitude": 0.0, "longitude": 0.0}, True),
+        # SEMANTIC-shaped row: last_seen + semantic_name but no coordinates and no
+        # metadata_only flag -> skipped the crypto path, so it proves nothing.
+        (
+            {
+                "last_seen": 123.0,
+                "semantic_name": "Home",
+                "status": "semantic",
+                "latitude": None,
+                "longitude": None,
+            },
+            False,
+        ),
+        # Partial coordinates (only one axis) -> not an authenticated fix.
+        ({"latitude": 1.0, "longitude": None}, False),
+        # metadata_only sentinel -> secrets-bundle key material, no decrypt.
+        ({"metadata_only": True, "owner_key_version": 7}, False),
+        ({}, False),
+        (None, False),
+    ],
+)
+async def test_is_real_location_record(record: object, expected: bool) -> None:
+    """Only an authenticated coordinate report proves the shared key.
+
+    Decrypted coordinates are produced solely by the authenticated crypto path, so
+    requiring a real ``latitude``/``longitude`` pair is an allowlist for genuine
+    reports. Truthy-but-unauthenticated shapes -- ``metadata_only=True`` sentinels
+    and SEMANTIC rows (no coordinates, crypto path skipped) -- must return False, or
+    they would clear the shared decrypt-failure budget and mask a stale key.
+    """
+    assert decrypt_locations.is_real_location_record(record) is expected
+
+
+@pytest.mark.parametrize(
+    ("records", "expected"),
+    [
+        # Empty / falsy inputs -> no proof.
+        (None, False),
+        ([], False),
+        # Only report-less rows -> no record authenticates a coordinate report.
+        (
+            [
+                {"metadata_only": True, "owner_key_version": 7},
+                {"last_seen": 9.0, "semantic_name": "Home", "latitude": None},
+            ],
+            False,
+        ),
+        # A real coordinate report anywhere in the list proves the shared key,
+        # even when a report-less SEMANTIC row would outrank it in the selector.
+        (
+            [
+                {"last_seen": 5.0, "latitude": 1.0, "longitude": 2.0},
+                {"last_seen": 9.0, "semantic_name": "Home", "latitude": None},
+            ],
+            True,
+        ),
+    ],
+)
+async def test_any_real_location_record(records: object, expected: bool) -> None:
+    """The decrypt proof is a full-list property, not a single-record property.
+
+    ``any_real_location_record`` must return True when ANY record authenticates a
+    coordinate report, so a successfully decrypted fix hidden behind a newer
+    report-less SEMANTIC/metadata row is never lost. Empty inputs and lists of only
+    report-less rows must return False so they cannot clear the reauth budget.
+    """
+    assert decrypt_locations.any_real_location_record(records) is expected

--- a/tests/test_decrypt_locations_crypto.py
+++ b/tests/test_decrypt_locations_crypto.py
@@ -1,0 +1,89 @@
+# tests/test_decrypt_locations_crypto.py
+"""Audit coverage for the local AES-GCM envelope unwrap primitive.
+
+``decrypt_locations`` is dominated by network/cache orchestration and protobuf
+parsing; the only self-contained cryptographic primitive in the module is
+``_try_unwrap_aesgcm_envelope`` (the M1-Nonce audit point: nonce is the envelope
+prefix, the AAD is the device id, and any authentication failure must fail
+closed to ``None``). These tests drive that primitive against an independent
+AES-GCM oracle so a regression flips an assertion rather than passing silently.
+"""
+
+from __future__ import annotations
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    _AESGCM_NONCE_LEN,
+    _try_unwrap_aesgcm_envelope,
+)
+
+_KEY = bytes(range(32))
+_NONCE = bytes(range(_AESGCM_NONCE_LEN))
+_PLAINTEXT = b"identity-key-material-32-bytes!!"
+_DEVICE_ID = "device-canonic-id-42"
+
+
+def _seal(key: bytes, nonce: bytes, plaintext: bytes, device_id: str) -> bytes:
+    """Build an AES-GCM envelope (nonce || ciphertext) with device_id as AAD."""
+
+    ciphertext = AESGCM(key).encrypt(nonce, plaintext, device_id.encode())
+    return nonce + ciphertext
+
+
+def test_unwrap_roundtrip_with_matching_aad_returns_plaintext() -> None:
+    """A well-formed envelope with the correct key and AAD decrypts to plaintext."""
+
+    envelope = _seal(_KEY, _NONCE, _PLAINTEXT, _DEVICE_ID)
+    assert _try_unwrap_aesgcm_envelope(envelope, _KEY, _DEVICE_ID) == _PLAINTEXT
+
+
+def test_unwrap_nonce_is_envelope_prefix() -> None:
+    """The primitive must split nonce/ciphertext at _AESGCM_NONCE_LEN, not elsewhere.
+
+    Sealing with a distinct nonce and re-prefixing it proves the prefix is the
+    nonce actually fed to AES-GCM: shifting the split point would break the tag.
+    """
+
+    nonce = bytes([0xA5] * _AESGCM_NONCE_LEN)
+    envelope = _seal(_KEY, nonce, _PLAINTEXT, _DEVICE_ID)
+    assert envelope[:_AESGCM_NONCE_LEN] == nonce
+    assert _try_unwrap_aesgcm_envelope(envelope, _KEY, _DEVICE_ID) == _PLAINTEXT
+
+
+def test_unwrap_wrong_device_id_fails_closed() -> None:
+    """A mismatched AAD (device_id) must fail closed to None, never plaintext."""
+
+    envelope = _seal(_KEY, _NONCE, _PLAINTEXT, _DEVICE_ID)
+    assert _try_unwrap_aesgcm_envelope(envelope, _KEY, "other-device-id") is None
+
+
+def test_unwrap_wrong_key_fails_closed() -> None:
+    """A wrong wrapping key must fail closed to None."""
+
+    envelope = _seal(_KEY, _NONCE, _PLAINTEXT, _DEVICE_ID)
+    wrong_key = bytes([0xFF]) + _KEY[1:]
+    assert _try_unwrap_aesgcm_envelope(envelope, wrong_key, _DEVICE_ID) is None
+
+
+def test_unwrap_tampered_ciphertext_fails_closed() -> None:
+    """Flipping a ciphertext byte must fail the GCM tag check and return None."""
+
+    envelope = bytearray(_seal(_KEY, _NONCE, _PLAINTEXT, _DEVICE_ID))
+    envelope[-1] ^= 0x01
+    assert _try_unwrap_aesgcm_envelope(bytes(envelope), _KEY, _DEVICE_ID) is None
+
+
+def test_unwrap_none_device_id_is_guarded() -> None:
+    """Without a device_id there is no AAD to bind, so the primitive declines."""
+
+    envelope = _seal(_KEY, _NONCE, _PLAINTEXT, _DEVICE_ID)
+    assert _try_unwrap_aesgcm_envelope(envelope, _KEY, None) is None
+
+
+def test_unwrap_envelope_too_short_is_guarded() -> None:
+    """An envelope no longer than the nonce cannot carry ciphertext and is declined."""
+
+    too_short = bytes(_AESGCM_NONCE_LEN)  # exactly nonce length, no ciphertext
+    assert _try_unwrap_aesgcm_envelope(too_short, _KEY, _DEVICE_ID) is None
+    assert _try_unwrap_aesgcm_envelope(b"", _KEY, _DEVICE_ID) is None

--- a/tests/test_decrypt_owner_key_discriminator.py
+++ b/tests/test_decrypt_owner_key_discriminator.py
@@ -1,0 +1,104 @@
+# tests/test_decrypt_owner_key_discriminator.py
+"""Discriminator for stale-vs-missing shared key in owner-key decryption.
+
+When ``async_get_owner_key`` fails, the root cause (wrong shared key vs. missing
+shared key vs. generic failure) is otherwise collapsed into a single opaque
+message. These tests pin ``_classify_owner_key_failure``, which restores the
+discriminator as a typed ``DecryptionError`` subclass, and the Liskov property
+that keeps every existing ``except DecryptionError`` handler working.
+"""
+
+from __future__ import annotations
+
+import pytest
+from cryptography.exceptions import InvalidTag
+
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker import (
+    decrypt_locations as _dl,
+)
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    DecryptionError,
+    SharedKeyMismatchError,
+    SharedKeyMissingError,
+    StaleOwnerKeyError,
+    _classify_owner_key_failure,
+)
+from custom_components.googlefindmy.ProtoDecoders import DeviceUpdate_pb2
+
+
+def test_liskov_subclasses_are_decryption_errors() -> None:
+    """All specific shared-key errors stay DecryptionError subclasses so existing
+    ``except DecryptionError`` handlers keep catching them (no silent breakage)."""
+    assert issubclass(SharedKeyMismatchError, DecryptionError)
+    assert issubclass(SharedKeyMissingError, DecryptionError)
+    assert issubclass(StaleOwnerKeyError, DecryptionError)
+
+
+def test_t2_invalid_tag_maps_to_shared_key_mismatch() -> None:
+    """InvalidTag (AES-GCM auth failure) => wrong/stale shared key."""
+    result = _classify_owner_key_failure(InvalidTag(), context="initial lookup")
+    assert isinstance(result, SharedKeyMismatchError)
+    assert "InvalidTag" in str(result)
+    assert "initial lookup" in str(result)
+
+
+def test_t2_missing_runtime_maps_to_shared_key_missing() -> None:
+    """RuntimeError mentioning 'missing or empty' => incomplete bundle."""
+    exc = RuntimeError("Shared key is missing or empty; cannot decrypt owner key")
+    result = _classify_owner_key_failure(exc, context="initial lookup")
+    assert isinstance(result, SharedKeyMissingError)
+
+
+def test_t2_generic_runtime_maps_to_plain_decryption_error() -> None:
+    """Any other RuntimeError => generic DecryptionError (still escalates, but is
+    not mis-labelled as a specific shared-key cause)."""
+    result = _classify_owner_key_failure(RuntimeError("boom"), context="x")
+    assert type(result) is DecryptionError
+
+
+@pytest.mark.asyncio
+async def test_owner_key_invalid_tag_propagates_as_shared_key_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Integration: an InvalidTag from the owner-key lookup surfaces from
+    async_retrieve_identity_key as SharedKeyMismatchError (the path that used to
+    collapse into an opaque, swallowed DecryptionError)."""
+
+    async def _boom(**_kwargs: object) -> object:
+        raise InvalidTag()
+
+    monkeypatch.setattr(_dl, "async_get_owner_key", _boom)
+
+    update = DeviceUpdate_pb2.DeviceUpdate()
+    registration = update.deviceMetadata.information.deviceRegistration
+    registration.encryptedUserSecrets.encryptedIdentityKey = b"\x00" * 60
+
+    with pytest.raises(SharedKeyMismatchError):
+        await _dl.async_retrieve_identity_key(registration, cache=object())
+
+
+@pytest.mark.asyncio
+async def test_owner_key_forced_refresh_invalid_tag_maps_to_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Integration: when a newer owner-key version triggers a forced refresh and
+    that refresh also fails with InvalidTag, the failure still surfaces as
+    SharedKeyMismatchError (the forced-refresh wrap path)."""
+    from custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices.get_owner_key import (
+        OwnerKeyInfo,
+    )
+
+    async def _owner(*, cache: object, force_refresh: bool = False, **_kw: object) -> object:
+        if force_refresh:
+            raise InvalidTag()
+        return OwnerKeyInfo(key=b"\x00" * 32, version=1)
+
+    monkeypatch.setattr(_dl, "async_get_owner_key", _owner)
+
+    update = DeviceUpdate_pb2.DeviceUpdate()
+    registration = update.deviceMetadata.information.deviceRegistration
+    registration.encryptedUserSecrets.encryptedIdentityKey = b"\x00" * 60
+    registration.encryptedUserSecrets.ownerKeyVersion = 5  # > cached version 1
+
+    with pytest.raises(SharedKeyMismatchError):
+        await _dl.async_retrieve_identity_key(registration, cache=object())

--- a/tests/test_decrypt_owner_key_discriminator.py
+++ b/tests/test_decrypt_owner_key_discriminator.py
@@ -10,6 +10,8 @@ that keeps every existing ``except DecryptionError`` handler working.
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 from cryptography.exceptions import InvalidTag
 
@@ -75,6 +77,61 @@ async def test_owner_key_invalid_tag_propagates_as_shared_key_mismatch(
 
     with pytest.raises(SharedKeyMismatchError):
         await _dl.async_retrieve_identity_key(registration, cache=object())
+
+
+@pytest.mark.asyncio
+async def test_e2ee_metadata_diagnostic_failure_logs_at_debug_not_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The best-effort E2EE metadata fetch is a non-actionable diagnostic aid.
+
+    When it fails (e.g. transient network timeout or SSL teardown), the failure
+    is swallowed and the regular decrypt error path continues unaffected, so it
+    must be logged at DEBUG, not WARNING, to avoid user-facing log noise.
+    """
+    from custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices.get_owner_key import (
+        OwnerKeyInfo,
+    )
+
+    async def _owner_ok(
+        *, cache: object, force_refresh: bool = False, **_kw: object
+    ) -> object:
+        # Owner-key acquisition succeeds, so the flow reaches the decrypt attempt.
+        return OwnerKeyInfo(key=b"\x00" * 32, version=1)
+
+    async def _meta_boom(**_kwargs: object) -> object:
+        raise TimeoutError("Timeout after retries.")
+
+    monkeypatch.setattr(_dl, "async_get_owner_key", _owner_ok)
+    monkeypatch.setattr(_dl, "async_get_eid_info", _meta_boom)
+
+    update = DeviceUpdate_pb2.DeviceUpdate()
+    registration = update.deviceMetadata.information.deviceRegistration
+    # Garbage identity key: decryption fails, so the flow falls through to the
+    # best-effort metadata fetch (which we force to fail). ownerKeyVersion stays
+    # 0, so no forced refresh short-circuits the path beforehand.
+    registration.encryptedUserSecrets.encryptedIdentityKey = b"\x00" * 60
+
+    caplog.set_level(logging.DEBUG, logger=_dl.__name__)
+
+    # The decrypt itself still fails; the metadata fetch is only a diagnostic aside.
+    # _retry=False keeps the path deterministic (single, non-recursive emission;
+    # avoids the blind-refresh branch and its unrelated WARNING).
+    with pytest.raises(DecryptionError):
+        await _dl.async_retrieve_identity_key(
+            registration, cache=object(), _retry=False
+        )
+
+    diagnostic_records = [
+        record
+        for record in caplog.records
+        if "Failed to retrieve E2EE metadata for diagnostics" in record.getMessage()
+    ]
+    assert diagnostic_records, "expected the best-effort diagnostic log line to be emitted"
+    # Mutation-sharp: reverting debug -> warning flips levelno and fails this assertion.
+    assert all(record.levelno == logging.DEBUG for record in diagnostic_records)
+    assert not any(record.levelno == logging.WARNING for record in diagnostic_records)
 
 
 @pytest.mark.asyncio

--- a/tests/test_eid_generator_variants.py
+++ b/tests/test_eid_generator_variants.py
@@ -16,9 +16,20 @@ from custom_components.googlefindmy.FMDNCrypto.eid_generator import (
     MODERN_EID_LENGTH,
     P256_ORDER,
     ROTATION_PERIOD,
+    ROTATION_PERIOD_900,
+    ROTATION_PERIOD_3600,
     EidVariant,
+    HeuristicBasis,
+    HeuristicEidResult,
+    _align_to_rotation_flexible,
+    _compute_heuristic_counter,
+    _generate_heuristic_eid_single,
+    build_heuristic_prf_input,
     build_table10_prf_input,
+    compute_flags_xor_mask,
+    generate_eid,
     generate_eid_variant,
+    generate_heuristic_eid,
     get_masked_counter,
     prf_aes_256_ecb,
 )
@@ -184,3 +195,353 @@ def test_strict_normalization_rejects_negative() -> None:
             EidVariant.LEGACY_SECP160R1_X20_BE,
             strict=True,
         )
+
+
+# =============================================================================
+# Audit coverage (AP10 Teil C): guards, flags mask, heuristic derivation.
+# Each test asserts behavior (independent recomputation for crypto paths), not
+# mere line execution, so a regression flips the assertion rather than silently
+# keeping coverage green.
+# =============================================================================
+
+
+def test_normalize_rejects_bool_and_non_int() -> None:
+    """The u32 counter must reject bool and non-int types (bool is not a counter)."""
+
+    with pytest.raises(TypeError, match="must be int"):
+        build_table10_prf_input(True, k=FHNA_K)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="must be int"):
+        build_table10_prf_input("0x10", k=FHNA_K)  # type: ignore[arg-type]
+
+
+def test_build_table10_rejects_wrong_rotation_exponent() -> None:
+    """Only FHNA_K is a valid rotation exponent; any other k must raise."""
+
+    with pytest.raises(ValueError, match="rotation exponent"):
+        build_table10_prf_input(SAMPLE_COUNTER, k=FHNA_K + 1)
+
+
+def test_build_table10_aligned_counter_skips_mask_log(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An already rotation-aligned counter must not trigger the masking debug log."""
+
+    aligned = 2 * ROTATION_PERIOD  # low K bits already zero
+    with caplog.at_level(logging.DEBUG):
+        block = build_table10_prf_input(aligned, k=FHNA_K)
+
+    assert len(block) == FHNA_PRF_INPUT_LENGTH
+    assert "masked to rotation-aligned" not in caplog.text
+
+
+def test_prf_rejects_wrong_key_length() -> None:
+    """The AES-256 PRF requires a 32-byte EIK."""
+
+    prf_input = build_table10_prf_input(SAMPLE_COUNTER, k=FHNA_K)
+    with pytest.raises(ValueError, match="Identity Key"):
+        prf_aes_256_ecb(SAMPLE_EIK[:16], prf_input)
+
+
+def test_prf_rejects_wrong_input_length() -> None:
+    """The PRF input buffer must be exactly the Table 10 length."""
+
+    with pytest.raises(ValueError, match="PRF input"):
+        prf_aes_256_ecb(SAMPLE_EIK, b"\x00" * (FHNA_PRF_INPUT_LENGTH - 1))
+
+
+def test_generate_variant_rejects_wrong_key_length() -> None:
+    """generate_eid_variant must reject a short EIK before any derivation."""
+
+    with pytest.raises(ValueError, match="Identity Key"):
+        generate_eid_variant(
+            SAMPLE_EIK[:8], SAMPLE_COUNTER, EidVariant.MODERN_P256_X32_BE
+        )
+
+
+def test_generate_variant_rejects_unknown_variant() -> None:
+    """An unsupported variant token must hit the explicit guard, not derive silently."""
+
+    with pytest.raises(ValueError, match="Unsupported EID variant"):
+        generate_eid_variant(SAMPLE_EIK, SAMPLE_COUNTER, "bogus_variant")  # type: ignore[arg-type]
+
+
+def test_get_masked_counter_rejects_wrong_rotation_exponent() -> None:
+    """get_masked_counter shares the FHNA_K precondition with the PRF builder."""
+
+    with pytest.raises(ValueError, match="rotation exponent"):
+        get_masked_counter(SAMPLE_COUNTER, FHNA_K + 2)
+
+
+def _independent_flags_mask(eik: bytes, counter: int, byte_len: int, order: int) -> int:
+    """Recompute the flags XOR mask from primitives, independently of the SUT."""
+
+    import hashlib
+
+    prf_input = build_table10_prf_input(counter, k=FHNA_K, strict=False)
+    r_dash = prf_aes_256_ecb(eik, prf_input)
+    r_int = int.from_bytes(r_dash, "big", signed=False)
+    r_scalar = r_int % order
+    r_bytes = r_scalar.to_bytes(byte_len, "big")
+    return hashlib.sha256(r_bytes).digest()[-1]
+
+
+def test_compute_flags_xor_mask_legacy_matches_recomputation() -> None:
+    """Legacy (secp160r1) flags mask must equal an independent primitive recomputation."""
+
+    legacy_order = int(load_curve().order)
+    expected = _independent_flags_mask(
+        SAMPLE_EIK, SAMPLE_COUNTER, LEGACY_EID_LENGTH, legacy_order
+    )
+    actual = compute_flags_xor_mask(SAMPLE_EIK, SAMPLE_COUNTER)
+
+    assert actual == expected
+    assert 0 <= actual <= 0xFF
+
+
+def test_compute_flags_xor_mask_p256_branch_uses_supplied_order() -> None:
+    """The P-256 branch must reduce mod P256_ORDER and pad to 32 bytes.
+
+    The independent recomputation (``expected``) is the real branch proof: if
+    the function ignored ``curve_byte_len``/``curve_order``, ``actual`` would
+    diverge from the P-256 oracle. The legacy comparison is an additional
+    collapse guard (a different order/padding must yield a different mask).
+    """
+
+    expected = _independent_flags_mask(
+        SAMPLE_EIK, SAMPLE_COUNTER, MODERN_EID_LENGTH, P256_ORDER
+    )
+    actual = compute_flags_xor_mask(
+        SAMPLE_EIK,
+        SAMPLE_COUNTER,
+        curve_byte_len=MODERN_EID_LENGTH,
+        curve_order=P256_ORDER,
+    )
+    legacy = compute_flags_xor_mask(SAMPLE_EIK, SAMPLE_COUNTER)
+
+    assert actual == expected
+    # Distinct curve order/padding must produce a distinct mask for these fixed
+    # inputs (legacy=213, p256=16): guards against a branch collapse that would
+    # ignore the supplied P-256 parameters.
+    assert actual != legacy
+
+
+def test_generate_eid_shim_warns_and_matches_variant() -> None:
+    """The deprecated generate_eid shim must warn and equal generate_eid_variant."""
+
+    with pytest.warns(DeprecationWarning, match="deprecated"):
+        shimmed = generate_eid(
+            SAMPLE_EIK, SAMPLE_COUNTER, variant=EidVariant.MODERN_P256_X32_BE
+        )
+
+    direct = generate_eid_variant(
+        SAMPLE_EIK, SAMPLE_COUNTER, EidVariant.MODERN_P256_X32_BE
+    )
+    assert shimmed == direct
+
+
+def test_align_flexible_rejects_nonpositive_period() -> None:
+    """Flexible alignment must reject non-positive rotation periods."""
+
+    with pytest.raises(ValueError, match="rotation_period must be positive"):
+        _align_to_rotation_flexible(1000, rotation_period=0)
+
+
+def test_align_flexible_floors_to_window_start() -> None:
+    """Flexible alignment floors a timestamp to the start of its rotation window."""
+
+    assert _align_to_rotation_flexible(1000, rotation_period=900) == 900
+    assert _align_to_rotation_flexible(1800, rotation_period=900) == 1800
+    assert _align_to_rotation_flexible(3601, rotation_period=3600) == 3600
+
+
+def test_heuristic_counter_absolute_uses_now() -> None:
+    """ABSOLUTE basis floors absolute now_unix and ignores any anchor."""
+
+    counter = _compute_heuristic_counter(
+        10_000, rotation_period=900, basis=HeuristicBasis.ABSOLUTE
+    )
+    assert counter == (10_000 // 900) * 900
+
+
+def test_heuristic_counter_relative_requires_anchor() -> None:
+    """RELATIVE basis without a valid anchor must raise."""
+
+    with pytest.raises(ValueError, match="RELATIVE basis requires"):
+        _compute_heuristic_counter(
+            10_000, rotation_period=900, basis=HeuristicBasis.RELATIVE, anchor=None
+        )
+    with pytest.raises(ValueError, match="RELATIVE basis requires"):
+        _compute_heuristic_counter(
+            10_000, rotation_period=900, basis=HeuristicBasis.RELATIVE, anchor=0
+        )
+
+
+def test_heuristic_counter_relative_clamps_negative_elapsed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A now_unix before the anchor clamps elapsed to 0 (counter 0), with a debug log."""
+
+    with caplog.at_level(logging.DEBUG):
+        counter = _compute_heuristic_counter(
+            500,
+            rotation_period=900,
+            basis=HeuristicBasis.RELATIVE,
+            anchor=1000,
+        )
+    assert counter == 0
+    assert "Negative elapsed time" in caplog.text
+
+
+def test_heuristic_counter_relative_valid_elapsed() -> None:
+    """RELATIVE basis floors (now - anchor) to the rotation window."""
+
+    counter = _compute_heuristic_counter(
+        5000,
+        rotation_period=900,
+        basis=HeuristicBasis.RELATIVE,
+        anchor=1000,
+    )
+    assert counter == ((5000 - 1000) // 900) * 900
+
+
+def test_build_heuristic_prf_input_effective_k_per_period() -> None:
+    """The effective-k marker byte must reflect the rotation period branch."""
+
+    counter = 2 * ROTATION_PERIOD
+    counter_bytes = (counter & FHNA_COUNTER_MASK).to_bytes(4, "big")
+
+    cases = {
+        ROTATION_PERIOD_900: 9,
+        ROTATION_PERIOD_3600: 12,
+        ROTATION_PERIOD: FHNA_K,
+        500: FHNA_K,  # non-standard period falls through to the FHNA_K default
+    }
+    for period, expected_k in cases.items():
+        block = build_heuristic_prf_input(counter, rotation_period=period)
+        assert len(block) == FHNA_PRF_INPUT_LENGTH
+        assert block[0:11] == b"\xff" * 11
+        assert block[11] == expected_k
+        assert block[12:16] == counter_bytes
+        assert block[16:27] == b"\x00" * 11
+        assert block[27] == expected_k
+        assert block[28:32] == counter_bytes
+
+
+def test_heuristic_single_rejects_wrong_key_length() -> None:
+    """The single-EID heuristic helper must reject a short EIK."""
+
+    with pytest.raises(ValueError, match="Identity Key"):
+        _generate_heuristic_eid_single(
+            SAMPLE_EIK[:4], 0, EidVariant.MODERN_P256_X32_BE
+        )
+
+
+def test_heuristic_single_rejects_unknown_variant() -> None:
+    """An unsupported variant reaches the explicit guard in the heuristic helper."""
+
+    with pytest.raises(ValueError, match="Unsupported EID variant"):
+        _generate_heuristic_eid_single(SAMPLE_EIK, 0, "bogus_variant")  # type: ignore[arg-type]
+
+
+def test_heuristic_single_all_variants_have_expected_lengths() -> None:
+    """Each variant emits a deterministic EID with the documented byte length."""
+
+    counter = 3 * ROTATION_PERIOD
+    for variant in EidVariant:
+        first = _generate_heuristic_eid_single(SAMPLE_EIK, counter, variant)
+        second = _generate_heuristic_eid_single(SAMPLE_EIK, counter, variant)
+        assert first == second  # deterministic
+        if variant in (
+            EidVariant.LEGACY_SECP160R1_X20_BE,
+            EidVariant.MODERN_P256_X20_TRUNC_BE,
+            EidVariant.MODERN_P256_X20_TRUNC_LE,
+        ):
+            assert len(first) == LEGACY_EID_LENGTH
+        else:
+            assert len(first) == MODERN_EID_LENGTH
+
+
+def test_heuristic_single_legacy_matches_primitive_recomputation() -> None:
+    """The legacy heuristic EID equals R=r*G x-coordinate from an independent scalar."""
+
+    counter = 3 * ROTATION_PERIOD
+    prf_input = build_heuristic_prf_input(counter, rotation_period=ROTATION_PERIOD)
+    r_dash = prf_aes_256_ecb(SAMPLE_EIK, prf_input)
+    legacy_curve = load_curve()
+    order = int(legacy_curve.order)
+    scalar = int.from_bytes(r_dash, "big", signed=False) % order
+    expected_x = int((scalar * legacy_curve.generator).x())
+    expected = expected_x.to_bytes(LEGACY_EID_LENGTH, "big")
+
+    actual = _generate_heuristic_eid_single(
+        SAMPLE_EIK, counter, EidVariant.LEGACY_SECP160R1_X20_BE
+    )
+    assert actual == expected
+
+
+def test_generate_heuristic_eid_rejects_wrong_key_length() -> None:
+    """generate_heuristic_eid must reject a short EIK before any derivation."""
+
+    with pytest.raises(ValueError, match="Identity Key"):
+        generate_heuristic_eid(
+            SAMPLE_EIK[:2],
+            10_000,
+            rotation_period=900,
+            basis=HeuristicBasis.ABSOLUTE,
+            variant=EidVariant.MODERN_P256_X32_BE,
+        )
+
+
+def test_generate_heuristic_eid_emits_normal_and_reversed_per_drift() -> None:
+    """Each drift offset yields a normal result and its byte-reversed twin."""
+
+    results = generate_heuristic_eid(
+        SAMPLE_EIK,
+        100_000,
+        rotation_period=900,
+        basis=HeuristicBasis.ABSOLUTE,
+        variant=EidVariant.MODERN_P256_X32_BE,
+        drift_offsets=(-1, 0, 1),
+    )
+    assert len(results) == 6  # 3 drifts x {normal, reversed}
+    assert all(isinstance(r, HeuristicEidResult) for r in results)
+
+    normals = [r for r in results if not r.is_reversed]
+    reverseds = [r for r in results if r.is_reversed]
+    assert len(normals) == len(reverseds) == 3
+    for normal, reversed_ in zip(normals, reverseds, strict=True):
+        assert reversed_.eid_bytes == normal.eid_bytes[::-1]
+        assert normal.basis is HeuristicBasis.ABSOLUTE
+        assert normal.rotation_period == 900
+
+
+def test_generate_heuristic_eid_skips_negative_counter() -> None:
+    """Drift offsets that push the counter below zero are skipped (no result)."""
+
+    results = generate_heuristic_eid(
+        SAMPLE_EIK,
+        0,
+        rotation_period=900,
+        basis=HeuristicBasis.ABSOLUTE,
+        variant=EidVariant.MODERN_P256_X32_BE,
+        drift_offsets=(-1,),
+    )
+    assert results == []
+
+
+def test_generate_heuristic_eid_swallows_derivation_errors(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A per-drift derivation failure is logged and skipped, not propagated."""
+
+    with caplog.at_level(logging.DEBUG):
+        results = generate_heuristic_eid(
+            SAMPLE_EIK,
+            100_000,
+            rotation_period=900,
+            basis=HeuristicBasis.ABSOLUTE,
+            variant="bogus_variant",  # type: ignore[arg-type]
+            drift_offsets=(0,),
+        )
+    assert results == []
+    assert "Heuristic EID generation failed" in caplog.text

--- a/tests/test_encryption_key_status_sensor.py
+++ b/tests/test_encryption_key_status_sensor.py
@@ -1,0 +1,300 @@
+# tests/test_encryption_key_status_sensor.py
+"""Tests for the Encryption Key Status diagnostic sensor (AP-9 / AP-10).
+
+Four concerns:
+
+- **T9 wiring** -- ``note_decrypt_failure`` maps each decryption error type to
+  the matching ``CryptoStatus`` on the coordinator, so the sensor and the reauth
+  escalation are driven from a single source (D6).
+- **T9 sensor** -- the entity renders that state, maps ``UNKNOWN`` to ``None``
+  for Home Assistant's enum contract (``native_value`` must be one of
+  ``options`` or ``None``), and every option is covered.
+- **T10 rename non-breaking** -- the connectivity entity's identity
+  (``key`` / ``translation_key``, from which ``entity_id`` and ``unique_id``
+  derive) is independent of the translated name, so the AP-9 name change cannot
+  alter existing ``entity_id``/``unique_id`` values or break automations.
+- **T11 translation completeness** -- every shipped translation file defines the
+  new sensor (name + four states) and the renamed connectivity name, so the
+  diagnosis stays consistent across all locales.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.binary_sensor import CONNECTIVITY_DESC
+from custom_components.googlefindmy.coordinator.helpers.stats import CryptoStatus
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    DecryptionError,
+    SharedKeyMismatchError,
+    SharedKeyMissingError,
+    StaleOwnerKeyError,
+)
+from custom_components.googlefindmy.sensor import (
+    ENCRYPTION_KEY_STATUS_OPTIONS,
+    GoogleFindMyEncryptionKeyStatusSensor,
+)
+
+from .helpers.polling_mixin_stub import PollingStub
+
+_ROOT = Path(__file__).resolve().parents[1] / "custom_components" / "googlefindmy"
+_TRANSLATIONS_DIR = _ROOT / "translations"
+_STRINGS_JSON = _ROOT / "strings.json"
+_REQUIRED_STATES = {
+    "ok",
+    "shared_key_invalid",
+    "shared_key_missing",
+    "tracker_key_outdated",
+}
+
+
+def _make_stub() -> PollingStub:
+    """Return a PollingStub seeded for decrypt-failure bookkeeping."""
+
+    stub = PollingStub()
+    stub._consecutive_decrypt_failures = 0
+    stub._last_decrypt_reauth_monotonic = None
+    stub._last_decrypt_error = None
+    stub._monotonic = lambda: 1_000_000.0
+    stub._set_auth_state = MagicMock()
+    return stub
+
+
+def _build_sensor(coordinator: Any) -> GoogleFindMyEncryptionKeyStatusSensor:
+    """Instantiate the sensor without running the HA entity __init__ chain."""
+
+    sensor = GoogleFindMyEncryptionKeyStatusSensor.__new__(
+        GoogleFindMyEncryptionKeyStatusSensor
+    )
+    sensor.coordinator = coordinator
+    sensor._attr_unique_id = "googlefindmy_entry_service_encryption_key_status"
+    return sensor
+
+
+def _all_translation_files() -> list[Path]:
+    return sorted(_TRANSLATIONS_DIR.glob("*.json")) + [_STRINGS_JSON]
+
+
+# --------------------------------------------------------------------------- #
+# T9 wiring: decryption error type -> CryptoStatus (single source, D6)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("stale", "error", "expected"),
+    [
+        (False, SharedKeyMismatchError("bad tag"), CryptoStatus.SHARED_KEY_INVALID),
+        (False, SharedKeyMissingError("empty"), CryptoStatus.SHARED_KEY_MISSING),
+        (False, DecryptionError("own reports failed"), CryptoStatus.SHARED_KEY_INVALID),
+        (True, StaleOwnerKeyError("v2 != v3"), CryptoStatus.TRACKER_KEY_OUTDATED),
+    ],
+)
+def test_t9_note_decrypt_failure_maps_to_crypto_status(
+    stale: bool, error: Exception, expected: str
+) -> None:
+    """Each error type lands as the matching diagnostic state on the coordinator.
+
+    This is the mutation-sharp assertion: swapping the mapping in
+    ``note_decrypt_failure`` flips the expected state and turns this red.
+    """
+
+    stub = _make_stub()
+    stub.note_decrypt_failure(stale=stale, error=error, device="dev")
+    assert stub.crypto_status.state == expected
+
+
+def test_t9_crypto_status_ok_and_churn_guard() -> None:
+    """``_set_crypto_status`` updates the snapshot and no-ops on unchanged state."""
+
+    stub = _make_stub()
+    stub.note_decrypt_failure(
+        stale=False, error=SharedKeyMismatchError("x"), device="d"
+    )
+    assert stub.crypto_status.state == CryptoStatus.SHARED_KEY_INVALID
+
+    stub._set_crypto_status(CryptoStatus.OK)
+    assert stub.crypto_status.state == CryptoStatus.OK
+
+    # Churn guard: setting the same state again is a no-op (early return), the
+    # snapshot stays stable and no exception escapes.
+    stub._set_crypto_status(CryptoStatus.OK)
+    assert stub.crypto_status.state == CryptoStatus.OK
+
+
+def test_t9_crypto_status_survives_listener_failure() -> None:
+    """A listener failure during _set_crypto_status is swallowed; state persists.
+
+    Mirrors the api/fcm status setters: a very early ``async_set_updated_data``
+    failure (listeners not ready) must not lose the state transition.
+    """
+
+    stub = _make_stub()
+    stub.async_set_updated_data = MagicMock(side_effect=RuntimeError("early"))
+    stub._set_crypto_status(CryptoStatus.SHARED_KEY_MISSING, reason="startup")
+    assert stub.crypto_status.state == CryptoStatus.SHARED_KEY_MISSING
+    assert stub.crypto_status.reason == "startup"
+
+
+# --------------------------------------------------------------------------- #
+# T9 sensor: native_value rendering + HA enum contract
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("state", "expected_native"),
+    [
+        (CryptoStatus.UNKNOWN, None),
+        (CryptoStatus.OK, "ok"),
+        (CryptoStatus.SHARED_KEY_INVALID, "shared_key_invalid"),
+        (CryptoStatus.SHARED_KEY_MISSING, "shared_key_missing"),
+        (CryptoStatus.TRACKER_KEY_OUTDATED, "tracker_key_outdated"),
+    ],
+)
+def test_t9_sensor_native_value(state: str, expected_native: str | None) -> None:
+    """The sensor renders the coordinator state; UNKNOWN -> None (HA "unknown")."""
+
+    coordinator = SimpleNamespace(
+        crypto_status=SimpleNamespace(state=state, changed_at=1_700_000_000.0),
+        _consecutive_decrypt_failures=0,
+        _last_decrypt_error=None,
+    )
+    sensor = _build_sensor(coordinator)
+
+    assert sensor.native_value == expected_native
+    # HA enum contract: a non-None native_value MUST be a declared option.
+    if sensor.native_value is not None:
+        assert sensor.native_value in ENCRYPTION_KEY_STATUS_OPTIONS
+
+
+def test_t9_native_value_handles_missing_snapshot() -> None:
+    """A coordinator without a usable crypto_status renders as unknown (None)."""
+
+    sensor = _build_sensor(SimpleNamespace(crypto_status=None))
+    assert sensor.native_value is None
+
+
+def test_t9_sensor_attaches_to_service_device() -> None:
+    """The sensor groups under the per-entry service device (account-wide)."""
+
+    from tests.helpers.config_entries_stub import make_config_entry
+
+    sensor = GoogleFindMyEncryptionKeyStatusSensor.__new__(
+        GoogleFindMyEncryptionKeyStatusSensor
+    )
+    sensor.coordinator = SimpleNamespace(
+        config_entry=make_config_entry(entry_id="entry")
+    )
+    sensor._subentry_identifier = "service"
+    sensor._subentry_key = "service"
+
+    info = sensor.device_info
+    assert info is not None
+    assert getattr(info, "identifiers", None)
+
+
+def test_t9_options_cover_all_states_except_unknown() -> None:
+    """``options`` lists exactly the four concrete states; UNKNOWN is excluded."""
+
+    assert set(ENCRYPTION_KEY_STATUS_OPTIONS) == {
+        CryptoStatus.OK,
+        CryptoStatus.SHARED_KEY_INVALID,
+        CryptoStatus.SHARED_KEY_MISSING,
+        CryptoStatus.TRACKER_KEY_OUTDATED,
+    }
+    assert CryptoStatus.UNKNOWN not in ENCRYPTION_KEY_STATUS_OPTIONS
+
+
+def test_t9_extra_state_attributes_show_escalation_progress() -> None:
+    """Attributes expose escalation progress from the same coordinator fields."""
+
+    coordinator = SimpleNamespace(
+        crypto_status=SimpleNamespace(
+            state=CryptoStatus.SHARED_KEY_INVALID, changed_at=1_700_000_000.0
+        ),
+        _consecutive_decrypt_failures=2,
+        _last_decrypt_error="SharedKeyMismatchError: bad tag",
+    )
+    sensor = _build_sensor(coordinator)
+
+    attrs = sensor.extra_state_attributes
+    assert attrs is not None
+    assert attrs["consecutive_decrypt_failures"] == 2
+    assert attrs["last_decrypt_error_class"] == "SharedKeyMismatchError"
+    assert attrs["changed_at"] == 1_700_000_000.0
+
+
+def test_t9_extra_state_attributes_empty_when_pristine() -> None:
+    """No attributes are emitted before any decryption activity (returns None)."""
+
+    coordinator = SimpleNamespace(
+        crypto_status=SimpleNamespace(state=CryptoStatus.UNKNOWN, changed_at=None),
+        _consecutive_decrypt_failures=None,
+        _last_decrypt_error=None,
+    )
+    sensor = _build_sensor(coordinator)
+    assert sensor.extra_state_attributes is None
+
+
+# --------------------------------------------------------------------------- #
+# T10 rename non-breaking: identity is independent of the translated name
+# --------------------------------------------------------------------------- #
+
+
+def test_t10_connectivity_identity_independent_of_translated_name() -> None:
+    """AP-9 changes only the translated name; the entity identity is untouched.
+
+    ``entity_id``/``unique_id`` derive from ``key``/``translation_key`` and the
+    unique-id suffix, never from the (now FCM-qualified) display name -- so the
+    rename cannot duplicate registry entries or break existing automations.
+    """
+
+    assert CONNECTIVITY_DESC.key == "connectivity"
+    assert CONNECTIVITY_DESC.translation_key == "connectivity"
+
+    en = json.loads((_TRANSLATIONS_DIR / "en.json").read_text(encoding="utf-8"))
+    assert (
+        en["entity"]["binary_sensor"]["connectivity"]["name"]
+        == "FCM Connection Status"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# T11 translation completeness across every shipped locale + strings.json
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "path", _all_translation_files(), ids=lambda p: p.name
+)
+def test_t11_encryption_key_status_present_and_complete(path: Path) -> None:
+    """Every translation file defines the sensor name and all four states."""
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    sensor = data["entity"]["sensor"]
+    assert "encryption_key_status" in sensor, f"{path.name} misses the sensor"
+
+    block = sensor["encryption_key_status"]
+    name = block.get("name")
+    assert isinstance(name, str) and name.strip(), f"{path.name} empty name"
+
+    states = set(block.get("state", {}).keys())
+    assert states == _REQUIRED_STATES, f"{path.name}: {states} != {_REQUIRED_STATES}"
+    for key, value in block["state"].items():
+        assert isinstance(value, str) and value.strip(), f"{path.name} {key} empty"
+
+
+@pytest.mark.parametrize(
+    "path", _all_translation_files(), ids=lambda p: p.name
+)
+def test_t11_connectivity_rename_present(path: Path) -> None:
+    """Every translation file carries the FCM-qualified connectivity name."""
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    name = data["entity"]["binary_sensor"]["connectivity"]["name"]
+    assert "FCM" in name, f"{path.name} connectivity name {name!r} lacks FCM"

--- a/tests/test_fcm_receiver_decrypt_escalation.py
+++ b/tests/test_fcm_receiver_decrypt_escalation.py
@@ -1,0 +1,125 @@
+# tests/test_fcm_receiver_decrypt_escalation.py
+"""Background-push decrypt-failure escalation in :class:`FcmReceiverHA`.
+
+A push-only setup must escalate to a reauth flow identically to the poll path.
+Because the background decode runs outside a coordinator update cycle, the
+receiver cannot raise ``ConfigEntryAuthFailed``; instead it starts the entry's
+reauth flow directly when the shared counter (driven through the coordinator's
+``note_decrypt_failure``) reports that the threshold was reached.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.Auth import fcm_receiver_ha
+from custom_components.googlefindmy.Auth.fcm_receiver_ha import FcmReceiverHA
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    DecryptionError,
+    StaleOwnerKeyError,
+)
+
+
+def _receiver_with_coordinator(*, escalate: bool) -> tuple[FcmReceiverHA, MagicMock, MagicMock]:
+    receiver = FcmReceiverHA()
+    hass = MagicMock()
+    receiver._hass = hass
+    entry = MagicMock()
+    entry.entry_id = "entry-1"
+    entry.async_start_reauth = MagicMock()
+    coordinator = MagicMock()
+    coordinator.config_entry = entry
+    coordinator.note_decrypt_failure = MagicMock(return_value=escalate)
+    receiver.coordinators = [coordinator]
+    return receiver, coordinator, entry
+
+
+def test_push_decrypt_failure_starts_reauth_when_threshold_reached() -> None:
+    """When the coordinator reports escalation, the entry's reauth flow is started
+    (the only way to surface a reauth from the background push path)."""
+    receiver, coordinator, entry = _receiver_with_coordinator(escalate=True)
+    err = DecryptionError("stale shared key")
+
+    receiver._note_decrypt_failure_for_entry("entry-1", stale=False, error=err)
+
+    coordinator.note_decrypt_failure.assert_called_once_with(stale=False, error=err)
+    entry.async_start_reauth.assert_called_once_with(receiver._hass)
+
+
+def test_push_decrypt_failure_below_threshold_does_not_start_reauth() -> None:
+    """Below threshold (escalate=False), the counter is fed but no reauth is fired.
+    A per-tracker stale key (stale=True) likewise never starts an account reauth."""
+    receiver, coordinator, entry = _receiver_with_coordinator(escalate=False)
+
+    receiver._note_decrypt_failure_for_entry(
+        "entry-1", stale=True, error=StaleOwnerKeyError("tracker outdated")
+    )
+
+    coordinator.note_decrypt_failure.assert_called_once()
+    entry.async_start_reauth.assert_not_called()
+
+
+def test_push_decrypt_failure_swallows_coordinator_errors() -> None:
+    """The push path must never break: a misbehaving coordinator is swallowed."""
+    receiver, coordinator, entry = _receiver_with_coordinator(escalate=True)
+    coordinator.note_decrypt_failure = MagicMock(side_effect=RuntimeError("boom"))
+
+    # Must not raise.
+    receiver._note_decrypt_failure_for_entry(
+        "entry-1", stale=False, error=DecryptionError("x")
+    )
+    entry.async_start_reauth.assert_not_called()
+
+
+def test_push_decrypt_failure_no_coordinator_for_entry_is_noop() -> None:
+    """Unknown entry id: nothing to feed, no crash."""
+    receiver, coordinator, entry = _receiver_with_coordinator(escalate=True)
+
+    receiver._note_decrypt_failure_for_entry(
+        "other-entry", stale=False, error=DecryptionError("x")
+    )
+
+    coordinator.note_decrypt_failure.assert_not_called()
+    entry.async_start_reauth.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("exc", "expect_reauth"),
+    [
+        (DecryptionError("stale shared key"), True),
+        (StaleOwnerKeyError("tracker outdated"), False),
+    ],
+)
+async def test_decode_background_location_feeds_counter_on_decrypt_error(
+    monkeypatch: pytest.MonkeyPatch, exc: Exception, expect_reauth: bool
+) -> None:
+    """The background decode path must funnel decryption failures into the shared
+    counter (and start reauth when the account-wide threshold is reached) instead
+    of silently returning an empty result."""
+    receiver, coordinator, entry = _receiver_with_coordinator(escalate=True)
+    receiver._entry_caches["entry-1"] = MagicMock()
+    # Model the real hook contract: a per-tracker stale key never escalates.
+    coordinator.note_decrypt_failure = MagicMock(
+        side_effect=lambda *, stale, error: not stale
+    )
+
+    # Parse step returns a harmless object; the decrypt step raises.
+    monkeypatch.setattr(
+        fcm_receiver_ha.decoder_module,
+        "parse_device_update_protobuf",
+        MagicMock(return_value=MagicMock()),
+    )
+    monkeypatch.setattr(
+        fcm_receiver_ha,
+        "async_decrypt_location_response_locations",
+        AsyncMock(side_effect=exc),
+    )
+
+    result = await receiver._decode_background_location_async("entry-1", "deadbeef")
+
+    assert result == {}
+    coordinator.note_decrypt_failure.assert_called_once()
+    assert entry.async_start_reauth.called is expect_reauth

--- a/tests/test_fcm_receiver_decrypt_escalation.py
+++ b/tests/test_fcm_receiver_decrypt_escalation.py
@@ -123,3 +123,61 @@ async def test_decode_background_location_feeds_counter_on_decrypt_error(
     assert result == {}
     coordinator.note_decrypt_failure.assert_called_once()
     assert entry.async_start_reauth.called is expect_reauth
+
+
+@pytest.mark.asyncio
+async def test_decode_background_location_clears_counter_on_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful background decrypt must clear the shared reauth budget.
+
+    The background path feeds decrypt *failures* into the coordinator's
+    account-wide counter, so a successful background decrypt has to clear it too
+    (symmetry with the poll cycle). Otherwise non-consecutive push failures
+    interleaved with healthy pushes could accumulate to the reauth threshold and
+    trip a spurious reauth for a perfectly healthy account.
+    """
+    receiver, coordinator, entry = _receiver_with_coordinator(escalate=False)
+    receiver._entry_caches["entry-1"] = MagicMock()
+
+    monkeypatch.setattr(
+        fcm_receiver_ha.decoder_module,
+        "parse_device_update_protobuf",
+        MagicMock(return_value=MagicMock()),
+    )
+    # Decrypt succeeds and yields one usable record (positive proof of the key).
+    monkeypatch.setattr(
+        fcm_receiver_ha,
+        "async_decrypt_location_response_locations",
+        AsyncMock(
+            return_value=[{"last_seen": 123.0, "latitude": 1.0, "longitude": 2.0}]
+        ),
+    )
+
+    result = await receiver._decode_background_location_async("entry-1", "deadbeef")
+
+    assert result.get("last_seen") == 123.0
+    coordinator.note_decrypt_success.assert_called_once_with()
+    coordinator.note_decrypt_failure.assert_not_called()
+    entry.async_start_reauth.assert_not_called()
+
+
+def test_note_decrypt_success_for_entry_swallows_coordinator_errors() -> None:
+    """The push success path must never break: a misbehaving coordinator is
+    swallowed exactly like the failure path."""
+    receiver, coordinator, entry = _receiver_with_coordinator(escalate=False)
+    coordinator.note_decrypt_success = MagicMock(side_effect=RuntimeError("boom"))
+
+    # Must not raise.
+    receiver._note_decrypt_success_for_entry("entry-1")
+
+    coordinator.note_decrypt_success.assert_called_once_with()
+
+
+def test_note_decrypt_success_for_entry_unknown_entry_is_noop() -> None:
+    """Unknown entry id: nothing to clear, no crash."""
+    receiver, coordinator, entry = _receiver_with_coordinator(escalate=False)
+
+    receiver._note_decrypt_success_for_entry("other-entry")
+
+    coordinator.note_decrypt_success.assert_not_called()

--- a/tests/test_fcm_receiver_decrypt_escalation.py
+++ b/tests/test_fcm_receiver_decrypt_escalation.py
@@ -162,6 +162,94 @@ async def test_decode_background_location_clears_counter_on_success(
     entry.async_start_reauth.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_decode_background_location_metadata_only_does_not_clear_counter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A metadata_only decode result must NOT clear the shared reauth budget.
+
+    The decode layer returns a single ``metadata_only`` sentinel row (key material
+    from the secrets bundle, no authenticated decrypt) when no encrypted report
+    decrypts. That row is non-empty, but it is no positive proof the shared key
+    works, so report-less pushes interleaved with real failures must not keep a
+    stale key below the reauth threshold (Codex finding on PR #182). The metadata
+    must still pass through downstream.
+    """
+    receiver, coordinator, entry = _receiver_with_coordinator(escalate=False)
+    receiver._entry_caches["entry-1"] = MagicMock()
+
+    monkeypatch.setattr(
+        fcm_receiver_ha.decoder_module,
+        "parse_device_update_protobuf",
+        MagicMock(return_value=MagicMock()),
+    )
+    # Decrypt yields only a metadata_only sentinel (no usable location report).
+    monkeypatch.setattr(
+        fcm_receiver_ha,
+        "async_decrypt_location_response_locations",
+        AsyncMock(
+            return_value=[{"metadata_only": True, "owner_key_version": 7}]
+        ),
+    )
+
+    result = await receiver._decode_background_location_async("entry-1", "deadbeef")
+
+    # Metadata still flows downstream ...
+    assert result.get("metadata_only") is True
+    # ... but the budget is NOT cleared (no authenticated decrypt happened).
+    coordinator.note_decrypt_success.assert_not_called()
+    coordinator.note_decrypt_failure.assert_not_called()
+    entry.async_start_reauth.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_decode_background_location_semantic_only_does_not_clear_counter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A SEMANTIC-only decode result must NOT clear the shared reauth budget.
+
+    SEMANTIC rows are appended with ``decrypted_location=b""`` and skip the crypto
+    path, so the record carries a ``semantic_name`` and ``last_seen`` but no
+    coordinates and no ``metadata_only`` flag. It is non-empty yet authenticates
+    nothing, so a background push of a semantic location must not clear the budget
+    and let a stale key stay below the reauth threshold (Codex finding on PR #182).
+    A denylist on ``metadata_only`` alone would miss this shape.
+    """
+    receiver, coordinator, entry = _receiver_with_coordinator(escalate=False)
+    receiver._entry_caches["entry-1"] = MagicMock()
+
+    monkeypatch.setattr(
+        fcm_receiver_ha.decoder_module,
+        "parse_device_update_protobuf",
+        MagicMock(return_value=MagicMock()),
+    )
+    # Decrypt yields only a SEMANTIC row (no authenticated coordinates).
+    monkeypatch.setattr(
+        fcm_receiver_ha,
+        "async_decrypt_location_response_locations",
+        AsyncMock(
+            return_value=[
+                {
+                    "last_seen": 123.0,
+                    "semantic_name": "Home",
+                    "status": "semantic",
+                    "latitude": None,
+                    "longitude": None,
+                }
+            ]
+        ),
+    )
+
+    result = await receiver._decode_background_location_async("entry-1", "deadbeef")
+
+    # Semantic data still flows downstream ...
+    assert result.get("semantic_name") == "Home"
+    # ... but the budget is NOT cleared (no authenticated decrypt happened).
+    coordinator.note_decrypt_success.assert_not_called()
+    coordinator.note_decrypt_failure.assert_not_called()
+    entry.async_start_reauth.assert_not_called()
+
+
 def test_note_decrypt_success_for_entry_swallows_coordinator_errors() -> None:
     """The push success path must never break: a misbehaving coordinator is
     swallowed exactly like the failure path."""

--- a/tests/test_fcm_receiver_decrypt_escalation.py
+++ b/tests/test_fcm_receiver_decrypt_escalation.py
@@ -157,7 +157,7 @@ async def test_decode_background_location_clears_counter_on_success(
     result = await receiver._decode_background_location_async("entry-1", "deadbeef")
 
     assert result.get("last_seen") == 123.0
-    coordinator.note_decrypt_success.assert_called_once_with()
+    coordinator.note_background_decrypt_success.assert_called_once_with()
     coordinator.note_decrypt_failure.assert_not_called()
     entry.async_start_reauth.assert_not_called()
 
@@ -197,7 +197,7 @@ async def test_decode_background_location_metadata_only_does_not_clear_counter(
     # Metadata still flows downstream ...
     assert result.get("metadata_only") is True
     # ... but the budget is NOT cleared (no authenticated decrypt happened).
-    coordinator.note_decrypt_success.assert_not_called()
+    coordinator.note_background_decrypt_success.assert_not_called()
     coordinator.note_decrypt_failure.assert_not_called()
     entry.async_start_reauth.assert_not_called()
 
@@ -245,7 +245,7 @@ async def test_decode_background_location_semantic_only_does_not_clear_counter(
     # Semantic data still flows downstream ...
     assert result.get("semantic_name") == "Home"
     # ... but the budget is NOT cleared (no authenticated decrypt happened).
-    coordinator.note_decrypt_success.assert_not_called()
+    coordinator.note_background_decrypt_success.assert_not_called()
     coordinator.note_decrypt_failure.assert_not_called()
     entry.async_start_reauth.assert_not_called()
 
@@ -254,12 +254,12 @@ def test_note_decrypt_success_for_entry_swallows_coordinator_errors() -> None:
     """The push success path must never break: a misbehaving coordinator is
     swallowed exactly like the failure path."""
     receiver, coordinator, entry = _receiver_with_coordinator(escalate=False)
-    coordinator.note_decrypt_success = MagicMock(side_effect=RuntimeError("boom"))
+    coordinator.note_background_decrypt_success = MagicMock(side_effect=RuntimeError("boom"))
 
     # Must not raise.
     receiver._note_decrypt_success_for_entry("entry-1")
 
-    coordinator.note_decrypt_success.assert_called_once_with()
+    coordinator.note_background_decrypt_success.assert_called_once_with()
 
 
 def test_note_decrypt_success_for_entry_unknown_entry_is_noop() -> None:
@@ -268,4 +268,4 @@ def test_note_decrypt_success_for_entry_unknown_entry_is_noop() -> None:
 
     receiver._note_decrypt_success_for_entry("other-entry")
 
-    coordinator.note_decrypt_success.assert_not_called()
+    coordinator.note_background_decrypt_success.assert_not_called()

--- a/tests/test_fcmpushclient_close_log_level.py
+++ b/tests/test_fcmpushclient_close_log_level.py
@@ -1,0 +1,65 @@
+# tests/test_fcmpushclient_close_log_level.py
+"""Regression suite for the server-initiated ``Close`` log level.
+
+A server-initiated MCS ``Close`` is a normal part of the FCM connection
+life-cycle: the worker stops cleanly and the supervisor reconnects. The
+``Close`` branch of ``FcmPushClient._handle_message`` was downgraded from a
+rate-limited WARNING to INFO so it no longer surfaces as a recurring false
+alarm in the Home Assistant log panel, matching the sibling worker-stop paths
+(``"FCM stream ended"`` / ``"FCM read ended"``) that already log at INFO.
+
+These tests pin that contract: the path logs at INFO (never WARNING), does not
+consume the warn rate-limit, and still signals the worker to stop. Before this
+suite ``_handle_message`` ran at ~0 % on the unit level (the poison stub mocks
+it away), so the changed branch had no coverage.
+"""
+from __future__ import annotations
+
+import logging
+
+from custom_components.googlefindmy.Auth.firebase_messaging.fcmpushclient import (
+    Close,
+)
+from tests.helpers.fcm_handle_stub import FcmMessageSlim
+
+
+class TestCloseLogLevel:
+    """Behaviour of the ``isinstance(msg, Close)`` branch of ``_handle_message``."""
+
+    async def test_close_logs_info_not_warning(
+        self, caplog: logging.LogCaptureFixture
+    ) -> None:
+        """Server ``Close`` -> single INFO record, no WARNING (false-alarm fix)."""
+        client = FcmMessageSlim()
+
+        with caplog.at_level(logging.INFO, logger=client.logger.name):
+            await client._handle_message(Close())
+
+        records = [r for r in caplog.records if r.name == client.logger.name]
+        # Exactly one record, emitted at INFO. The level IS the contract here
+        # (the WARNING -> INFO downgrade); the exact wording is deliberately not
+        # pinned so a future reword cannot break this regression test.
+        assert len(records) == 1
+        assert records[0].levelno == logging.INFO
+        assert records[0].getMessage().strip()
+        # No record at WARNING or above on this normal life-cycle path.
+        assert not [r for r in records if r.levelno >= logging.WARNING]
+
+    async def test_close_does_not_consume_warn_rate_limit(self) -> None:
+        """Close path must not call ``_log_warn_with_limit`` after the downgrade."""
+        client = FcmMessageSlim()
+
+        await client._handle_message(Close())
+
+        assert client.warnings == []
+
+    async def test_close_stops_worker(self) -> None:
+        """Close still sets ``do_listen=False`` so the supervisor reconnects."""
+        client = FcmMessageSlim()
+        assert client.do_listen is True
+
+        await client._handle_message(Close())
+
+        assert client.do_listen is False
+        # The unconditional preamble ran (message accounted for).
+        assert client.input_stream_id == 1

--- a/tests/test_foreign_tracker_cryptor.py
+++ b/tests/test_foreign_tracker_cryptor.py
@@ -3,13 +3,22 @@
 
 from __future__ import annotations
 
+import secrets
+
 import pytest
 
-from custom_components.googlefindmy.FMDNCrypto.eid_generator import EIK_LENGTH
+from custom_components.googlefindmy.FMDNCrypto.eid_generator import (
+    EIK_LENGTH,
+    EidVariant,
+    generate_eid_variant,
+)
 from custom_components.googlefindmy.FMDNCrypto.foreign_tracker_cryptor import (
     _COORD_LEN,
+    _get_curve,
     _require_len,
     decrypt,
+    encrypt,
+    rx_to_ry,
 )
 
 
@@ -60,3 +69,104 @@ class TestDecryptIdentityKeyLength:
             _require_len("foo", b"\x00" * 5, 10)
         # No error when length matches
         _require_len("bar", b"\x00" * 10, 10)
+
+
+def _valid_eid() -> bytes:
+    """Build a valid SECP160r1 EID (on-curve x-coordinate) for encrypt() inputs."""
+    identity_key = b"\x01" * EIK_LENGTH
+    return generate_eid_variant(
+        identity_key, 0, EidVariant.LEGACY_SECP160R1_X20_BE
+    )
+
+
+class TestNonceFreshnessContract:
+    """H1 (A7-H hardening): AES-EAX nonce uniqueness rests on caller entropy.
+
+    ``encrypt(message, random, eid)`` derives the ephemeral scalar ``s`` solely
+    from ``random``; the EAX nonce is ``LRx(8) || LSx(8)`` where ``LSx`` is the
+    low 8 bytes of ``(s*G).x``. The only production caller,
+    ``fmdn_finder/location_uploader.py:551``, passes ``secrets.token_bytes(32)``
+    as ``random``, so a fresh nonce (and HKDF key) is produced per message.
+
+    AP5 flagged this isolated function as a nonce-reuse FAIL (M1); the Tier-4
+    code verification (Regel 10) downgraded it to PASS precisely because of that
+    caller contract. These tests lock the contract so a future refactor that
+    reuses ``random`` (constant/cached bytes, a counter, etc.) — which would
+    reuse the EAX nonce and break confidentiality/integrity — turns the audited
+    PASS back into a red test instead of a silent regression.
+    """
+
+    def test_fresh_random_yields_distinct_nonce_and_ciphertext(self) -> None:
+        """Two encryptions of identical plaintext with fresh entropy must differ."""
+        eid = _valid_eid()
+        message = b"identical-plaintext-payload"
+        ct1, sx1 = encrypt(message, secrets.token_bytes(32), eid)
+        ct2, sx2 = encrypt(message, secrets.token_bytes(32), eid)
+        # Fresh entropy -> different ephemeral S -> different Sx -> different nonce.
+        assert sx1 != sx2
+        assert ct1 != ct2
+
+    def test_reused_random_repeats_nonce_mutation_guard(self) -> None:
+        """Mutation guard proving the freshness test is sharp.
+
+        If a caller violates the entropy contract and passes constant bytes,
+        the ephemeral S (hence Sx, hence the nonce) repeats and the ciphertext
+        of a fixed plaintext is identical. Asserting that equality here proves
+        the freshness test above would actually catch nonce reuse.
+        """
+        eid = _valid_eid()
+        message = b"identical-plaintext-payload"
+        fixed_random = b"\x02" * 32
+        ct1, sx1 = encrypt(message, fixed_random, eid)
+        ct2, sx2 = encrypt(message, fixed_random, eid)
+        assert sx1 == sx2  # nonce component repeats under reused entropy
+        assert ct1 == ct2
+
+
+class TestRxToRyCofactorSafety:
+    """H2 (A7-H hardening): rx_to_ry rejects off-curve X and recovers on-curve Y.
+
+    AP5 flagged a possible invalid-curve / small-subgroup attack (M4); the
+    Tier-4 verification downgraded it to PASS because SECP160r1 has cofactor 1
+    (prime order) and ``rx_to_ry`` reconstructs Y on the correct curve, raising
+    on a non-quadratic residue (the residue check in the production code). Any
+    point it returns therefore lies in the legitimate prime-order group, so no
+    small-subgroup confinement is possible.
+
+    These tests lock both halves of that argument: an X with no valid Y must
+    raise, and an on-curve X must yield a Y satisfying the curve equation. A
+    future relaxation of the residue check (which would admit off-curve points)
+    would make the negative case go red.
+    """
+
+    def test_off_curve_x_raises(self) -> None:
+        """An X whose y^2 is a non-residue has no curve point -> ValueError."""
+        curve_fp = _get_curve().curve
+        p = int(curve_fp.p())
+        a = int(curve_fp.a())
+        b = int(curve_fp.b())
+        # Find a small x whose y^2 is a quadratic non-residue (Euler's criterion
+        # gives p-1 for non-residues). Roughly half of all x qualify.
+        non_residue_x = None
+        for cand in range(2, 500):
+            ryy = (pow(cand, 3, p) + a * cand + b) % p
+            if ryy != 0 and pow(ryy, (p - 1) // 2, p) == p - 1:
+                non_residue_x = cand
+                break
+        assert non_residue_x is not None, "expected an off-curve x for the negative case"
+        with pytest.raises(ValueError, match="not on the curve"):
+            rx_to_ry(non_residue_x, curve_fp)
+
+    def test_on_curve_x_recovers_even_y(self) -> None:
+        """The generator's X is on-curve; recovered Y satisfies y^2 = x^3+ax+b."""
+        curve = _get_curve()
+        curve_fp = curve.curve
+        p = int(curve_fp.p())
+        a = int(curve_fp.a())
+        b = int(curve_fp.b())
+        gx = int(curve.generator.x())
+        y = rx_to_ry(gx, curve_fp)
+        lhs = (y * y) % p
+        rhs = (pow(gx, 3, p) + a * gx + b) % p
+        assert lhs == rhs  # recovered point lies on the curve
+        assert y % 2 == 0  # even-Y canonical form (FMDN convention)

--- a/tests/test_get_owner_key.py
+++ b/tests/test_get_owner_key.py
@@ -27,7 +27,7 @@ Each ``RL-*`` test pins one member of the eight bug families distilled from the
     RL-12  missing/empty shared_key -> RuntimeError
     RL-13  missing encryptedOwnerKeyAndMetadata -> RuntimeError
     RL-14  missing/empty encryptedOwnerKey -> RuntimeError
-    RL-15  InvalidTag from decrypt -> RuntimeError (actionable message)
+    RL-15  InvalidTag from decrypt -> propagated unwrapped (discriminator)
     RL-16  decrypted owner_key empty/wrong type -> RuntimeError
     RL-17  hex happy path -> OwnerKeyInfo(32 bytes, version)
     RL-18  base64url fallback + self-heal: cache normalized to hex
@@ -366,14 +366,21 @@ async def test_rl14_missing_encrypted_owner_key_raises(
         )
 
 
-async def test_rl15_invalid_tag_maps_to_runtime_error(
+async def test_rl15_invalid_tag_propagates_unwrapped(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """RL-15: an AES-GCM InvalidTag during owner-key decryption propagates
+    unchanged instead of being wrapped into RuntimeError.
+
+    decrypt_locations relies on the unwrapped InvalidTag to map the failure to
+    SharedKeyMismatchError and distinguish a wrong/stale shared key from a missing
+    one. Wrapping it here would erase that discriminator.
+    """
     monkeypatch.setattr(
         gok, "decrypt_owner_key", MagicMock(side_effect=gok.InvalidTag())
     )
     cache = _FakeCache()
-    with pytest.raises(RuntimeError, match="InvalidTag"):
+    with pytest.raises(gok.InvalidTag):
         await gok.async_get_owner_key(
             cache=cache, username="g@acct.example.com", **_getters()
         )

--- a/tests/test_guard_asyncio_run_antipattern.py
+++ b/tests/test_guard_asyncio_run_antipattern.py
@@ -13,7 +13,6 @@ import pytest
 LEGACY_ALLOWLIST: set[str] = {
     "tests/test_adm_token_retrieval.py",
     "tests/test_api_fcm_token_scoping.py",
-    "tests/test_api_location_selection.py",
     "tests/test_cli_entry_selection.py",
     "tests/test_cli_sound_request_entry_selection.py",
     "tests/test_config_flow_discovery.py",

--- a/tests/test_hass_data_layout.py
+++ b/tests/test_hass_data_layout.py
@@ -530,7 +530,9 @@ async def test_async_setup_entry_hijacks_legacy_credentials_when_cache_empty(
     cache = harness.cache
     username_key = integration.username_string
     assert cache.values[username_key] == "legacyuser@example.com"
-    assert cache.values[DATA_SECRET_BUNDLE]["email"] == "LegacyUser@Example.com "
+    # The secrets-bundle normalizer edge-trims non-credential fields (case is
+    # preserved, only the pasted trailing space is removed).
+    assert cache.values[DATA_SECRET_BUNDLE]["email"] == "LegacyUser@Example.com"
     assert cache.values[CONF_OAUTH_TOKEN] == "outer-oauth-token"
     assert cache.values[DATA_AAS_TOKEN] == "legacy-aas-token"
 

--- a/tests/test_nova_request.py
+++ b/tests/test_nova_request.py
@@ -765,6 +765,85 @@ async def test_async_nova_request_raises_on_connection_setup_failure(
     assert session.calls  # post() *was* attempted (and retried), only entry failed
 
 
+async def test_async_nova_request_network_retry_uses_tiered_log_level(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The network-exception retry path logs the first attempt at INFO, not WARNING.
+
+    A single transient network blip is not actionable, so attempt 1 must be INFO
+    to avoid log noise, while repeated failures (attempt 2+) escalate to WARNING.
+    This mirrors the tiered severity already used by the HTTP-status retry path in
+    the same function. The previous code logged WARNING from the very first
+    attempt, which spammed the log on momentary connectivity hiccups that the
+    built-in retry recovered from on its own.
+    """
+
+    class _ConnFailingResponse:
+        """Context manager that raises on entry, mimicking a connect failure."""
+
+        async def __aenter__(self) -> Any:
+            raise aiohttp.ConnectionTimeoutError
+
+        async def __aexit__(self, *_exc: object) -> None:
+            return None
+
+    class _ConnFailingSession:
+        """Session stub whose every POST fails during connection setup."""
+
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+
+        def post(self, *_args: object, **_kwargs: object) -> _ConnFailingResponse:
+            self.calls.append({"args": _args, "kwargs": _kwargs})
+            return _ConnFailingResponse()
+
+    cache = _StubCache()
+    session = _ConnFailingSession()
+
+    async def _fake_get_adm_token(
+        username: str | None = None, *, retries: int = 2, backoff: float = 1.0, cache: Any
+    ) -> str:
+        return "resolved-token"
+
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.NovaApi.nova_request.async_get_adm_token_api",
+        _fake_get_adm_token,
+    )
+
+    # Collapse the retry backoff so the test stays fast across NOVA_MAX_RETRIES.
+    async def _instant_sleep(_: float) -> None:
+        return None
+
+    monkeypatch.setattr("asyncio.sleep", _instant_sleep)
+
+    caplog.set_level(
+        logging.INFO, logger="custom_components.googlefindmy.NovaApi.nova_request"
+    )
+
+    # Exhaust the retries: every attempt fails pre-connect, so the loop logs the
+    # first retry, then escalates, then raises once retries are spent.
+    with pytest.raises(NovaError):
+        await async_nova_request(
+            "testScope",
+            "00",
+            username="user@example.com",
+            cache=cache,
+            session=session,
+        )
+
+    retry_records = [r for r in caplog.records if "Retrying in" in r.getMessage()]
+    first_attempt = [r for r in retry_records if "(Attempt 1/" in r.getMessage()]
+    later_attempts = [r for r in retry_records if "(Attempt 2/" in r.getMessage()]
+
+    # Mutation sentinel: the first retry is INFO. If the tiering is removed and
+    # the code logs WARNING from attempt 1 again, this assertion turns red.
+    assert len(first_attempt) == 1
+    assert first_attempt[0].levelno == logging.INFO
+    # Escalation still works: a repeated failure surfaces at WARNING.
+    assert later_attempts
+    assert all(r.levelno == logging.WARNING for r in later_attempts)
+
+
 async def test_async_nova_request_marks_read_phase_failure_dispatched(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_options_flow_credentials_cache.py
+++ b/tests/test_options_flow_credentials_cache.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
 from collections.abc import Awaitable
 from dataclasses import dataclass
 from types import MappingProxyType
@@ -21,6 +22,7 @@ from custom_components.googlefindmy.const import (
     CONF_GOOGLE_EMAIL,
     CONF_OAUTH_TOKEN,
     DATA_AAS_TOKEN,
+    DATA_SECRET_BUNDLE,
     DOMAIN,
     SERVICE_SUBENTRY_KEY,
     SUBENTRY_TYPE_SERVICE,
@@ -419,5 +421,127 @@ def test_play_stop_sound_uses_entry_cache(  # noqa: PLR0915
         assert cache_primary.get_calls[-1] == "entry-one:ttl2"
         await stop_set("ttl2", "value2")
         assert ("entry-one:ttl2", "value2") in cache_primary.set_calls
+
+    asyncio.run(_exercise())
+
+
+def test_options_flow_secrets_reauth_strips_owner_key_space(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Options reauth with a pasted secrets bundle strips owner_key whitespace."""
+
+    async def _exercise() -> None:
+        cache = _MemoryCache()
+        entry = _DummyEntry(
+            entry_id="entry-1",
+            data={
+                CONF_GOOGLE_EMAIL: "user@example.com",
+                CONF_OAUTH_TOKEN: "oauth-original-token-123456",
+            },
+            cache=cache,
+        )
+        hass = _DummyHass(entry, cache)
+
+        flow = config_flow.OptionsFlowHandler()
+        flow.hass = hass  # type: ignore[assignment]
+        flow.config_entry = entry  # type: ignore[attr-defined]
+
+        async def _fake_pick(
+            hass: Any,
+            email: str,
+            candidates: list[tuple[str, str]],
+            *,
+            secrets_bundle: dict[str, Any] | None = None,
+        ) -> str | None:
+            # The bundle handed downstream is already whitespace-normalized.
+            assert secrets_bundle is not None
+            assert secrets_bundle["owner_key"] == "AABBCC"
+            return candidates[0][1] if candidates else None
+
+        monkeypatch.setattr(config_flow, "async_pick_working_token", _fake_pick)
+
+        payload = {
+            "google_email": "user@example.com",
+            "oauth_token": "oauth-token-from-secrets-123456",
+            "owner_key": "AA BB\nCC ",
+            "username": "  Keep Me  ",
+        }
+        result = await flow.async_step_credentials(
+            {"new_secrets_json": json.dumps(payload), "subentry": TRACKER_SUBENTRY_KEY}
+        )
+        if inspect.isawaitable(result):
+            result = await result
+        assert isinstance(result, dict)
+
+        updated = hass.config_entries.updated_payloads[-1]
+        bundle = updated[DATA_SECRET_BUNDLE]
+        assert bundle["owner_key"] == "AABBCC"
+        assert bundle["username"] == "Keep Me"
+        await hass.drain_tasks()
+
+    asyncio.run(_exercise())
+
+
+def test_options_flow_secrets_reauth_guard_error_fallback_normalizes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The multi-entry-guard fallback path also normalizes the bundle."""
+
+    async def _exercise() -> None:
+        cache = _MemoryCache()
+        entry = _DummyEntry(
+            entry_id="entry-1",
+            data={
+                CONF_GOOGLE_EMAIL: "user@example.com",
+                CONF_OAUTH_TOKEN: "oauth-original-token-123456",
+            },
+            cache=cache,
+        )
+        hass = _DummyHass(entry, cache)
+
+        # Force the first update to raise a multi-entry guard error so the
+        # fallback branch (which re-parses and re-normalizes) is exercised.
+        calls = {"n": 0}
+        original_update = hass.config_entries.async_update_entry
+
+        def _maybe_raise(entry_: Any, *, data: dict[str, Any]) -> None:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("Multiple config entries active for this domain")
+            original_update(entry_, data=data)
+
+        hass.config_entries.async_update_entry = _maybe_raise  # type: ignore[assignment]
+
+        flow = config_flow.OptionsFlowHandler()
+        flow.hass = hass  # type: ignore[assignment]
+        flow.config_entry = entry  # type: ignore[attr-defined]
+
+        async def _fake_pick(
+            hass: Any,
+            email: str,
+            candidates: list[tuple[str, str]],
+            *,
+            secrets_bundle: dict[str, Any] | None = None,
+        ) -> str | None:
+            return candidates[0][1] if candidates else None
+
+        monkeypatch.setattr(config_flow, "async_pick_working_token", _fake_pick)
+
+        payload = {
+            "google_email": "user@example.com",
+            "oauth_token": "oauth-token-from-secrets-123456",
+            "owner_key": "AA BB CC",
+        }
+        result = await flow.async_step_credentials(
+            {"new_secrets_json": json.dumps(payload), "subentry": TRACKER_SUBENTRY_KEY}
+        )
+        if inspect.isawaitable(result):
+            result = await result
+        assert isinstance(result, dict)
+        # First update raised, fallback re-attempted the update.
+        assert calls["n"] >= 2
+        updated = hass.config_entries.updated_payloads[-1]
+        assert updated[DATA_SECRET_BUNDLE]["owner_key"] == "AABBCC"
+        await hass.drain_tasks()
 
     asyncio.run(_exercise())

--- a/tests/test_sensor_subentry_setup.py
+++ b/tests/test_sensor_subentry_setup.py
@@ -108,6 +108,7 @@ async def test_setup_iterates_sensor_subentries(stub_coordinator_factory: Any) -
     assert configs == {service_subentry.subentry_id, tracker_subentry.subentry_id}
     assert {entity.unique_id for entity, _ in added} == {
         f"{DOMAIN}_{entry.entry_id}_{service_subentry.subentry_id}_semantic_labels",
+        f"{DOMAIN}_{entry.entry_id}_{service_subentry.subentry_id}_encryption_key_status",
         f"{DOMAIN}_{entry.entry_id}_{service_subentry.subentry_id}_background_updates",
         f"{DOMAIN}_{entry.entry_id}_{tracker_subentry.subentry_id}_device-1_last_seen",
     }
@@ -169,8 +170,10 @@ async def test_dispatcher_adds_new_tracker_subentries(
     configs = [config for _, config in added]
     assert configs.count(tracker_subentry.subentry_id) == 1
     assert configs.count(new_subentry.subentry_id) == 1
-    assert configs.count(service_subentry.subentry_id) == 2
-    assert len({entity.unique_id for entity, _ in added}) == 4
+    # Service scope now emits three diagnostic sensors: semantic_labels,
+    # encryption_key_status (AP-10) and the background_updates stat.
+    assert configs.count(service_subentry.subentry_id) == 3
+    assert len({entity.unique_id for entity, _ in added}) == 5
     assert entry._unload_callbacks, "dispatcher listener should be cleaned up on unload"
 
 
@@ -222,7 +225,9 @@ async def test_dispatcher_deduplicates_existing_subentry_signals(
     async_dispatcher_send(hass, signal, service_subentry.subentry_id)
     await asyncio.gather(*pending)
 
-    assert len(added) == initial_count == 3
+    # Four entities: service semantic_labels + encryption_key_status (AP-10) +
+    # background_updates stat, plus the tracker last_seen sensor.
+    assert len(added) == initial_count == 4
     assert {config for _, config in added} == {
         service_subentry.subentry_id,
         tracker_subentry.subentry_id,
@@ -273,6 +278,7 @@ async def test_hidden_tracker_sensors_skip_invisible_devices(
         f"{DOMAIN}_{entry.entry_id}_{tracker_subentry.subentry_id}_visible-device_last_seen",
         f"{DOMAIN}_{entry.entry_id}_service_background_updates",
         f"{DOMAIN}_{entry.entry_id}_service_semantic_labels",
+        f"{DOMAIN}_{entry.entry_id}_service_encryption_key_status",
     }
     config_by_unique_id = {entity.unique_id: config for entity, config in added}
     assert (

--- a/tests/test_spot_grpc_client.py
+++ b/tests/test_spot_grpc_client.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import grpclib.client as grpclib_client
 import grpclib.exceptions
@@ -382,7 +382,11 @@ def _prepare_coordinator(loop: asyncio.AbstractEventLoop) -> GoogleFindMyCoordin
     hass = _DummyHass(loop)
     coordinator = GoogleFindMyCoordinator(hass, cache=_DummyCacheProtocol())
     coordinator.config_entry = SimpleNamespace(
-        entry_id="entry-id", options={}, data={}, title="Test Entry"
+        entry_id="entry-id",
+        options={},
+        data={},
+        title="Test Entry",
+        async_start_reauth=Mock(),
     )
     coordinator._get_google_home_filter = lambda: None
     coordinator._is_fcm_ready_soft = lambda: True
@@ -409,7 +413,14 @@ def _prepare_coordinator(loop: asyncio.AbstractEventLoop) -> GoogleFindMyCoordin
 def test_poll_spot_auth_error_triggers_config_entry_auth_failed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """SpotAuthPermanentError should propagate as ConfigEntryAuthFailed in polling."""
+    """SpotAuthPermanentError in polling should start the entry reauth flow.
+
+    The poll cycle runs as a fire-and-forget task (``hass.async_create_task``), so a
+    raised ``ConfigEntryAuthFailed`` would never reach the awaited coordinator
+    refresh and HA's automatic reauth would never fire. The cycle therefore starts
+    the entry-scoped reauth flow directly and still records ``last_exception`` so
+    the ``finally`` block marks the update failed.
+    """
 
     loop = asyncio.new_event_loop()
     hass_coordinator = _prepare_coordinator(loop)
@@ -420,17 +431,19 @@ def test_poll_spot_auth_error_triggers_config_entry_auth_failed(
         AsyncMock(return_value=None),
     )
 
-    with pytest.raises(ConfigEntryAuthFailed):
-        try:
-            loop.run_until_complete(
-                hass_coordinator._async_start_poll_cycle(
-                    [{"id": "dev-1", "name": "Device"}], force=True
-                )
+    try:
+        loop.run_until_complete(
+            hass_coordinator._async_start_poll_cycle(
+                [{"id": "dev-1", "name": "Device"}], force=True
             )
-        finally:
-            drain_loop(loop)
-            loop.close()
+        )
+    finally:
+        drain_loop(loop)
+        loop.close()
 
+    hass_coordinator.config_entry.async_start_reauth.assert_called_once_with(
+        hass_coordinator.hass
+    )
     assert isinstance(hass_coordinator.last_exception, ConfigEntryAuthFailed)
 
 

--- a/tests/test_spot_grpc_resilience.py
+++ b/tests/test_spot_grpc_resilience.py
@@ -320,7 +320,13 @@ async def test_non_teardown_attribute_error_is_reraised(
 
 
 def test_polling_path_translates_auth_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    """SpotAuthPermanentError from the API should surface as ConfigEntryAuthFailed."""
+    """SpotAuthPermanentError from the API should start the entry reauth flow.
+
+    The poll cycle runs as a fire-and-forget task, so it starts the entry-scoped
+    reauth flow directly rather than raising (a raised ``ConfigEntryAuthFailed``
+    would never reach the awaited coordinator refresh). It still records
+    ``last_exception`` so the ``finally`` block marks the update failed.
+    """
 
     loop = asyncio.new_event_loop()
     hass_coordinator = _prepare_coordinator(loop)
@@ -331,19 +337,21 @@ def test_polling_path_translates_auth_error(monkeypatch: pytest.MonkeyPatch) -> 
         AsyncMock(return_value=None),
     )
 
-    with pytest.raises(ConfigEntryAuthFailed):
-        try:
-            loop.run_until_complete(
-                hass_coordinator._async_start_poll_cycle(
-                    [{"id": "dev-1", "name": "Device"}], force=True
-                )
+    try:
+        loop.run_until_complete(
+            hass_coordinator._async_start_poll_cycle(
+                [{"id": "dev-1", "name": "Device"}], force=True
             )
-        finally:
-            from tests.helpers import drain_loop
+        )
+    finally:
+        from tests.helpers import drain_loop
 
-            drain_loop(loop)
-            loop.close()
+        drain_loop(loop)
+        loop.close()
 
+    hass_coordinator.config_entry.async_start_reauth.assert_called_once_with(
+        hass_coordinator.hass
+    )
     assert isinstance(hass_coordinator.last_exception, ConfigEntryAuthFailed)
 
 


### PR DESCRIPTION
# Summary

This brings the `1.7.2` maintenance line into `1.7`. The headline change makes a previously silent failure mode self-healing: when the end-to-end encryption (E2EE) shared key is stale or incompatible, the integration now prompts for re-authentication instead of silently returning no locations. It also adds a new diagnostic sensor for encryption-key health and removes three sources of log noise.

- Type: ☑ fix ☑ feat ☐ refactor ☐ docs ☑ chore ☐ ci ☑ test ☐ perf
- Scope/Area: coordinator, config-flow, diagnostics, nova, decrypt, translations
- Linked issues: —

## Motivation

Several users with a stale or mismatched E2EE shared key could see their devices and ring them, but never received any location updates, and got **no** prompt to re-authenticate. The root cause (an `AES-GCM InvalidTag` on every decrypt) was swallowed across multiple layers, so the integration looked healthy while being effectively blind. On top of that, a single stray space pasted into `secrets.json` could break owner-key decryption, and transient network blips produced WARNING-level log spam even though the built-in retry recovered on its own.

---

## Change Log (human-readable)

### Added
- **New "Encryption Key Status" diagnostic sensor** (enum) on the per-entry service device. It exposes end-to-end decryption health as a third status axis alongside the existing Nova auth and FCM connection sensors, with states: `OK`, `Tracker key outdated`, `Missing (incomplete bundle)`, and `Invalid (re-authentication required)`. Available in all 10 shipped languages.

### Changed
- **Renamed the connectivity sensor display name to "FCM Connection Status"** (translations only). The entity key, `translation_key` and `unique_id` are unchanged, so this is **non-breaking**: existing entities, history and automations keep working.
- Integration version bumped from `1.7.1` to `1.7.2`. Storage/config-entry schema versions are intentionally untouched (no migration).

### Fixed
- **Stale/incompatible E2EE shared key now escalates to re-authentication.** After three consecutive account-wide decrypt-clean failures (with a 6-hour cooldown), the integration raises a reauth prompt instead of silently failing. The counter resets only on a fully decrypt-clean cycle, so a single healthy tracker cannot mask an account-wide stale key. The same logic also runs on the background FCM push path. A per-tracker outdated key is reported (it needs a re-pair, not a reauth) but does not trigger an account-wide reauth.
- **Typed decryption errors** (`SharedKeyMismatchError` / `SharedKeyMissingError`) so the actual root cause (wrong vs. missing shared key) is visible in the logs and drives the correct sensor state.
- **Pasted `secrets.json` whitespace is normalized.** Credential values (owner key, shared key, tokens) have all whitespace stripped (base64/hex/JWT never contain legitimate spaces, including line-wrapped pastes), while display names and emails keep their interior spaces. This is applied at every parse point and is idempotent. Users no longer have to hand-delete a stray space that broke owner-key decryption.
- **Reauth escalation no longer depends on process uptime.** A sentinel bug suppressed the very first reauth escalation on a freshly booted host; the first escalation now always fires regardless of how long the process has been running.
- **The "Encryption Key Status" sensor now heals from a successful background push.** Previously only a foreground poll cycle could clear the sensor's stale-key state, so on push-only setups with idle polling it could stay on `Invalid`/`Missing` even after decryption had recovered. A proven decrypt from a background FCM push (gated on a real location report) now clears the account-wide error states back to `OK`, while a per-tracker `Tracker key outdated` state is preserved (a single push has no cross-tracker view). The shared reauth-counter contract is unchanged.

### Diagnostics & Logging
- **Less log noise on transient network hiccups:** the first network-retry attempt in the Nova API path now logs at INFO; repeated failures escalate to WARNING, and full exhaustion still logs ERROR. This mirrors the tiered severity already used by the HTTP-status retry path.
- **Best-effort E2EE metadata lookup downgraded from WARNING to DEBUG.** This lookup only runs after a decryption has already failed and does not change the outcome; under a transient outage it previously produced dozens of non-actionable warnings.
- **Server-initiated FCM stream close downgraded from WARNING to INFO.** The FCM endpoint periodically rotates its long-lived stream; the worker stops cleanly and the supervisor reconnects automatically with backoff. This normal life-cycle event no longer shows up as a recurring false alarm in the log panel, consistent with the other clean worker-stop paths that already log at INFO.

### Security/Privacy
- README clarifies that `secrets.json` must be generated from the same public IP and Google account.
- A crypto audit (misuse and arithmetic axes) was run over five primitive files (`lskf_hasher`, `eid_generator`, `foreign_tracker_cryptor`, `decrypt_locations`, `cloud_key_decryptor`). It added hardening/coverage tests only; **no production crypto code was changed** by the audit.

### Compatibility
- **No breaking changes.** No schema migration. The connectivity sensor rename is display-name only (stable entity IDs).

---

## Tests
- ☑ `pytest -q` passes (all changes landed on `1.7.2` with green CI)
- ☑ New/updated unit/integration tests cover the change
- ☑ For bugfixes: minimal, mutation-checked regression tests are included (each fails without the fix and passes with it)
- Coverage targets:
  - ☑ `config_flow.py` remains 100%
  - ☑ Changed/new production lines are covered by behavior-asserting tests

### Expected areas
- ☑ **Config flow**: pasted-secret whitespace normalization at every parse point
- ☑ **Coordinator & availability**: per-cycle decrypt-failure counting; reauth escalation
- ☑ **Diagnostics**: new encryption-key status sensor (enum, redaction-safe)
- ☑ **Token cache**: defense-in-depth normalization at the cache-write choke point

---

## Risk & Rollback
- Risk level: ☑ low
- Rollback plan: revert this merge. No schema or entity-ID changes, so existing config entries and entity history remain consistent.

---

## Reviewer Notes
- The sensor rename is intentionally translations-only to stay non-breaking; `unique_id` and `translation_key` are unchanged.
- The reauth escalation is deliberately conservative (3 consecutive clean-cycle failures + 6h cooldown) to avoid prompting on a single transient blip.

