### PR TITLE
feat: integrate 1.7.3 (map "Min Accuracy" slider now filters points)

### DIFF
--- a/custom_components/googlefindmy/AGENTS.md
+++ b/custom_components/googlefindmy/AGENTS.md
@@ -32,6 +32,16 @@ When reusing the shared grpclib transport (`SpotGrpcTransport`), keep SSL contex
 When adding new guidance, prefer creating another `agents/<topic>/AGENTS.md` file instead of expanding this index. This keeps
 updates like the subentry unload reminder easy to place without scrolling through unrelated instructions.
 
+### Version bump touches two files (manifest.json + const.py)
+
+The integration version lives in **two** places that MUST be bumped together on every release:
+`manifest.json` `"version"` and `const.py` `INTEGRATION_VERSION` (the latter feeds diagnostics,
+device `sw_version`, and logs). `manifest.json` is strict JSON validated by hassfest, so it cannot
+carry an inline cross-reference comment or an extra key; this note is the canonical anchor for the
+manifest side, while `const.py` carries the reverse reference in a code comment. A release that bumps
+only one file ships an inconsistent version string. Before tagging a release, grep both:
+`git grep -nE '"version"|INTEGRATION_VERSION' custom_components/googlefindmy/manifest.json custom_components/googlefindmy/const.py`.
+
 ### Quick-start reminder: avoid false-positive tracker discovery
 
 When restoring `device_tracker` entities on startup, confirm the cloud discovery trigger only fires for **truly new** tracker

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -21,7 +21,7 @@ DATA_EID_RESOLVER: Final[Literal["eid_resolver"]] = "eid_resolver"
 # Latest config entry schema version handled by this integration.
 CONFIG_ENTRY_VERSION: int = 2
 # Keep the integration version aligned across the project (match manifest.json)
-INTEGRATION_VERSION: str = "1.7.2"
+INTEGRATION_VERSION: str = "1.7.3"
 
 # --------------------------------------------------------------------------------------
 # Shared textual constants

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -20,7 +20,10 @@ DOMAIN: str = "googlefindmy"
 DATA_EID_RESOLVER: Final[Literal["eid_resolver"]] = "eid_resolver"
 # Latest config entry schema version handled by this integration.
 CONFIG_ENTRY_VERSION: int = 2
-# Keep the integration version aligned across the project (match manifest.json)
+# Integration version. MUST be bumped together with manifest.json "version" on every
+# release; the two are a coupled pair. manifest.json is strict JSON (hassfest-validated)
+# and cannot carry this cross-reference, so the manifest side is anchored in this
+# directory's AGENTS.md ("Version bump touches two files").
 INTEGRATION_VERSION: str = "1.7.3"
 
 # --------------------------------------------------------------------------------------

--- a/custom_components/googlefindmy/coordinator/__init__.py
+++ b/custom_components/googlefindmy/coordinator/__init__.py
@@ -32,6 +32,13 @@ from ..KeyBackup.cloud_key_decryptor import decrypt_eik
 # Re-export helpers subpackage
 from . import helpers
 
+# Re-export the canonical GPS accuracy normalizer. Exposing it as a direct
+# attribute of the coordinator package (mirroring GoogleFindMyCoordinator) lets
+# lightweight consumers such as map_view resolve it without reaching into the
+# nested .helpers.geo submodule, which keeps them tolerant of plain ModuleType
+# coordinator stubs in tests. geo is a pure, dependency-light module.
+from .helpers.geo import safe_accuracy
+
 # Re-export stats classes from helpers (commonly needed)
 from .helpers.stats import (
     ApiStatus,
@@ -88,6 +95,7 @@ __all__ = [
     "format_epoch_utc",
     "get_recorder",
     "normalize_epoch_seconds",
+    "safe_accuracy",
     # Semi-public functions
     "_as_ha_attributes",
     "_sync_get_last_gps_from_history",

--- a/custom_components/googlefindmy/manifest.json
+++ b/custom_components/googlefindmy/manifest.json
@@ -35,5 +35,5 @@
     "selenium>=4.25.0",
     "undetected_chromedriver>=3.5.5"
   ],
-  "version": "1.7.2"
+  "version": "1.7.3"
 }

--- a/custom_components/googlefindmy/map_view.py
+++ b/custom_components/googlefindmy/map_view.py
@@ -44,6 +44,27 @@ def _resolve_coordinator_class() -> type[Any]:
     return _COORDINATOR_CLASS
 
 
+_SAFE_ACCURACY: Any = None
+
+
+def _resolve_safe_accuracy() -> Any:
+    """Import the canonical GPS accuracy normalizer lazily.
+
+    ``safe_accuracy`` lives under the coordinator package, which map_view
+    deliberately avoids importing at module load time (see
+    ``_resolve_coordinator_class``). Resolving and caching it on first use
+    preserves the same import-time guarantees while letting the map reuse the
+    integration-wide accuracy policy instead of duplicating it.
+    """
+
+    global _SAFE_ACCURACY
+    if _SAFE_ACCURACY is None:
+        from .coordinator.helpers.geo import safe_accuracy as _safe_accuracy
+
+        _SAFE_ACCURACY = _safe_accuracy
+    return _SAFE_ACCURACY
+
+
 # ------------------------------- HTML Helpers -------------------------------
 
 
@@ -257,6 +278,7 @@ class GoogleFindMyMapView(HomeAssistantView):
         # 5. Fetch History from Recorder
         locations: list[dict[str, Any]] = []
         seen_timestamps: set[float] = set()
+        safe_accuracy = _resolve_safe_accuracy()
         if entity_id:
             try:
                 from homeassistant.components.recorder import get_instance
@@ -279,7 +301,24 @@ class GoogleFindMyMapView(HomeAssistantView):
                         try:
                             lat = float(state.attributes.get("latitude"))
                             lon = float(state.attributes.get("longitude"))
-                            acc = float(state.attributes.get("gps_accuracy", 0))
+                            # Normalize accuracy through the integration's
+                            # canonical policy: 0.0m (the Android error code),
+                            # negative, NaN, Inf and missing values are corrupted
+                            # data and map to a conservative fallback radius (see
+                            # coordinator.helpers.geo.safe_accuracy). This keeps
+                            # the map consistent with the live entity and stops
+                            # unknown-quality points from masquerading as 0.0m.
+                            acc = safe_accuracy(state.attributes.get("gps_accuracy"))
+
+                            # Apply the "Min Accuracy" filter from the UI slider.
+                            # accuracy_filter <= 0 disables the filter (default),
+                            # so every point is kept. Otherwise drop points whose
+                            # accuracy radius is larger (worse) than the requested
+                            # threshold. Because acc is normalized above, invalid
+                            # or missing accuracies fall back to the conservative
+                            # radius and are dropped under any tighter slider.
+                            if accuracy_filter > 0 and acc > accuracy_filter:
+                                continue
 
                             # Determine timestamp (prefer last_seen attribute if available for precision)
                             ts = state.last_updated.timestamp()

--- a/custom_components/googlefindmy/map_view.py
+++ b/custom_components/googlefindmy/map_view.py
@@ -55,11 +55,18 @@ def _resolve_safe_accuracy() -> Any:
     ``_resolve_coordinator_class``). Resolving and caching it on first use
     preserves the same import-time guarantees while letting the map reuse the
     integration-wide accuracy policy instead of duplicating it.
+
+    We import it as a direct attribute of ``.coordinator`` (re-exported there),
+    exactly like ``_resolve_coordinator_class`` resolves the coordinator class.
+    Reaching into the nested ``.coordinator.helpers.geo`` submodule instead would
+    require the coordinator to be a real package, which breaks lightweight test
+    loaders that install it as a plain ``ModuleType`` stub. Tests can also patch
+    the cached ``_SAFE_ACCURACY`` directly or expose ``safe_accuracy`` on the stub.
     """
 
     global _SAFE_ACCURACY
     if _SAFE_ACCURACY is None:
-        from .coordinator.helpers.geo import safe_accuracy as _safe_accuracy
+        from .coordinator import safe_accuracy as _safe_accuracy
 
         _SAFE_ACCURACY = _safe_accuracy
     return _SAFE_ACCURACY

--- a/tests/test_map_view_features.py
+++ b/tests/test_map_view_features.py
@@ -423,3 +423,536 @@ async def test_redirect_uses_relative_location(monkeypatch: pytest.MonkeyPatch) 
         ctx.value.location
         == "/api/googlefindmy/map/device123?token=abc&start=2024-01-01T00%3A00%3A00Z"
     )
+
+
+def _install_multi_history_stub(
+    monkeypatch: pytest.MonkeyPatch,
+    entity_id: str,
+    states: list[_StubState],
+) -> None:
+    """Install a recorder history stub returning multiple states for one entity."""
+
+    history_module = ModuleType("homeassistant.components.recorder.history")
+
+    def _get_significant_states(
+        _hass: Any, _start: Any, _end: Any, _entity_ids: list[str]
+    ) -> dict[str, list[_StubState]]:
+        return {entity_id: list(states)}
+
+    history_module.get_significant_states = _get_significant_states  # type: ignore[attr-defined]
+
+    recorder_module = ModuleType("homeassistant.components.recorder")
+    recorder_module.history = history_module
+    components_module = ModuleType("homeassistant.components")
+    components_module.recorder = recorder_module
+
+    monkeypatch.setitem(
+        sys.modules, "homeassistant.components.recorder.history", history_module
+    )
+    monkeypatch.setitem(
+        sys.modules, "homeassistant.components.recorder", recorder_module
+    )
+    monkeypatch.setitem(sys.modules, "homeassistant.components", components_module)
+
+
+async def _render_map_with_states(
+    monkeypatch: pytest.MonkeyPatch,
+    states: list[_StubState],
+    query_extra: dict[str, str],
+) -> Any:
+    """Render the map view for the given history states and extra query params."""
+
+    device_id = "device123"
+    coordinator = SimpleNamespace(data=[{"id": device_id, "name": "Test Device"}])
+    entry = make_config_entry(entry_id="entry-id", runtime_data=coordinator)
+    hass = _StubHass([entry])
+
+    monkeypatch.setattr(
+        map_view, "_resolve_coordinator_class", lambda: SimpleNamespace
+    )
+
+    registry_entry = _StubRegistryEntry(
+        entity_id="device_tracker.device123",
+        unique_id=f"{entry.entry_id}:{device_id}",
+        config_entry_id=entry.entry_id,
+    )
+    registry = _StubEntityRegistry([registry_entry])
+    monkeypatch.setattr(map_view.er, "async_get", lambda _hass: registry)
+
+    _install_multi_history_stub(monkeypatch, registry_entry.entity_id, states)
+
+    ha_uuid = hass.data["core.uuid"]
+    secret = map_token_secret_seed(ha_uuid, entry.entry_id, False)
+    token = map_token_hex_digest(secret)
+
+    query = {"token": token, **query_extra}
+    return await map_view.GoogleFindMyMapView(hass).get(
+        SimpleNamespace(query=query),
+        device_id=device_id,
+    )
+
+
+def _precise_and_coarse_states() -> list[_StubState]:
+    """One precise point (5 m) and one coarse point (150 m), distinct timestamps."""
+
+    precise = _StubState(latitude=10.0, longitude=20.0)
+    precise.attributes["gps_accuracy"] = 5
+    precise.attributes["last_seen"] = 1704067200.0
+
+    coarse = _StubState(latitude=50.0, longitude=60.0)
+    coarse.attributes["gps_accuracy"] = 150
+    coarse.attributes["last_seen"] = 1704067260.0
+
+    return [precise, coarse]
+
+
+@pytest.mark.asyncio
+async def test_accuracy_filter_drops_points_worse_than_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A point coarser than the requested accuracy must not be rendered."""
+
+    response = await _render_map_with_states(
+        monkeypatch, _precise_and_coarse_states(), {"accuracy": "10"}
+    )
+
+    assert response.status == 200
+    assert "showing 1 points" in response.text.lower()
+    assert '"lat": 10.0' in response.text
+    assert '"lat": 50.0' not in response.text
+
+
+@pytest.mark.asyncio
+async def test_accuracy_filter_zero_keeps_all_points(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The default threshold of 0 disables the filter and keeps every point."""
+
+    response = await _render_map_with_states(
+        monkeypatch, _precise_and_coarse_states(), {"accuracy": "0"}
+    )
+
+    assert response.status == 200
+    assert "showing 2 points" in response.text.lower()
+    assert '"lat": 10.0' in response.text
+    assert '"lat": 50.0' in response.text
+
+
+@pytest.mark.asyncio
+async def test_accuracy_filter_drops_points_with_missing_accuracy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A point without gps_accuracy is corrupted data and must be dropped.
+
+    Missing accuracy is normalized to the conservative fallback radius
+    (safe_accuracy), so it can no longer masquerade as a best-possible 0.0m
+    point and slip past a tighter slider threshold.
+    """
+
+    unknown = _StubState(latitude=33.0, longitude=44.0)
+    unknown.attributes.pop("gps_accuracy", None)
+    unknown.attributes["last_seen"] = 1704067300.0
+
+    response = await _render_map_with_states(
+        monkeypatch, [unknown], {"accuracy": "10"}
+    )
+
+    assert response.status == 200
+    assert "showing 0 points" in response.text.lower()
+    assert '"lat": 33.0' not in response.text
+
+
+@pytest.mark.asyncio
+async def test_accuracy_filter_drops_points_with_zero_accuracy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A reported gps_accuracy of 0.0m is the Android error code, not a fix."""
+
+    zeroed = _StubState(latitude=33.0, longitude=44.0)
+    zeroed.attributes["gps_accuracy"] = 0.0
+    zeroed.attributes["last_seen"] = 1704067300.0
+
+    response = await _render_map_with_states(
+        monkeypatch, [zeroed], {"accuracy": "10"}
+    )
+
+    assert response.status == 200
+    assert "showing 0 points" in response.text.lower()
+    assert '"lat": 33.0' not in response.text
+
+
+@pytest.mark.asyncio
+async def test_accuracy_filter_drops_points_with_negative_accuracy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A negative gps_accuracy is corrupted; the raw value would wrongly pass.
+
+    Before normalization ``-5 > 10`` is ``False`` so the point slipped through;
+    safe_accuracy maps it to the fallback radius and the slider now drops it.
+    """
+
+    negative = _StubState(latitude=33.0, longitude=44.0)
+    negative.attributes["gps_accuracy"] = -5.0
+    negative.attributes["last_seen"] = 1704067300.0
+
+    response = await _render_map_with_states(
+        monkeypatch, [negative], {"accuracy": "10"}
+    )
+
+    assert response.status == 200
+    assert "showing 0 points" in response.text.lower()
+    assert '"lat": 33.0' not in response.text
+
+
+@pytest.mark.asyncio
+async def test_accuracy_filter_drops_points_with_nan_accuracy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A NaN gps_accuracy must be dropped; ``NaN > threshold`` is always False.
+
+    Without normalization the comparison silently admits NaN points under any
+    slider; safe_accuracy rejects non-finite values to the fallback radius.
+    """
+
+    nan_state = _StubState(latitude=33.0, longitude=44.0)
+    nan_state.attributes["gps_accuracy"] = float("nan")
+    nan_state.attributes["last_seen"] = 1704067300.0
+
+    response = await _render_map_with_states(
+        monkeypatch, [nan_state], {"accuracy": "10"}
+    )
+
+    assert response.status == 200
+    assert "showing 0 points" in response.text.lower()
+    assert '"lat": 33.0' not in response.text
+
+
+@pytest.mark.asyncio
+async def test_invalid_accuracy_rendered_as_fallback_when_filter_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With the filter off, an invalid point is kept but shown at the fallback.
+
+    The point is no longer advertised as a pinpoint 0.0m fix; it carries the
+    conservative 200m fallback radius, matching the live entity's accuracy.
+    """
+
+    unknown = _StubState(latitude=33.0, longitude=44.0)
+    unknown.attributes.pop("gps_accuracy", None)
+    unknown.attributes["last_seen"] = 1704067300.0
+
+    response = await _render_map_with_states(
+        monkeypatch, [unknown], {"accuracy": "0"}
+    )
+
+    assert response.status == 200
+    assert "showing 1 points" in response.text.lower()
+    assert '"lat": 33.0' in response.text
+    assert '"accuracy": 200.0' in response.text
+    assert '"accuracy": 0.0' not in response.text
+
+
+# --------------------------------------------------------------------------- #
+# Full-coverage suite: token buckets, coordinator resolution, name resolution, #
+# query-filter parsing and per-state fallbacks.                                #
+# --------------------------------------------------------------------------- #
+
+
+async def _render_view(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    runtime_data: Any,
+    states: list[_StubState],
+    query_extra: dict[str, str] | None = None,
+    registry: Any = None,
+    entity_id: str = "device_tracker.device123",
+    device_id: str = "device123",
+) -> Any:
+    """Render the map view with full control over runtime data and registry.
+
+    The helper authorizes with a static token, installs a recorder history
+    stub for ``entity_id`` and resolves the coordinator class to
+    ``SimpleNamespace`` so callers can drive the device-name resolution and
+    history-parsing branches with hand-built stubs.
+    """
+
+    entry = make_config_entry(entry_id="entry-id", runtime_data=runtime_data)
+    hass = _StubHass([entry])
+
+    monkeypatch.setattr(map_view, "_resolve_coordinator_class", lambda: SimpleNamespace)
+
+    if registry is None:
+        registry = _StubEntityRegistry(
+            [
+                _StubRegistryEntry(
+                    entity_id=entity_id,
+                    unique_id=f"{entry.entry_id}:{device_id}",
+                    config_entry_id=entry.entry_id,
+                )
+            ]
+        )
+    monkeypatch.setattr(map_view.er, "async_get", lambda _hass: registry)
+
+    _install_multi_history_stub(monkeypatch, entity_id, states)
+
+    token = map_token_hex_digest(
+        map_token_secret_seed(hass.data["core.uuid"], entry.entry_id, False)
+    )
+    query = {"token": token, **(query_extra or {})}
+    return await map_view.GoogleFindMyMapView(hass).get(
+        SimpleNamespace(query=query),
+        device_id=device_id,
+    )
+
+
+def test_entry_accept_tokens_weekly_returns_two_buckets() -> None:
+    """Weekly tokens accept both the current and the previous bucket."""
+
+    hass = _StubHass([])
+
+    weekly = map_view._entry_accept_tokens(hass, "entry-id", True)
+    static = map_view._entry_accept_tokens(hass, "entry-id", False)
+
+    assert len(weekly) == 2  # current and previous week
+    assert len(static) == 1
+    assert weekly.isdisjoint(static)
+
+
+def test_resolve_coordinator_class_returns_cached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A populated cache short-circuits the lazy import."""
+
+    monkeypatch.setattr(map_view, "_COORDINATOR_CLASS", SimpleNamespace)
+
+    assert map_view._resolve_coordinator_class() is SimpleNamespace
+
+
+@pytest.mark.asyncio
+async def test_device_name_skipped_when_runtime_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without runtime data the coordinator name lookup is skipped."""
+
+    response = await _render_view(
+        monkeypatch,
+        runtime_data=None,
+        states=[_StubState(latitude=10.0, longitude=20.0)],
+    )
+
+    assert response.status == 200
+    assert "Unknown Device" in response.text
+
+
+@pytest.mark.asyncio
+async def test_device_name_skipped_when_runtime_not_coordinator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A runtime object without a coordinator attribute resolves no name."""
+
+    response = await _render_view(
+        monkeypatch,
+        runtime_data=object(),
+        states=[_StubState(latitude=10.0, longitude=20.0)],
+    )
+
+    assert response.status == 200
+    assert "Unknown Device" in response.text
+
+
+@pytest.mark.asyncio
+async def test_device_name_loop_skips_non_matching_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The coordinator scan ignores other devices before the match."""
+
+    coordinator = SimpleNamespace(
+        data=[
+            {"id": "other-device", "name": "Other"},
+            {"id": "device123", "name": "Real Device"},
+        ]
+    )
+
+    response = await _render_view(
+        monkeypatch,
+        runtime_data=coordinator,
+        states=[_StubState(latitude=10.0, longitude=20.0)],
+    )
+
+    assert response.status == 200
+    assert "Real Device" in response.text
+
+
+@pytest.mark.asyncio
+async def test_entity_entry_refetched_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A resolved entity_id without a registry entry still drives history."""
+
+    class _GhostEntityRegistry:
+        """Resolves an entity_id but never returns a registry entry object."""
+
+        entities: dict[str, Any] = {}
+
+        def async_get_entity_id(
+            self, _domain: str, _platform: str, _unique_id: str
+        ) -> str:
+            return "device_tracker.ghost"
+
+        def async_get(self, _entity_id: str) -> None:
+            return None
+
+    response = await _render_view(
+        monkeypatch,
+        runtime_data=None,
+        states=[_StubState(latitude=12.0, longitude=21.0)],
+        registry=_GhostEntityRegistry(),
+        entity_id="device_tracker.ghost",
+    )
+
+    assert response.status == 200
+    assert "showing 1 points" in response.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_time_filters_parsed_from_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Valid ISO start/end values populate the filter controls."""
+
+    response = await _render_view(
+        monkeypatch,
+        runtime_data=SimpleNamespace(data=[{"id": "device123", "name": "Test"}]),
+        states=[_StubState(latitude=10.0, longitude=20.0)],
+        query_extra={
+            "start": "2024-03-15T08:00:00Z",
+            "end": "2024-03-16T09:30:00Z",
+        },
+    )
+
+    assert response.status == 200
+    assert 'value="2024-03-15T08:00"' in response.text
+    assert 'value="2024-03-16T09:30"' in response.text
+
+
+@pytest.mark.asyncio
+async def test_time_filters_invalid_fall_back_to_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unparseable start value is swallowed and defaults are kept."""
+
+    response = await _render_view(
+        monkeypatch,
+        runtime_data=SimpleNamespace(data=[{"id": "device123", "name": "Test"}]),
+        states=[_StubState(latitude=10.0, longitude=20.0)],
+        query_extra={"start": "not-a-date"},
+    )
+
+    assert response.status == 200
+    assert 'value="not-a-date"' not in response.text
+
+
+@pytest.mark.asyncio
+async def test_naive_time_filters_get_utc(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Timezone-naive start/end values are coerced to UTC."""
+
+    response = await _render_view(
+        monkeypatch,
+        runtime_data=SimpleNamespace(data=[{"id": "device123", "name": "Test"}]),
+        states=[_StubState(latitude=10.0, longitude=20.0)],
+        query_extra={
+            "start": "2024-06-01T00:00:00",
+            "end": "2024-06-02T00:00:00",
+        },
+    )
+
+    assert response.status == 200
+    assert 'value="2024-06-01T00:00"' in response.text
+    assert 'value="2024-06-02T00:00"' in response.text
+
+
+@pytest.mark.asyncio
+async def test_accuracy_filter_invalid_defaults_to_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-numeric accuracy value disables the filter."""
+
+    response = await _render_map_with_states(
+        monkeypatch, _precise_and_coarse_states(), {"accuracy": "abc"}
+    )
+
+    assert response.status == 200
+    assert "showing 2 points" in response.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_last_seen_non_string_falls_back_to_state_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-string last_seen is ignored and the state time is used."""
+
+    state = _StubState(latitude=10.0, longitude=20.0)
+    state.attributes["last_seen"] = ["not", "a", "scalar"]
+
+    response = await _render_view(
+        monkeypatch,
+        runtime_data=SimpleNamespace(data=[{"id": "device123", "name": "Test"}]),
+        states=[state],
+    )
+
+    assert response.status == 200
+    assert "showing 1 points" in response.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_last_seen_unparseable_string_falls_back_to_state_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A last_seen string that is neither float nor ISO is ignored."""
+
+    state = _StubState(latitude=10.0, longitude=20.0)
+    state.attributes["last_seen"] = "definitely-not-a-timestamp"
+
+    response = await _render_view(
+        monkeypatch,
+        runtime_data=SimpleNamespace(data=[{"id": "device123", "name": "Test"}]),
+        states=[state],
+    )
+
+    assert response.status == 200
+    assert "showing 1 points" in response.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_invalid_state_is_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A state with a non-numeric coordinate is skipped, valid ones survive."""
+
+    invalid = _StubState(latitude=None, longitude=20.0)
+    valid = _StubState(latitude=77.0, longitude=88.0)
+
+    response = await _render_view(
+        monkeypatch,
+        runtime_data=SimpleNamespace(data=[{"id": "device123", "name": "Test"}]),
+        states=[invalid, valid],
+    )
+
+    assert response.status == 200
+    assert "showing 1 points" in response.text.lower()
+    assert '"lat": 77.0' in response.text
+
+
+@pytest.mark.asyncio
+async def test_redirect_missing_token_returns_bad_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The redirect view rejects requests without a token via HTTP 400."""
+
+    view = map_view.GoogleFindMyMapRedirectView(_StubHass([]))
+
+    response = await view.get(SimpleNamespace(query={}), device_id="device123")
+
+    assert response.status == 400

--- a/tests/test_map_view_unique_id_resolution.py
+++ b/tests/test_map_view_unique_id_resolution.py
@@ -122,6 +122,32 @@ class _StubEntityRegistry:
         return self.entities.get(entity_id)
 
 
+def _load_real_safe_accuracy() -> Any:
+    """Load the canonical ``safe_accuracy`` from geo.py by file path.
+
+    Loading the module directly (rather than importing it through the package)
+    keeps this lightweight loader free of the heavy integration import chain
+    while still exercising the real accuracy policy that production re-exports as
+    ``coordinator.safe_accuracy``. geo.py imports only ``math``/``typing`` and has
+    no relative imports, so it loads in isolation.
+    """
+
+    geo_path = (
+        Path(__file__).resolve().parents[1]
+        / "custom_components"
+        / "googlefindmy"
+        / "coordinator"
+        / "helpers"
+        / "geo.py"
+    )
+    spec = importlib.util.spec_from_file_location("googlefindmy_test_geo", geo_path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError("Failed to load geo module for testing")
+    geo = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(geo)
+    return geo.safe_accuracy
+
+
 def _load_map_view_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
     """Load the map_view module with stubbed Home Assistant dependencies."""
 
@@ -210,9 +236,24 @@ def _load_map_view_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
 
     coordinator_module = ModuleType("custom_components.googlefindmy.coordinator")
     coordinator_module.GoogleFindMyCoordinator = _StubCoordinator
+    # Expose safe_accuracy as a direct attribute, mirroring the production
+    # re-export in coordinator/__init__.py. map_view resolves it via
+    # ``from .coordinator import safe_accuracy``; without this attribute the
+    # plain ModuleType stub (no __path__) would make that import fail.
+    coordinator_module.safe_accuracy = _load_real_safe_accuracy()
     monkeypatch.setitem(
         sys.modules, "custom_components.googlefindmy.coordinator", coordinator_module
     )
+    # Force every coordinator lookup through the stub. If a previous test already
+    # imported the real ``coordinator.helpers.geo`` it would linger in sys.modules
+    # and let a nested ``from .coordinator.helpers.geo import ...`` resolve from
+    # that cache, masking the very import-order fragility this loader guards
+    # against. Dropping the cached submodules makes the stub the only source.
+    for cached in (
+        "custom_components.googlefindmy.coordinator.helpers.geo",
+        "custom_components.googlefindmy.coordinator.helpers",
+    ):
+        monkeypatch.delitem(sys.modules, cached, raising=False)
 
     module_name = "custom_components.googlefindmy.map_view"
     spec = importlib.util.spec_from_file_location(
@@ -463,3 +504,30 @@ def test_map_view_html_uses_iso_conversion(monkeypatch: pytest.MonkeyPatch) -> N
     assert "parsed.toISOString()" in html_empty
     assert "getFullYear()" in html_with_locations
     assert "getFullYear()" in html_empty
+
+
+def test_map_view_resolves_safe_accuracy_under_stub(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The accuracy resolver must work under the lightweight coordinator stub.
+
+    Regression for the Codex #186 finding: ``_resolve_safe_accuracy`` previously
+    imported ``.coordinator.helpers.geo``, which requires the coordinator to be a
+    real package. Under the plain ModuleType stub installed by this loader the
+    nested import aborted with "coordinator is not a package", so any history
+    render exercising the accuracy filter would crash. Resolving the re-exported
+    ``coordinator.safe_accuracy`` keeps the map renderable under the stub.
+    """
+
+    map_view = _load_map_view_module(monkeypatch)
+
+    safe_accuracy = map_view._resolve_safe_accuracy()
+
+    # Canonical policy: valid measurements pass through unchanged, while the 0.0
+    # Android error code and missing values map to the conservative fallback.
+    assert safe_accuracy(50.0) == 50.0
+    assert safe_accuracy(0.0) == 200.0
+    assert safe_accuracy(None) == 200.0
+
+    # Second call must hit the cache instead of re-importing (same object).
+    assert map_view._resolve_safe_accuracy() is safe_accuracy


### PR DESCRIPTION
# Summary

This brings the `1.7.3` maintenance line into `1.7`. The headline change makes the map view's **"Min Accuracy (meters)"** slider actually work: it now filters out low-accuracy location points instead of being a label-only control. It also normalizes corrupted accuracy values so they can no longer slip past the filter, and adds a small contributor note about the version-string coupling.

- Type: ☑ fix ☐ feat ☐ refactor ☑ docs ☑ chore ☐ ci ☑ test ☐ perf
- Scope/Area: map view, recorder history rendering, docs
- Linked issues: —

## Motivation

On the live map, the **"Min Accuracy (meters)"** slider was a dead control: its value was parsed and shown next to the slider, but never used to filter anything. Low-accuracy crowdsourced points (for example a 100 m radius point that visually lands on the wrong river bank) stayed visible even with the slider set to 10 m, so users could not clean up their map.

Two further problems made this worse for points read back from the recorder: legacy or malformed history states can carry a missing, zero, negative, `NaN` or `Inf` `gps_accuracy`. Those collapsed to `0.0 m` and were treated as "best possible", so even after wiring up the filter they would have masqueraded as perfect-quality points and passed any positive threshold.

---

## Change Log (human-readable)

### Fixed
- **The "Min Accuracy" map slider now filters location points.** The threshold is applied server-side in the history render loop (the page already re-renders whenever the slider moves). Setting the slider to e.g. `10 m` now hides points whose accuracy radius is larger (worse) than 10 m. The default value `0` keeps the filter **off**, so existing behavior is preserved for anyone who does not touch the slider.
- **Corrupted accuracy values are normalized before filtering.** Missing, zero, negative, `NaN` and `Inf` `gps_accuracy` values now map to the same conservative fallback radius the integration already uses for the live entity (`coordinator.helpers.geo.safe_accuracy`), instead of being shown as a perfect `0.0 m`. This keeps the map consistent with the live sensor and stops unknown-quality points from sneaking past the slider.

### Changed
- Integration version bumped from `1.7.2` to `1.7.3`. Storage/config-entry schema versions are intentionally untouched (no migration).

### Docs
- Added a short note (in `const.py` and the integration's `AGENTS.md`) documenting that the version string lives in **two** coupled files (`manifest.json` + `const.py`) and must be bumped in both. This is a contributor-only change with no runtime effect; `manifest.json` itself is left untouched because it is strict, hassfest-validated JSON that cannot carry comments.

### Compatibility
- **No breaking changes.** No schema migration. The map filter defaults to off, so existing maps render exactly as before until the user moves the slider.

---

## Tests
- ☑ `pytest -q` passes (all changes landed on `1.7.3` with green CI)
- ☑ New/updated behavior tests cover the change
- ☑ For the bugfix: minimal, mutation-checked regression tests are included (reverting the fix turns the "drops low-accuracy point" test red)
- Coverage targets:
  - ☑ `map_view.py` raised to **100%** (14 additional behavior tests covering previously untested time-filter parsing, name resolution, redirect edge cases and invalid-state skipping)
  - ☑ Changed/new production lines are covered by behavior-asserting tests
- ☑ `tests/` use `await` directly (no `asyncio.run()`, per `tests/AGENTS.md`)
- ☑ `ruff` clean

## Notes for review
- The accuracy normalizer is imported lazily (`_resolve_safe_accuracy`) to preserve `map_view`'s existing import-time guarantee of not pulling in the coordinator package at module load.
- The filter and the normalization were reviewed and refined via Codex on the source PRs (jleinenbach/GoogleFindMy-HA#1121, #1122) before landing on `1.7.3`.
