### PR TITLE
feat: contribute 1.7.7 → 1.7.8 (standalone CLI first-run setup, clearer key-setup errors, --debug flag, reliable first FCM locate)

### DIFF
--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -276,6 +276,19 @@ _MAX_CONSECUTIVE_SHORT_RUNS = 10
 _SHORT_RUN_THRESHOLD_S = (
     30.0  # strictly < 30s between pc.start() and STOPPED = short run
 )
+# First-locate delivery reconnect (AP1): a brand-new MCS session can reach
+# ``STARTED`` yet never receive the very first locate push (``STARTED`` is
+# necessary but not sufficient for delivery; third of the #1148/#1149 family).
+# Only a full reconnect — a fresh session that subscribes *after* registration
+# completes — heals it.  This window bounds "how young a session still counts as
+# freshly registered / churning" for that one-shot decision.  It is deliberately
+# NOT the activity-health freshness window (``_activity_stale_after_s`` /
+# ``FCM_IDLE_RESET_AFTER_S`` = 90s, idle-reset semantics): it feeds no health
+# snapshot and no coordinator state, so it does not violate the Auth/AGENTS.md
+# "reuse the health helper, do not add parallel health windows" rule (whose
+# rationale is diagnostics/coordinator-state consistency, untouched here).
+_CHURN_WINDOW_S = 15.0
+
 _HTTP_UNAUTHORIZED = 401
 _HTTP_NOT_FOUND = 404
 
@@ -412,6 +425,22 @@ class FcmReceiverHA:
         self._activity_stale_after_s: float = float(FCM_IDLE_RESET_AFTER_S)
         self._entry_health: dict[str, bool] = {}
         self._entry_last_connected_wall: dict[str, float] = {}
+
+        # One-shot first-locate reconnect (#1150) serialization. Concurrent
+        # manual locates for different trackers on the *same* entry both enter
+        # the fresh/no-delivery reconnect branch; without coordination the
+        # second caller tears down the replacement client the first caller just
+        # waited for, so the first request hands its token to a listener that is
+        # already gone and times out (Codex #1150 follow-up). A per-entry lock
+        # serialises the decision and ``_first_locate_reconnect_done`` records
+        # the replacement we already reconnected to (by identity), so a
+        # concurrent or sequential second caller reuses it instead of forcing
+        # another reconnect. A genuinely new session generation (a different
+        # client object) is still allowed exactly one fresh reconnect. Not the
+        # global ``self._lock``: the reconnect awaits the supervisor rebuild,
+        # which itself takes ``self._lock``, so reusing it would deadlock.
+        self._first_locate_locks: dict[str, asyncio.Lock] = {}
+        self._first_locate_reconnect_done: dict[str, FcmPushClient[Any]] = {}
 
         # Active background tasks for exception tracking (P0 fix)
         self._active_tasks: set[asyncio.Task[Any]] = set()
@@ -1218,11 +1247,8 @@ class FcmReceiverHA:
                     _on_creds_updated_entry,
                 )
                 pc = _FcmPushClientFactory(
-                    lambda payload,
-                    persistent_id,
-                    context,
-                    eid=entry_id: self._on_notification(
-                        eid, payload, persistent_id, context
+                    lambda payload, persistent_id, context, eid=entry_id: (
+                        self._on_notification(eid, payload, persistent_id, context)
                     ),
                     fcm_config,
                     creds,
@@ -3182,8 +3208,13 @@ class FcmReceiverHA:
                 )
         self.creds[entry_id] = normalized if isinstance(normalized, dict) else None
 
-        # Update token routing from fresh creds if possible
-        token = self.get_fcm_token(entry_id)
+        # Update token routing from fresh creds if possible.  Read strictly
+        # entry-scoped: the creds for this entry were just written above, so
+        # ``get_fcm_token``'s cross-entry fallback could only route a *foreign*
+        # account's token under this entry when the update is tokenless -- the
+        # same leak class as the forced first-locate reconnect refresh (Codex
+        # #1150 follow-ups).  A tokenless update must route nothing here.
+        token = self._entry_scoped_fcm_token(entry_id)
         if token:
             self._update_token_routing(token, {entry_id})
             self._dispatch_to_hass_loop(
@@ -3425,6 +3456,11 @@ class FcmReceiverHA:
     def _purge_entry_tokens(self, entry_id: str) -> None:
         """Remove all routing references and per-entry runtime state for an entry."""
         self._entry_last_activity_monotonic.pop(entry_id, None)
+        # First-locate reconnect serialization state (#1150 follow-up): drop the
+        # per-entry lock and the consumed-replacement record so a later reload
+        # under the same entry_id starts from a clean slate.
+        self._first_locate_locks.pop(entry_id, None)
+        self._first_locate_reconnect_done.pop(entry_id, None)
         # AP1 (finding 2a): fatal retry counters are only cleared on the success
         # path (registration ok), so they leak per teardown without this.
         self._fatal_retry_counts.pop(f"{entry_id}:auth", None)
@@ -3461,6 +3497,33 @@ class FcmReceiverHA:
 
     # -------------------- Public token accessor --------------------
 
+    def _entry_scoped_fcm_token(self, entry_id: str) -> str | None:
+        """Return the FCM token that belongs strictly to ``entry_id``.
+
+        Reads the entry's persisted creds first, then the live client's
+        credentials.  Unlike :meth:`get_fcm_token`, this never falls back to
+        another entry's token, so a caller that requires per-entry correctness
+        (the forced first-locate reconnect in a multi-account setup) can fail
+        closed instead of routing a foreign account's token to the wrong entry.
+        """
+        creds = self.creds.get(entry_id)
+        if isinstance(creds, dict):
+            tok = (creds.get("fcm") or {}).get("registration", {}).get("token")
+            if isinstance(tok, str) and tok:
+                return tok
+        # Also try the current client's live creds if present
+        pc = self.pcs.get(entry_id)
+        if pc:
+            try:
+                c = getattr(pc, "credentials", None)
+                if isinstance(c, dict):
+                    tok = (c.get("fcm") or {}).get("registration", {}).get("token")
+                    if isinstance(tok, str) and tok:
+                        return tok
+            except Exception:
+                pass
+        return None
+
     def get_fcm_token(self, entry_id: str | None = None) -> str | None:
         """Return current FCM token (best-effort).
 
@@ -3471,22 +3534,9 @@ class FcmReceiverHA:
         target_entry = entry_id if entry_id is not None else self._default_entry_id
 
         if target_entry:
-            creds = self.creds.get(target_entry)
-            if isinstance(creds, dict):
-                tok = (creds.get("fcm") or {}).get("registration", {}).get("token")
-                if isinstance(tok, str) and tok:
-                    return tok
-            # Also try the current client's live creds if present
-            pc = self.pcs.get(target_entry)
-            if pc:
-                try:
-                    c = getattr(pc, "credentials", None)
-                    if isinstance(c, dict):
-                        tok = (c.get("fcm") or {}).get("registration", {}).get("token")
-                        if isinstance(tok, str) and tok:
-                            return tok
-                except Exception:
-                    pass
+            scoped = self._entry_scoped_fcm_token(target_entry)
+            if scoped:
+                return scoped
         # Fallback: first available token across entries
         for c in self.creds.values():
             if isinstance(c, dict):
@@ -3580,6 +3630,242 @@ class FcmReceiverHA:
 
         return self.get_fcm_token(entry_id)
 
+    async def _await_entry_started(
+        self,
+        entry_id: str,
+        fallback_pc: FcmPushClient[Any],
+        max_wait_s: float,
+        *,
+        exclude_pc: FcmPushClient[Any] | None = None,
+    ) -> FcmPushClient[Any] | None:
+        """Poll the live entry client until it reaches ``STARTED``.
+
+        Returns the ``STARTED`` client, or ``None`` if the budget expires.
+
+        Re-reads ``self.pcs[entry_id]`` on every poll (falling back to
+        ``fallback_pc`` only while the slot is momentarily empty) so a concurrent
+        supervisor restart that stops the captured client and swaps a replacement
+        into the slot is honored — the stale object may never transition while
+        the replacement reaches ``STARTED``.
+
+        ``exclude_pc`` (used after a forced reconnect) requires a *different*
+        instance to count, so a stale client that still lingers in ``STARTED`` is
+        not mistaken for the fresh replacement.
+        """
+        _POLL_INTERVAL_S = 0.3
+        waited = 0.0
+        while waited < max_wait_s:
+            current_pc = self.pcs.get(entry_id, fallback_pc)
+            if self._is_started(current_pc) and (
+                exclude_pc is None or current_pc is not exclude_pc
+            ):
+                return current_pc
+            await asyncio.sleep(_POLL_INTERVAL_S)
+            waited += _POLL_INTERVAL_S
+        return None
+
+    def _is_started(self, pc: FcmPushClient[Any]) -> bool:
+        """True if *pc* is currently in the ``STARTED`` run state.
+
+        Single definition of "listening" shared by the readiness poll and the
+        first-locate reconnect short-circuits, so both fail closed on a client
+        that is not actually STARTED (e.g. a fresh, not-yet-started replacement
+        a concurrent supervisor swapped in).
+        """
+        if FcmPushClientRunState is None:
+            return False
+        return bool(getattr(pc, "run_state", None) == FcmPushClientRunState.STARTED)
+
+    def _session_age_s(self, pc: FcmPushClient[Any]) -> float | None:
+        """Age (seconds) since this client's STARTED transition, or ``None``.
+
+        Anchored on the client's own ``_started_monotonic`` — stamped where the
+        library assigns ``run_state = STARTED`` — not the supervisor's
+        ``last_start_monotonic``, which is recorded *before* ``pc.start()`` and
+        before the listener reaches STARTED.  The readiness gate deliberately
+        allows a fresh MCS connection ~15-20s to reach STARTED; measuring the
+        churn window from the supervisor start would let a slow-but-fresh session
+        age past ``_CHURN_WINDOW_S`` before its first STARTED observation and skip
+        the very reconnect this heals (Codex #1150 follow-up).  Being per-client,
+        it is also exact under Home Assistant multi-entry — no aggregate blur.
+
+        Returns ``None`` until the client has reached STARTED at least once; the
+        manual-locate caller only consults this for an already-STARTED client, so
+        ``None`` there means "library without a STARTED stamp" and fails safe (no
+        reconnect).
+        """
+        started: float | None = getattr(pc, "_started_monotonic", None)
+        if started is None:
+            return None
+        return max(time.monotonic() - started, 0.0)
+
+    def _needs_first_locate_reconnect(self, pc: FcmPushClient[Any]) -> bool:
+        """True if a fresh, not-yet-delivering session should reconnect once.
+
+        Trigger (T-A + per-entry sharpening): the session is *young*
+        (STARTED age < ``_CHURN_WINDOW_S``, measured from this client's own
+        STARTED transition) **and** this client has not delivered any data
+        message since login.  Delivery is read from the library's
+        ``persistent_ids`` list, which is reset to ``[]`` on each successful
+        login and appended to only for a ``DataMessageStanza`` — so a non-empty
+        list is a clean "has delivered" proof.  It deliberately does *not* use
+        the activity clock (``last_message_time`` / ``_entry_last_activity_
+        monotonic``), which a bare heartbeat ack also advances and which would
+        therefore never separate a broken fresh session (heartbeats, zero data)
+        from a healthy one.  A healthy, already-delivering session (e.g. a
+        long-running HA entry) is thus never torn down, independent of the
+        session age.
+        """
+        age = self._session_age_s(pc)
+        if age is None or age >= _CHURN_WINDOW_S:
+            return False
+        delivered = bool(getattr(pc, "persistent_ids", None))
+        return not delivered
+
+    async def _force_first_locate_reconnect(
+        self, entry_id: str, stale_pc: FcmPushClient[Any], max_wait_s: float
+    ) -> FcmPushClient[Any] | None:
+        """Force one cooperative reconnect for a fresh, not-yet-delivering session.
+
+        Stops ``stale_pc``, nudges the supervisor to rebuild immediately, and
+        waits (``max_wait_s`` budget) for the *replacement* instance to reach
+        STARTED.  Returns the fresh client, or ``None`` if it never starts (the
+        caller then fails closed, exactly like the readiness gate).  The
+        supervisor owns the rebuild, so no new race surface is introduced against
+        it.  Part of the first-locate-delivery fix (#1148/#1149 family): STARTED
+        is necessary but not sufficient for the first push to arrive.
+        """
+        session_age = self._session_age_s(stale_pc)
+        _LOGGER.debug(
+            "[entry=%s] Fresh FCM session (age=%.1fs) reached STARTED but has not "
+            "delivered a data message yet; forcing one reconnect before the first "
+            "locate",
+            entry_id,
+            session_age if session_age is not None else -1.0,
+        )
+        try:
+            await stale_pc.stop()
+        except Exception as err:  # noqa: BLE001
+            # A stop() failure on an already-dying client is benign; the
+            # supervisor rebuild is driven by the nudge below.
+            _LOGGER.debug(
+                "[entry=%s] Forced-reconnect stop() raised (ignored): %s",
+                entry_id,
+                err,
+            )
+        self.nudge_retry(entry_id)
+        return await self._await_entry_started(
+            entry_id, stale_pc, max_wait_s, exclude_pc=stale_pc
+        )
+
+    def _get_first_locate_lock(self, entry_id: str) -> asyncio.Lock:
+        """Return the per-entry first-locate reconnect lock, creating it lazily.
+
+        Runs in the event loop with no ``await`` between the read and the
+        store, so the lazy creation is atomic against other callers.
+        """
+        lock = self._first_locate_locks.get(entry_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._first_locate_locks[entry_id] = lock
+        return lock
+
+    async def _reconnect_for_first_locate(
+        self, entry_id: str, max_wait_s: float
+    ) -> FcmPushClient[Any] | None:
+        """Serialise the one-shot first-locate reconnect for *entry_id*.
+
+        Concurrent manual locates for different trackers on the same entry must
+        not each tear down the fresh session (Codex #1150 follow-up): only the
+        first caller forces the single cooperative reconnect, and concurrent or
+        sequential callers await it and reuse the same replacement. The live
+        client is re-read under the per-entry lock because a concurrent caller
+        may already have replaced it. Returns the client to hand the locate to,
+        or ``None`` when no started client is available (the caller then fails
+        closed exactly like the readiness gate).
+        """
+        async with self._get_first_locate_lock(entry_id):
+            current = self.pcs.get(entry_id)
+            if current is None:
+                # The supervisor tore the client down; fail closed.
+                return None
+            reuse_current = (
+                # This exact replacement already had its one forced reconnect
+                # (a concurrent caller won the race), ...
+                self._first_locate_reconnect_done.get(entry_id) is current
+                # ... or another caller's reconnect already delivered / the
+                # session is no longer a fresh, undelivered one.
+                or not self._needs_first_locate_reconnect(current)
+            )
+            if reuse_current:
+                # Reuse the live client instead of forcing another reconnect,
+                # but only if it is actually STARTED. A concurrent supervisor
+                # swap may have installed a fresh, not-yet-started client here
+                # between the branch pre-check and this lock; handing the locate
+                # token to a non-listening client would reproduce the very
+                # timeout this heals, so fail closed like the readiness gate.
+                return current if self._is_started(current) else None
+            fresh_pc = await self._force_first_locate_reconnect(
+                entry_id, current, max_wait_s
+            )
+            if fresh_pc is not None:
+                self._first_locate_reconnect_done[entry_id] = fresh_pc
+            return fresh_pc
+
+    async def _reconnect_and_refresh_token(
+        self, entry_id: str, previous_token: str, max_wait_s: float
+    ) -> str | None:
+        """Force the first-locate reconnect, then return the *live* entry token.
+
+        Fails closed (returns ``None``) when the replacement never reaches
+        STARTED, or when the entry has no FCM token after the reconnect.
+
+        The reconnect nudges a supervisor rebuild that may run a full
+        re-registration (``checkin_or_register`` / ``reregister_keeping_identity``)
+        and rotate the entry's FCM token after the caller captured
+        ``previous_token``.  Returning the stale token would send the locate to
+        the old registration while the live listener is subscribed with the new
+        one, reproducing the very timeout this fix heals (Codex #1150 follow-up).
+        Routing is re-pointed at the refreshed token only when it actually
+        rotated; the stale mapping for a dead registration is benign (it receives
+        no pushes) and is not eagerly purged here.
+
+        The refreshed token is read strictly entry-scoped
+        (:meth:`_entry_scoped_fcm_token`, not :meth:`get_fcm_token`): in a
+        multi-account setup ``get_fcm_token``'s cross-entry fallback could return
+        another account's token when this entry is momentarily tokenless after the
+        rebuild, which would route a foreign token for this entry.  Failing closed
+        is correct there (Codex #1150 follow-up).
+        """
+        fresh_pc = await self._reconnect_for_first_locate(entry_id, max_wait_s)
+        if fresh_pc is None:
+            _LOGGER.warning(
+                "[entry=%s] Forced reconnect did not reach STARTED after %.1fs; "
+                "aborting manual locate registration (fail-closed)",
+                entry_id,
+                max_wait_s,
+            )
+            return None
+
+        refreshed = self._entry_scoped_fcm_token(entry_id)
+        if not refreshed:
+            _LOGGER.warning(
+                "[entry=%s] FCM token unavailable after forced reconnect; "
+                "aborting manual locate registration (fail-closed)",
+                entry_id,
+            )
+            return None
+
+        if refreshed != previous_token:
+            _LOGGER.debug(
+                "[entry=%s] FCM token rotated during forced first-locate "
+                "reconnect; using the refreshed token for the locate",
+                entry_id,
+            )
+            self._update_token_routing(refreshed, {entry_id})
+            await self._persist_routing_token(entry_id, refreshed)
+        return refreshed
+
     async def async_register_for_location_updates(
         self, canonic_id: str, callback: Callable[[str, str], None]
     ) -> str | None:
@@ -3649,27 +3935,10 @@ class FcmReceiverHA:
                     int(FCM_CONNECTION_RETRY_COUNT) * _PER_ATTEMPT_WAIT_S
                     + _READY_WAIT_MARGIN_S
                 )
-                _POLL_INTERVAL_S = 0.3
-                waited = 0.0
-                while waited < _MAX_READY_WAIT_S:
-                    # Re-read the live entry client each iteration.  A concurrent
-                    # supervisor restart can stop the captured ``pc`` and swap a
-                    # replacement into ``self.pcs[entry_id]`` on a transient
-                    # pre-start connection/login failure; that replacement may
-                    # reach STARTED while the stale object never does.  Polling
-                    # the current client (falling back to ``pc`` only while the
-                    # slot is momentarily empty) avoids a false fail-closed that
-                    # would abort a locate the replacement client could serve.
-                    current_pc = self.pcs.get(entry_id, pc)
-                    run_state = getattr(current_pc, "run_state", None)
-                    if (
-                        FcmPushClientRunState is not None
-                        and run_state == FcmPushClientRunState.STARTED
-                    ):
-                        break
-                    await asyncio.sleep(_POLL_INTERVAL_S)
-                    waited += _POLL_INTERVAL_S
-                else:
+                started_pc = await self._await_entry_started(
+                    entry_id, pc, _MAX_READY_WAIT_S
+                )
+                if started_pc is None:
                     # Fail closed: the client never started listening, so sending
                     # the location request would hand the token to a dead listener
                     # and the caller would block until an opaque 30s timeout.
@@ -3684,6 +3953,20 @@ class FcmReceiverHA:
                         _MAX_READY_WAIT_S,
                     )
                     token = None
+                elif self._needs_first_locate_reconnect(started_pc):
+                    # AP1 (first-locate-delivery fix): a fresh, not-yet-delivering
+                    # session reached STARTED but empirically will not receive the
+                    # very first locate push until it reconnects.  Force exactly
+                    # one cooperative reconnect (serialised per entry so concurrent
+                    # locates on the same entry share one replacement instead of
+                    # tearing down each other's fresh session), then re-read the
+                    # token: the reconnect's supervisor rebuild may re-register and
+                    # rotate the entry's FCM token after it was captured above.
+                    # Fail closed if the replacement never starts or the token
+                    # vanished (Codex #1150 follow-ups).
+                    token = await self._reconnect_and_refresh_token(
+                        entry_id, token, _MAX_READY_WAIT_S
+                    )
 
             if token is not None:
                 _LOGGER.info(

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -3634,11 +3634,34 @@ class FcmReceiverHA:
             # Google may arrive before the MCS connection is established.
             pc = self.pcs.get(entry_id)
             if pc is not None:
-                _MAX_READY_WAIT_S = 15.0
+                # Derive the readiness budget from the library's connection-retry
+                # count instead of a fixed 15.0s.  A brand-new FCM identity's
+                # first MCS connect can take the full retry budget
+                # (FCM_CONNECTION_RETRY_COUNT attempts, ~15-20s per the note near
+                # _listen()); a hard-coded 15.0s under-covered that window and let
+                # the gate expire before STARTED on the very first run.  Adding a
+                # small margin keeps a fresh registration from being abandoned
+                # prematurely, which is the root of the deterministic first-run
+                # locate timeout.
+                _PER_ATTEMPT_WAIT_S = 4.0
+                _READY_WAIT_MARGIN_S = 2.0
+                _MAX_READY_WAIT_S = (
+                    int(FCM_CONNECTION_RETRY_COUNT) * _PER_ATTEMPT_WAIT_S
+                    + _READY_WAIT_MARGIN_S
+                )
                 _POLL_INTERVAL_S = 0.3
                 waited = 0.0
                 while waited < _MAX_READY_WAIT_S:
-                    run_state = getattr(pc, "run_state", None)
+                    # Re-read the live entry client each iteration.  A concurrent
+                    # supervisor restart can stop the captured ``pc`` and swap a
+                    # replacement into ``self.pcs[entry_id]`` on a transient
+                    # pre-start connection/login failure; that replacement may
+                    # reach STARTED while the stale object never does.  Polling
+                    # the current client (falling back to ``pc`` only while the
+                    # slot is momentarily empty) avoids a false fail-closed that
+                    # would abort a locate the replacement client could serve.
+                    current_pc = self.pcs.get(entry_id, pc)
+                    run_state = getattr(current_pc, "run_state", None)
                     if (
                         FcmPushClientRunState is not None
                         and run_state == FcmPushClientRunState.STARTED
@@ -3647,18 +3670,27 @@ class FcmReceiverHA:
                     await asyncio.sleep(_POLL_INTERVAL_S)
                     waited += _POLL_INTERVAL_S
                 else:
+                    # Fail closed: the client never started listening, so sending
+                    # the location request would hand the token to a dead listener
+                    # and the caller would block until an opaque 30s timeout.
+                    # Clearing the local token means the function returns None (the
+                    # sole caller, location_request.py, then reports a clear error
+                    # and returns early) and the finally block pops the manual-
+                    # locate callback so no stale registration leaks.
                     _LOGGER.warning(
                         "[entry=%s] FCM client not in STARTED state after %.1fs; "
-                        "location request may time out",
+                        "aborting manual locate registration (fail-closed)",
                         entry_id,
                         _MAX_READY_WAIT_S,
                     )
+                    token = None
 
-            _LOGGER.info(
-                "[entry=%s] Manual locate registration ready for %s",
-                entry_id,
-                canonic_id[:8],
-            )
+            if token is not None:
+                _LOGGER.info(
+                    "[entry=%s] Manual locate registration ready for %s",
+                    entry_id,
+                    canonic_id[:8],
+                )
             return token
         finally:
             if not token:

--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
@@ -396,7 +396,12 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
     # protobuf varint32 helpers
     async def _read_varint32(self) -> int:
         reader = self.reader
-        assert reader is not None, "StreamReader is not initialized"
+        if reader is None:
+            # Same class as the ``_send_msg`` writer guard: a read on a
+            # torn-down stream is a normal connection life-cycle event, not an
+            # invariant violation. Surface it as a ConnectionError the listener
+            # already handles gracefully rather than an "Unknown error" trace.
+            raise ConnectionError("StreamReader is not initialized")
         res = 0
         shift = 0
         while True:
@@ -434,13 +439,26 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
         self._log_verbose("Sending packet to server: %s", self._msg_str(msg))
         buf = FcmPushClient._make_packet(msg, self.first_message)
         writer = self.writer
-        assert writer is not None, "StreamWriter is not initialized"
+        if writer is None:
+            # A send on a torn-down stream is a normal connection life-cycle
+            # event, not a programming-invariant violation: e.g. an in-flight
+            # heartbeat ack racing a concurrent stop()/teardown that already
+            # nulled ``self.writer`` in ``_do_writer_close``. Raise a
+            # ConnectionError so the listener's connection-error handling stops
+            # the worker cleanly, instead of an ``assert`` whose AssertionError
+            # falls through to the generic arm and surfaces as an alarming
+            # "Unknown error in listener" traceback for a benign shutdown.
+            raise ConnectionError("StreamWriter is not initialized")
         writer.write(buf)
         await writer.drain()
 
     async def _receive_msg(self) -> MessageProto | None:
         reader = self.reader
-        assert reader is not None, "StreamReader is not initialized"
+        if reader is None:
+            # Same class as the ``_send_msg`` writer guard (see there): a torn-
+            # down stream is a normal life-cycle event; raise ConnectionError so
+            # the listener stops cleanly instead of logging an "Unknown error".
+            raise ConnectionError("StreamReader is not initialized")
 
         if self.first_message:
             r = await reader.readexactly(2)

--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
@@ -306,6 +306,13 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
         self.last_message_time: float = 0.0
 
         self.run_state: FcmPushClientRunState = FcmPushClientRunState.CREATED
+        # Monotonic timestamp of this client's STARTED transition (set in
+        # ``_handle_message`` on a successful login, alongside ``persistent_ids``).
+        # Consumers measure "session age since STARTED" from this instead of the
+        # supervisor's pre-start timestamp, which is recorded before ``start()``
+        # and can trail the actual STARTED transition by the connection budget
+        # (~15-20s). ``None`` until the client first reaches STARTED.
+        self._started_monotonic: float | None = None
         self.tasks: list[asyncio.Task[None]] = []
         # Set by ``_listen`` when stored FCM key material is found to be
         # corrupt/undecodable. The supervisor reads this after the listener
@@ -829,6 +836,10 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
             else:
                 self.logger.info("Successfully logged in to MCS endpoint")
                 self._reset_error_count(ErrorType.LOGIN)
+                # Stamp the STARTED-transition time *before* publishing the
+                # STARTED state so any observer that sees STARTED also sees the
+                # timestamp (single authoritative transition point, race-free).
+                self._started_monotonic = time.monotonic()
                 self.run_state = FcmPushClientRunState.STARTED
                 self.persistent_ids = []
                 # Refresh activity timestamp

--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmregister.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmregister.py
@@ -94,6 +94,23 @@ class FcmRegisterHTTPError(RuntimeError):
 _FATAL_HTTP_STATUSES = (HTTPStatus.UNAUTHORIZED, HTTPStatus.NOT_FOUND)
 
 
+class FcmCheckinTransientError(RuntimeError):
+    """Raised when GCM check-in exhausts its retry budget on pure network errors.
+
+    Distinguishes a *transient* transport failure (DNS timeout, connection
+    reset — the endpoint was never reached at the HTTP layer) from an
+    authoritative empty/non-OK response. Returning ``None`` for both cases made
+    callers treat a temporary network outage as an invalid identity and rotate a
+    working android_id/key material via a full ``register()``. By raising a
+    distinct ``RuntimeError`` subclass instead, callers preserve the device
+    identity and let the supervisor retry later, mirroring the
+    ``FcmRegisterHTTPError`` split for fatal HTTP statuses. Inherits from
+    ``RuntimeError`` so the supervisor's existing transient/retry classification
+    (``isinstance(err, (TimeoutError, RuntimeError))``) applies without a
+    dedicated branch.
+    """
+
+
 _SHA1_HEX_LENGTH = 40
 
 
@@ -298,6 +315,11 @@ class FcmRegister:
 
         max_attempts = 8
         content: bytes | None = None
+        # Distinguish a pure transport-layer exhaustion (the endpoint was never
+        # reached at the HTTP layer) from an authoritative empty/non-OK
+        # response, so callers can preserve identity on transient outages.
+        saw_http_response = False
+        last_transient_exc: Exception | None = None
 
         for attempt in range(1, max_attempts + 1):
             try:
@@ -308,6 +330,14 @@ class FcmRegister:
                     timeout=self.CLIENT_TIMEOUT,
                 ) as resp:
                     status = resp.status
+                    # Reached the endpoint at the HTTP layer: any later
+                    # exhaustion is authoritative, not a transport outage, so we
+                    # defer to the register() fallback rather than raising a
+                    # transient. Deliberately conservative: a mid-body read
+                    # failure after a 200 status line is also treated as
+                    # authoritative (errs toward re-register, never toward
+                    # blocking a genuinely revoked identity).
+                    saw_http_response = True
                     if status == HTTPStatus.OK:
                         content = await resp.read()
                         break
@@ -337,6 +367,7 @@ class FcmRegister:
                 # into the generic transient-retry loop below.
                 raise
             except Exception as e:
+                last_transient_exc = e
                 _logger.warning(
                     "GCM check-in error (attempt %d/%d) at url=%s: %s",
                     attempt,
@@ -352,6 +383,21 @@ class FcmRegister:
                 await asyncio.sleep(delay)
 
         if not content:
+            if not saw_http_response and last_transient_exc is not None:
+                # Pure transport failure (e.g. DNS timeout): the endpoint was
+                # never reached, so the existing identity is almost certainly
+                # still valid. Surface as transient so callers keep it instead
+                # of rotating android_id/keys via a full register().
+                _logger.error(
+                    "Unable to check-in to GCM after %d attempts (url=%s): "
+                    "transient network failure, preserving identity",
+                    max_attempts,
+                    GCM_CHECKIN_URL,
+                )
+                raise FcmCheckinTransientError(
+                    "GCM check-in exhausted after "
+                    f"{max_attempts} transient network failures"
+                ) from last_transient_exc
             _logger.error(
                 "Unable to check-in to GCM after %d attempts (url=%s)",
                 max_attempts,
@@ -888,6 +934,12 @@ class FcmRegister:
                 )
                 if gcm_response:
                     return self.credentials
+            except FcmCheckinTransientError:
+                # Transport-level check-in outage (e.g. DNS timeout): the
+                # existing identity is almost certainly still valid. Propagate
+                # so the supervisor retries later instead of discarding a
+                # working android_id/keys via a full register().
+                raise
             except Exception as e:
                 _logger.warning(
                     "Existing credentials check-in failed; re-registering",
@@ -937,6 +989,11 @@ class FcmRegister:
         # Step 1: Check-in with existing device identity
         try:
             gcm_response = await self.gcm_check_in(android_id, security_token)
+        except FcmCheckinTransientError:
+            # Transport-level check-in outage (e.g. DNS timeout): keep the
+            # existing GCM identity and let the supervisor retry later, rather
+            # than rotating a working android_id/keys via a full register().
+            raise
         except Exception as e:
             _logger.debug("Check-in exception detail", exc_info=e)
             return await self._fallback_full_register(

--- a/custom_components/googlefindmy/NovaApi/ListDevices/nbe_list_devices.py
+++ b/custom_components/googlefindmy/NovaApi/ListDevices/nbe_list_devices.py
@@ -279,9 +279,15 @@ async def _async_cli_main(
         entry_id: Optional config entry ID to scope the CLI session.
         session: Optional shared aiohttp session to avoid ephemeral per-request sessions.
     """
-    cache, namespace = _resolve_cli_cache(
-        entry_id or os.environ.get("GOOGLEFINDMY_ENTRY_ID")
-    )
+    # ``entry_id`` is the single source of truth when the caller supplied one.
+    # Use ``is not None`` (not ``or``) so an explicit empty string -- the
+    # documented "use the sole default cache" selector that ``--entry ""`` sets
+    # to defeat ``GOOGLEFINDMY_ENTRY_ID`` -- is honoured verbatim instead of
+    # silently falling through to the env var (which would then look up an
+    # unregistered id and raise "Unknown entry_id"). The env fallback only
+    # applies when the caller passed nothing at all (``None``).
+    hint = entry_id if entry_id is not None else os.environ.get("GOOGLEFINDMY_ENTRY_ID")
+    cache, namespace = _resolve_cli_cache(hint)
 
     print("Loading...")
     result_hex = await async_request_device_list(
@@ -401,7 +407,9 @@ if __name__ == "__main__":
     # for testing or manual device registration.
     try:
         args = _parse_cli_args()
-        entry_hint = args.entry or os.environ.get("GOOGLEFINDMY_ENTRY_ID")
-        asyncio.run(_async_cli_main(entry_hint))
+        # Forward the raw --entry value (None when unset). _async_cli_main is
+        # the single resolver: it applies the GOOGLEFINDMY_ENTRY_ID fallback
+        # only for None, so an explicit --entry "" is honoured here too.
+        asyncio.run(_async_cli_main(args.entry))
     except KeyboardInterrupt:
         print("\nExiting.")

--- a/custom_components/googlefindmy/chrome_driver.py
+++ b/custom_components/googlefindmy/chrome_driver.py
@@ -87,11 +87,66 @@ def _load_uc() -> Any:
 _UC_CACHE = SimpleNamespace(module=None)
 
 
+def _neutralize_uc_finalizer(module: Any) -> None:
+    """Silence undetected_chromedriver's ``Chrome.__del__`` re-quit noise.
+
+    uc's ``Chrome.__del__`` calls ``self.quit()`` during garbage collection.
+    After our own ``safe_quit_driver`` has already torn the driver down, that GC
+    re-quit raises ``OSError [WinError 6] (The handle is invalid)`` on Windows —
+    pure teardown noise that alarms users reading the log.
+
+    We do NOT replace ``__del__`` with a no-op: that would also disable uc's
+    cleanup of a *partially constructed* driver.  When ``uc.Chrome(...)`` raises
+    after the browser already launched (e.g. a Chrome/driver version mismatch),
+    the strategy helpers in this module never receive a ``driver`` object, so
+    their ``_quit_driver(driver)`` is a no-op and uc's own ``__del__`` is the
+    only thing that would kill the orphaned browser process and remove its temp
+    profile.  uc's ``weakref.finalize(self._ensure_close)`` reaper only kills the
+    chromedriver *service* process, not the browser or the temp dir, so a no-op
+    would leak both until interpreter exit.
+
+    Instead we wrap the original ``__del__`` so its cleanup still runs but any
+    exception it raises is swallowed.  This kills the redundant-quit noise
+    without weakening cleanup on failed constructions.
+
+    Idempotent and guarded: only a real ``Chrome`` class that still defines its
+    own ``__del__`` is wrapped (the import-failure stub and an already-wrapped
+    module are skipped; a uc release without its own ``__del__`` is left
+    untouched rather than having one fabricated).
+    """
+    chrome = getattr(module, "Chrome", None)
+    if not isinstance(chrome, type):
+        return  # import stub (SimpleNamespace with a function), nothing to wrap
+    if getattr(chrome, "_gfmy_del_neutralized", False):
+        return  # already wrapped in this process
+    if "__del__" not in chrome.__dict__:
+        return  # no own __del__ to wrap; do not fabricate one
+
+    original_del = chrome.__dict__["__del__"]
+
+    def _quiet_del(self: Any) -> None:
+        # Preserve uc's cleanup (service + browser process + temp profile) for
+        # failed constructions; only swallow the redundant-quit error it raises
+        # after our safe_quit_driver has already torn the driver down.
+        with contextlib.suppress(Exception):
+            original_del(self)
+
+    # ``chrome`` is narrowed to ``type`` by the isinstance guard above, which
+    # mypy treats as having no assignable ``__del__``/marker attributes. Assign
+    # through an ``Any`` alias so the dynamic class patch stays type-clean
+    # without resorting to ``setattr`` (which ruff B010 would flag).
+    chrome_cls: Any = chrome
+    chrome_cls.__del__ = _quiet_del
+    chrome_cls._gfmy_del_neutralized = True
+
+
 def _get_uc_module() -> Any:
     """Lazily import and cache ``undetected_chromedriver``."""
 
     if _UC_CACHE.module is None:
-        _UC_CACHE.module = cast(Any, _load_uc())
+        module = cast(Any, _load_uc())
+        _neutralize_uc_finalizer(module)
+        _UC_CACHE.module = module
 
     return _UC_CACHE.module
 

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -26,7 +26,7 @@ CONFIG_ENTRY_VERSION: int = 2
 # cross-reference, so the manifest side is anchored in this directory's AGENTS.md
 # ("Version bump touches three files"). pyproject.toml carries the reverse reference
 # in a TOML comment.
-INTEGRATION_VERSION: str = "1.7.7"
+INTEGRATION_VERSION: str = "1.7.8"
 
 # --------------------------------------------------------------------------------------
 # Shared textual constants

--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -10,16 +10,18 @@ Usage:
 
 Flags:
     --reauth   Force re-authentication by clearing cached tokens and running the
-               Chrome login flow.  Only active in standalone mode (flat directory
-               layout); in repo/HA layout the flag is currently a no-op and emits
-               a stderr warning.
+               Chrome login flow.  Honored in any directory layout; it always
+               forces a fresh token bootstrap.
     --entry    Target config entry ID.  Required when secrets.json contains caches
                for multiple HA config entries.  May also be set via the
                ``GOOGLEFINDMY_ENTRY_ID`` environment variable.
 
-The module selects between two code paths via ``_standalone``:
-    * standalone (flat directory):  runs the full token-bootstrap pipeline.
-    * non-standalone (HA repo layout): delegates to ``nbe_list_devices._async_cli_main``.
+Run as a script, the module always runs the full token-bootstrap pipeline and
+writes ``secrets.json``, regardless of flat vs. repo directory layout.  When a
+usable cache already exists, ``_ensure_authenticated`` returns early so no Chrome
+login is launched; ``--reauth`` forces a fresh login.  ``_standalone`` only
+governs packaging (virtual package vs. real package), which is the one thing the
+directory name legitimately determines.
 """
 
 import os
@@ -794,13 +796,52 @@ def _resolve_effective_entry_id(cli_entry: str | None, env_entry: str | None) ->
     return ""
 
 
+async def _run_cli_bootstrap(file_cache: object, entry_id: str | None) -> None:
+    """Run the standalone token bootstrap, then hand off to the interactive CLI.
+
+    A single aiohttp session is shared across the whole flow and managed by
+    ``async with`` so it is closed deterministically on *every* exit path,
+    including the ``sys.exit(1)`` that ``_ensure_vault_keys`` raises on a fatal
+    shared-key failure: ``__aexit__`` runs for ``BaseException`` (``SystemExit``,
+    ``KeyboardInterrupt``) too.  Previously the session was created before the
+    ``try`` and closed only in a ``finally``, so any ``sys.exit`` from the eager
+    key-retrieval steps leaked it, producing 'Unclosed client session' warnings
+    and the WinError-6 teardown noise on Windows.
+
+    Extracted from the ``__main__`` block so the session lifecycle is testable
+    without spawning a subprocess (mirrors ``_resolve_effective_entry_id``).
+    """
+    import contextlib  # noqa: PLC0415
+
+    import aiohttp  # noqa: PLC0415
+
+    from custom_components.googlefindmy.NovaApi.ListDevices.nbe_list_devices import (  # noqa: PLC0415
+        _async_cli_main,
+    )
+
+    async with aiohttp.ClientSession(
+        connector=aiohttp.TCPConnector(limit=16, enable_cleanup_closed=True)
+    ) as session:
+        # Exchange the single-use OAuth cookie for an AAS master token BEFORE
+        # opening Chrome again for the shared key flow.  The OAuth cookie has a
+        # very short TTL and is invalidated once a new Chrome session is opened,
+        # so the exchange must happen immediately.
+        await _ensure_aas_token(file_cache)
+        # Eagerly obtain both vault keys (shared + owner); a vault failure exits
+        # cleanly without deleting the durable AAS/oauth tokens.
+        await _ensure_vault_keys(file_cache)
+        await _clear_stale_adm_token(file_cache)
+        fcm = await _setup_fcm_receiver(file_cache)
+        try:
+            await _async_cli_main(entry_id=entry_id, session=session)
+        finally:
+            with contextlib.suppress(Exception):
+                await fcm.async_stop()
+
+
 if __name__ == "__main__":
     import argparse  # noqa: PLC0415
     import asyncio  # noqa: PLC0415
-
-    from custom_components.googlefindmy.NovaApi.ListDevices.nbe_list_devices import (  # noqa: E402, PLC0415
-        _async_cli_main,
-    )
 
     _cli_parser = argparse.ArgumentParser(description="Google Find My Device CLI")
     _cli_parser.add_argument(
@@ -818,59 +859,29 @@ if __name__ == "__main__":
     )
     _cli_args = _cli_parser.parse_args()
 
-    if _standalone:
-        if _cli_args.reauth:
-            _clear_stale_tokens_for_reauth()
-        _ensure_authenticated()
-        # Resolve the effective entry id (CLI > env > ""). Without this,
-        # _async_cli_main forwards a non-empty hint that _resolve_cli_cache
-        # would reject as "Unknown entry_id" because the cache was only
-        # registered under "".  Codex review on 694f6883aa.
-        _effective_entry_id = _resolve_effective_entry_id(
-            _cli_args.entry, os.environ.get("GOOGLEFINDMY_ENTRY_ID")
-        )
-        _file_cache = _register_file_cache(_effective_entry_id)
+    # Always run the token-bootstrap pipeline, regardless of flat vs. repo
+    # directory layout.  When a usable cache already exists, _ensure_authenticated
+    # returns early so no Chrome login is launched; --reauth forces a fresh login.
+    # This replaces the earlier branch gates (first the _standalone directory name,
+    # then a cache-signal check that was always empty for a fresh shell start),
+    # both of which could dead-end a repo-layout start in an opaque
+    # MissingTokenCacheError instead of bootstrapping.
+    if _cli_args.reauth:
+        _clear_stale_tokens_for_reauth()
+    _ensure_authenticated()
+    # Resolve the effective entry id once (CLI > env > "") and use the SAME
+    # value for both registration and hand-off, so the registry key and the
+    # lookup hint can never diverge.  Forwarding the raw _cli_args.entry instead
+    # would re-trigger _async_cli_main's env fallback for an explicit
+    # --entry "" (empty string is falsy), making _resolve_cli_cache reject the
+    # env value as "Unknown entry_id" although the cache was registered under
+    # "".  Codex reviews on 694f6883aa and 17669c7ff2.
+    _effective_entry_id = _resolve_effective_entry_id(
+        _cli_args.entry, os.environ.get("GOOGLEFINDMY_ENTRY_ID")
+    )
+    _file_cache = _register_file_cache(_effective_entry_id)
 
-        async def _cli_main() -> None:
-            import aiohttp  # noqa: PLC0415
-
-            session = aiohttp.ClientSession(
-                connector=aiohttp.TCPConnector(limit=16, enable_cleanup_closed=True)
-            )
-            # Exchange the single-use OAuth cookie for an AAS master token
-            # BEFORE opening Chrome again for the shared key flow.  The OAuth
-            # cookie has a very short TTL and is invalidated once a new Chrome
-            # session is opened, so the exchange must happen immediately.
-            await _ensure_aas_token(_file_cache)
-            # Eagerly obtain both vault keys (shared + owner); a vault failure
-            # exits cleanly without deleting the durable AAS/oauth tokens.
-            await _ensure_vault_keys(_file_cache)
-            await _clear_stale_adm_token(_file_cache)
-            fcm = await _setup_fcm_receiver(_file_cache)
-            try:
-                await _async_cli_main(entry_id=_cli_args.entry, session=session)
-            finally:
-                with __import__("contextlib").suppress(Exception):
-                    await fcm.async_stop()
-                await session.close()
-
-        try:
-            asyncio.run(_cli_main())
-        except KeyboardInterrupt:
-            print("\nExiting.")
-    else:
-        # Repo/HA layout: --reauth is a standalone-only feature (see module
-        # docstring).  Warn explicitly instead of silently ignoring the flag.
-        if _cli_args.reauth:
-            print(
-                "warning: --reauth is only honored in standalone mode; ignoring.",
-                file=sys.stderr,
-            )
-        # Bypass list_devices() so we can forward --entry into _async_cli_main.
-        # list_devices() is a deliberately minimal upstream-API wrapper that
-        # takes no entry_id argument; extending its signature would change a
-        # public helper for a CLI-local concern.
-        try:
-            asyncio.run(_async_cli_main(_cli_args.entry))
-        except KeyboardInterrupt:
-            print("\nExiting.")
+    try:
+        asyncio.run(_run_cli_bootstrap(_file_cache, _effective_entry_id))
+    except KeyboardInterrupt:
+        print("\nExiting.")

--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -588,33 +588,56 @@ async def _ensure_owner_key(cache: object) -> None:
 
 
 async def _ensure_vault_keys(cache: object) -> None:
-    """Eagerly obtain both vault keys, exiting cleanly on any vault failure.
+    """Eagerly obtain the vault keys with a per-key criticality boundary.
 
-    Wraps the eager shared-key and owner-key retrieval at the CLI terminal
-    point. The vault/login step can fail in several ways (``RuntimeError`` from
-    ``shared_key_retrieval``, ``ValueError`` from hex/base64 decoding, or
-    ``ConfigEntryAuthFailed`` from the SPOT auth path); rather than surfacing a
-    raw traceback, this prints an actionable message and exits with status 1.
-    ``except Exception`` deliberately does *not* catch ``KeyboardInterrupt``
-    (a ``BaseException``), so a user-initiated abort still propagates.
+    The two eager retrievals have opposite criticality contracts, so each gets
+    its own error boundary instead of a single shared ``try`` that flattens both
+    to "all or nothing":
+
+    * **Shared key** (``_ensure_shared_key``) is *essential* and browser/login
+      bound. Failure here is fatal: there is no usable bundle without it, so we
+      print an actionable sign-in hint and exit with status 1.
+    * **Owner key** (``_ensure_owner_key``) is *optional* and non-interactive (a
+      SPOT API call plus a decrypt, no browser). The runtime re-derives it
+      lazily on first use (``decrypt_locations``/``eid_resolver`` call
+      ``async_get_owner_key`` with a ``force_refresh`` fallback), so a failure
+      here still leaves a usable ``secrets.json``. We warn and continue rather
+      than aborting the whole run.
+
+    Both blocks catch only ``Exception``; ``KeyboardInterrupt`` (a
+    ``BaseException``) still propagates so a user-initiated abort is honoured.
 
     No tokens are deleted on failure: the AAS/oauth tokens are durable by design
     (``_FileCache._SOFT_INVALIDATE_KEYS``); removing them would force an
     expensive full OAuth login on the next run.
     """
+    # Shared key: essential and browser-bound. Failure is fatal.
     try:
         await _ensure_shared_key(cache)
-        await _ensure_owner_key(cache)
     except Exception:  # noqa: BLE001
         print(
             "\nError: vault key retrieval failed.\n"
-            "Could not obtain the encryption keys from Google's vault.\n"
+            "Could not obtain the encryption key from Google's vault.\n"
             "\n"
             "Please re-run the tool and complete the Google sign-in when the "
             "browser opens.\n",
             file=sys.stderr,
         )
         sys.exit(1)
+
+    # Owner key: optional and non-interactive. The runtime re-derives it lazily,
+    # so a failure here is non-fatal -- warn and keep the usable secrets.json.
+    try:
+        await _ensure_owner_key(cache)
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"\nNote: the owner key could not be pre-fetched "
+            f"({type(exc).__name__}).\n"
+            "This is non-fatal: the shared key alone is sufficient for the Home "
+            "Assistant integration, and the owner key is fetched automatically "
+            "on first use. The generated secrets.json is ready to use.\n",
+            file=sys.stderr,
+        )
 
 
 async def _clear_stale_adm_token(cache: object) -> None:

--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -5,8 +5,8 @@
 """Standalone CLI entry point for GoogleFindMy functionality.
 
 Usage:
-    python -m custom_components.googlefindmy.main [--reauth] [--entry ENTRY_ID]
-    python custom_components/googlefindmy/main.py [--reauth] [--entry ENTRY_ID]
+    python -m custom_components.googlefindmy.main [--reauth] [--entry ENTRY_ID] [--debug]
+    python custom_components/googlefindmy/main.py [--reauth] [--entry ENTRY_ID] [--debug]
 
 Flags:
     --reauth   Force re-authentication by clearing cached tokens and running the
@@ -15,6 +15,10 @@ Flags:
     --entry    Target config entry ID.  Required when secrets.json contains caches
                for multiple HA config entries.  May also be set via the
                ``GOOGLEFINDMY_ENTRY_ID`` environment variable.
+    --debug    Enable verbose DEBUG logging for the bootstrap and FCM flow.  The
+               package configures no logging otherwise, so bootstrap/FCM diagnostics
+               are invisible without this flag.  May also be enabled via the
+               ``GOOGLEFINDMY_DEBUG`` environment variable.
 
 Run as a script, the module always runs the full token-bootstrap pipeline and
 writes ``secrets.json``, regardless of flat vs. repo directory layout.  When a
@@ -24,11 +28,17 @@ governs packaging (virtual package vs. real package), which is the one thing the
 directory name legitimately determines.
 """
 
+from __future__ import annotations
+
 import os
 import sys
 import types
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - import-time typing block
+    import argparse
+    from collections.abc import Mapping, Sequence
 
 _this_dir = Path(__file__).resolve().parent
 _standalone = not (
@@ -168,7 +178,7 @@ else:
                 fullname: str,
                 path: object,
                 target: object = None,
-            ) -> "importlib.machinery.ModuleSpec | None":
+            ) -> importlib.machinery.ModuleSpec | None:
                 if (
                     fullname == "homeassistant" or fullname.startswith("homeassistant.")
                 ) and fullname not in sys.modules:
@@ -839,17 +849,21 @@ async def _run_cli_bootstrap(file_cache: object, entry_id: str | None) -> None:
                 await fcm.async_stop()
 
 
-if __name__ == "__main__":
-    import argparse  # noqa: PLC0415
-    import asyncio  # noqa: PLC0415
+def _build_cli_parser() -> argparse.ArgumentParser:
+    """Build the standalone CLI argument parser.
 
-    _cli_parser = argparse.ArgumentParser(description="Google Find My Device CLI")
-    _cli_parser.add_argument(
+    Extracted from the ``__main__`` block so the flag surface (and therefore the
+    ``--help`` output) is unit-testable without spawning a subprocess.
+    """
+    import argparse  # noqa: PLC0415
+
+    parser = argparse.ArgumentParser(description="Google Find My Device CLI")
+    parser.add_argument(
         "--reauth",
         action="store_true",
         help="Force re-authentication by clearing cached tokens and running Chrome login",
     )
-    _cli_parser.add_argument(
+    parser.add_argument(
         "--entry",
         default=None,
         help=(
@@ -857,7 +871,53 @@ if __name__ == "__main__":
             "Required when secrets.json contains caches for multiple HA config entries."
         ),
     )
-    _cli_args = _cli_parser.parse_args()
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help=(
+            "Enable verbose DEBUG logging for the bootstrap and FCM flow. "
+            "Also enabled via the GOOGLEFINDMY_DEBUG environment variable."
+        ),
+    )
+    return parser
+
+
+def _configure_cli_logging(*, debug_flag: bool, env: Mapping[str, str]) -> None:
+    """Configure root logging for the standalone CLI.
+
+    The package never calls ``logging.basicConfig``; without it the root logger's
+    last-resort handler discards everything below WARNING, so every
+    ``_LOGGER.debug``/``info`` in the bootstrap and FCM path is invisible and the
+    first-run locate timeout cannot be diagnosed from a log.  DEBUG is enabled
+    when ``--debug`` is passed or ``GOOGLEFINDMY_DEBUG`` is truthy; otherwise the
+    default keeps normal runs at WARNING so the critical readiness warning still
+    surfaces without extra noise.
+
+    Must be called before the bootstrap so the auth and FCM steps emit under the
+    configured level.
+    """
+    import logging  # noqa: PLC0415
+
+    env_value = env.get("GOOGLEFINDMY_DEBUG", "").strip().lower()
+    debug_enabled = debug_flag or env_value not in ("", "0", "false", "no", "off")
+    logging.basicConfig(
+        level=logging.DEBUG if debug_enabled else logging.WARNING,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+
+def _main(argv: Sequence[str] | None = None) -> None:
+    """Standalone CLI entry point.
+
+    Extracted from the ``__main__`` guard so flag parsing, logging setup, and the
+    bootstrap call order are unit-testable (the guard itself cannot be imported).
+    Logging is configured *before* ``_ensure_authenticated`` so the Chrome/FCM
+    diagnostics are captured from the very first step.
+    """
+    import asyncio  # noqa: PLC0415
+
+    args = _build_cli_parser().parse_args(argv)
+    _configure_cli_logging(debug_flag=args.debug, env=os.environ)
 
     # Always run the token-bootstrap pipeline, regardless of flat vs. repo
     # directory layout.  When a usable cache already exists, _ensure_authenticated
@@ -866,22 +926,26 @@ if __name__ == "__main__":
     # then a cache-signal check that was always empty for a fresh shell start),
     # both of which could dead-end a repo-layout start in an opaque
     # MissingTokenCacheError instead of bootstrapping.
-    if _cli_args.reauth:
+    if args.reauth:
         _clear_stale_tokens_for_reauth()
     _ensure_authenticated()
     # Resolve the effective entry id once (CLI > env > "") and use the SAME
     # value for both registration and hand-off, so the registry key and the
-    # lookup hint can never diverge.  Forwarding the raw _cli_args.entry instead
+    # lookup hint can never diverge.  Forwarding the raw args.entry instead
     # would re-trigger _async_cli_main's env fallback for an explicit
     # --entry "" (empty string is falsy), making _resolve_cli_cache reject the
     # env value as "Unknown entry_id" although the cache was registered under
     # "".  Codex reviews on 694f6883aa and 17669c7ff2.
-    _effective_entry_id = _resolve_effective_entry_id(
-        _cli_args.entry, os.environ.get("GOOGLEFINDMY_ENTRY_ID")
+    effective_entry_id = _resolve_effective_entry_id(
+        args.entry, os.environ.get("GOOGLEFINDMY_ENTRY_ID")
     )
-    _file_cache = _register_file_cache(_effective_entry_id)
+    file_cache = _register_file_cache(effective_entry_id)
 
     try:
-        asyncio.run(_run_cli_bootstrap(_file_cache, _effective_entry_id))
+        asyncio.run(_run_cli_bootstrap(file_cache, effective_entry_id))
     except KeyboardInterrupt:
         print("\nExiting.")
+
+
+if __name__ == "__main__":
+    _main()

--- a/custom_components/googlefindmy/manifest.json
+++ b/custom_components/googlefindmy/manifest.json
@@ -35,5 +35,5 @@
     "selenium>=4.25.0",
     "undetected_chromedriver>=3.5.5"
   ],
-  "version": "1.7.7"
+  "version": "1.7.8"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "googlefindmy-ha"
 # [tool.semantic_release] version_toml below); on release branches it MUST be
 # bumped by hand alongside the other two. Canonical anchor:
 # custom_components/googlefindmy/AGENTS.md ("Version bump touches three files").
-version = "1.7.7"
+version = "1.7.8"
 description = "Home Assistant integration for Google's Find My Device network."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_chrome_driver.py
+++ b/tests/test_chrome_driver.py
@@ -372,6 +372,98 @@ def test_get_uc_module_caches_loaded_module(
 
 
 # ---------------------------------------------------------------------------
+# _neutralize_uc_finalizer (WinError 6 teardown noise)
+# ---------------------------------------------------------------------------
+
+
+def test_neutralize_preserves_original_cleanup() -> None:
+    """The wrapped __del__ still runs uc's cleanup (no leak on failed builds)."""
+    cleanup_calls: list[str] = []
+
+    class _FakeChrome:
+        def __del__(self) -> None:
+            cleanup_calls.append("cleanup")
+
+    chrome_driver._neutralize_uc_finalizer(SimpleNamespace(Chrome=_FakeChrome))
+
+    assert _FakeChrome._gfmy_del_neutralized is True
+    # The wrapper delegates to the original __del__ instead of dropping it:
+    # this preserves browser/temp-profile cleanup for a partially built driver.
+    inst = _FakeChrome.__new__(_FakeChrome)
+    assert _FakeChrome.__del__(inst) is None
+    assert cleanup_calls == ["cleanup"]
+
+
+def test_neutralize_suppresses_del_errors() -> None:
+    """A WinError-6-style raise from uc's __del__ is swallowed, not propagated."""
+
+    class _FakeChrome:
+        def __del__(self) -> None:
+            raise OSError(6, "The handle is invalid")
+
+    chrome_driver._neutralize_uc_finalizer(SimpleNamespace(Chrome=_FakeChrome))
+
+    # Invoking the wrapped __del__ must not raise despite the original raising.
+    inst = _FakeChrome.__new__(_FakeChrome)
+    assert _FakeChrome.__del__(inst) is None
+
+
+def test_neutralize_skips_import_stub() -> None:
+    """The import-failure stub exposes ``Chrome`` as a function, not a class."""
+
+    def _stub_chrome(*, options: object) -> object:  # pragma: no cover - shape only
+        return object()
+
+    # Must not raise and must not mark a plain function.
+    chrome_driver._neutralize_uc_finalizer(SimpleNamespace(Chrome=_stub_chrome))
+
+    assert not hasattr(_stub_chrome, "_gfmy_del_neutralized")
+
+
+def test_neutralize_is_idempotent() -> None:
+    """A second call does not re-wrap an already-neutralized class."""
+
+    class _FakeChrome:
+        def __del__(self) -> None:
+            return None
+
+    module = SimpleNamespace(Chrome=_FakeChrome)
+    chrome_driver._neutralize_uc_finalizer(module)
+    patched = _FakeChrome.__del__
+    chrome_driver._neutralize_uc_finalizer(module)
+
+    assert _FakeChrome.__del__ is patched
+
+
+def test_neutralize_leaves_class_without_own_del() -> None:
+    """A uc release without its own ``__del__`` is left untouched (none fabricated)."""
+
+    class _NoDel:
+        pass
+
+    chrome_driver._neutralize_uc_finalizer(SimpleNamespace(Chrome=_NoDel))
+
+    assert "__del__" not in _NoDel.__dict__
+    assert not hasattr(_NoDel, "_gfmy_del_neutralized")
+
+
+def test_get_uc_module_neutralizes_finalizer(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``_get_uc_module`` neutralizes the finalizer on the freshly loaded module."""
+
+    class _FakeChrome:
+        def __del__(self) -> None:  # pragma: no cover - not invoked in this test
+            return None
+
+    fake_module = SimpleNamespace(Chrome=_FakeChrome, ChromeOptions=FakeChromeOptions)
+    chrome_driver._reset_uc_cache(None)
+    monkeypatch.setattr(chrome_driver, "_load_uc", lambda: fake_module)
+
+    chrome_driver._get_uc_module()
+
+    assert _FakeChrome._gfmy_del_neutralized is True
+
+
+# ---------------------------------------------------------------------------
 # get_chrome_version
 # ---------------------------------------------------------------------------
 

--- a/tests/test_cli_entry_selection.py
+++ b/tests/test_cli_entry_selection.py
@@ -73,6 +73,7 @@ def test_resolve_cli_cache_multiple_entries_require_hint(
     assert "GOOGLEFINDMY_ENTRY_ID" in message
 
 
+@pytest.mark.asyncio
 async def test_cli_main_passes_selected_cache(monkeypatch: pytest.MonkeyPatch) -> None:
     """CLI helper should forward the selected cache/namespace to API calls."""
 
@@ -168,6 +169,7 @@ class TestAsyncCliMainEntryResolution:
         monkeypatch.setattr(nbe_list_devices, "_resolve_cli_cache", _stub)
         return seen
 
+    @pytest.mark.asyncio
     async def test_explicit_empty_entry_id_is_not_overridden_by_env(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -180,6 +182,7 @@ class TestAsyncCliMainEntryResolution:
 
         assert seen["hint"] == ""
 
+    @pytest.mark.asyncio
     async def test_none_entry_id_falls_back_to_env(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -192,6 +195,7 @@ class TestAsyncCliMainEntryResolution:
 
         assert seen["hint"] == "from-env"
 
+    @pytest.mark.asyncio
     async def test_explicit_entry_id_wins_over_env(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_cli_entry_selection.py
+++ b/tests/test_cli_entry_selection.py
@@ -139,3 +139,67 @@ async def test_cli_main_passes_selected_cache(monkeypatch: pytest.MonkeyPatch) -
     assert called["list_namespace"] == "entry-one"
     assert called["loc_cache"] is cache
     assert called["loc_namespace"] == "entry-one"
+
+
+class _StopAfterResolve(Exception):
+    """Sentinel raised from a stubbed _resolve_cli_cache to stop _async_cli_main."""
+
+
+class TestAsyncCliMainEntryResolution:
+    """The env fallback must apply only for an unspecified (None) entry id.
+
+    Regression for Codex review on 17669c7ff2: ``entry_id or env`` conflated an
+    explicit empty string (the documented "use the sole default cache" selector
+    that ``--entry ""`` sets to defeat ``GOOGLEFINDMY_ENTRY_ID``) with "not
+    supplied", so the env value overrode it and ``_resolve_cli_cache`` raised
+    ``Unknown entry_id``.  ``_async_cli_main`` now resolves with ``is not None``,
+    making it the single source of the env fallback.
+    """
+
+    @staticmethod
+    def _capture_hint(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+        """Stub _resolve_cli_cache to record its hint and short-circuit."""
+        seen: dict[str, Any] = {}
+
+        def _stub(hint: Any) -> tuple[Any, str]:
+            seen["hint"] = hint
+            raise _StopAfterResolve
+
+        monkeypatch.setattr(nbe_list_devices, "_resolve_cli_cache", _stub)
+        return seen
+
+    async def test_explicit_empty_entry_id_is_not_overridden_by_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``--entry ""`` must win over GOOGLEFINDMY_ENTRY_ID (CLI > env)."""
+        monkeypatch.setenv("GOOGLEFINDMY_ENTRY_ID", "from-env")
+        seen = self._capture_hint(monkeypatch)
+
+        with pytest.raises(_StopAfterResolve):
+            await nbe_list_devices._async_cli_main("")
+
+        assert seen["hint"] == ""
+
+    async def test_none_entry_id_falls_back_to_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unspecified (None) entry id still uses the env var."""
+        monkeypatch.setenv("GOOGLEFINDMY_ENTRY_ID", "from-env")
+        seen = self._capture_hint(monkeypatch)
+
+        with pytest.raises(_StopAfterResolve):
+            await nbe_list_devices._async_cli_main(None)
+
+        assert seen["hint"] == "from-env"
+
+    async def test_explicit_entry_id_wins_over_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-empty explicit entry id is used verbatim, ignoring env."""
+        monkeypatch.setenv("GOOGLEFINDMY_ENTRY_ID", "from-env")
+        seen = self._capture_hint(monkeypatch)
+
+        with pytest.raises(_StopAfterResolve):
+            await nbe_list_devices._async_cli_main("explicit")
+
+        assert seen["hint"] == "explicit"

--- a/tests/test_fcm_receiver_guard.py
+++ b/tests/test_fcm_receiver_guard.py
@@ -212,6 +212,51 @@ def test_multi_entry_buffers_prevent_global_cache_access(
     assert start_calls.count("entry-2") == 1
 
 
+def test_credentials_update_routes_only_own_entry_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tokenless creds update never routes another entry's token.
+
+    Regression (Codex #1150 follow-up, same leak class as the forced-reconnect
+    refresh): ``_on_credentials_updated_for_entry`` writes ``self.creds[entry_id]``
+    and then routes that entry's token.  Reading via ``get_fcm_token`` would fall
+    back to the first token across *all* entries, so a tokenless update for one
+    account while another account holds a token would route the foreign token
+    under the wrong entry.  The strict entry-scoped read must route nothing.
+    """
+    receiver = FcmReceiverHA()
+
+    # Another account already holds a token.
+    receiver.creds["entry-2"] = {"fcm": {"registration": {"token": "token-entry-2"}}}
+
+    routed: list[tuple[str, set[str]]] = []
+    monkeypatch.setattr(
+        receiver, "_update_token_routing", lambda tok, ids: routed.append((tok, ids))
+    )
+    # Isolate the routing decision: swallow (and close) the dispatched coroutines
+    # and neutralise the fatal-error clear so no event loop is required.
+    monkeypatch.setattr(
+        receiver, "_dispatch_to_hass_loop", lambda coro, label=None: coro.close()
+    )
+    monkeypatch.setattr(
+        receiver, "_clear_fatal_error_for_entry", lambda eid, reason=None: None
+    )
+
+    # entry-1 receives a tokenless credentials update while entry-2 has a token.
+    receiver._on_credentials_updated_for_entry("entry-1", {"fcm": {}})
+
+    # The foreign account's token is never routed under entry-1; in fact nothing
+    # is routed, because entry-1 has no token of its own.
+    assert ("token-entry-2", {"entry-1"}) not in routed
+    assert routed == []
+
+    # A subsequent update *with* an own token routes exactly that token.
+    receiver._on_credentials_updated_for_entry(
+        "entry-1", {"fcm": {"registration": {"token": "token-entry-1"}}}
+    )
+    assert routed == [("token-entry-1", {"entry-1"})]
+
+
 def test_unregister_prunes_token_routing(monkeypatch: pytest.MonkeyPatch) -> None:
     """Removing a coordinator clears its tokens and blocks future fan-out."""
 

--- a/tests/test_fcm_receiver_manual_locate.py
+++ b/tests/test_fcm_receiver_manual_locate.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import pytest
 
+from custom_components.googlefindmy.Auth import fcm_receiver_ha as fcm_mod
 from custom_components.googlefindmy.Auth.fcm_receiver_ha import FcmReceiverHA
 
 
@@ -157,3 +158,156 @@ def test_process_background_update_uses_thread(
     assert receiver._pending_targets[key] == {"entry-1", "entry-2"}
     assert schedule_calls == [key]
     assert decode_calls == [("entry-1", "c0ffee")]
+
+
+# ---------------------------------------------------------------------------
+# Readiness gate: fail-closed when the FCM client never reaches STARTED
+# ---------------------------------------------------------------------------
+
+
+class _RunState:
+    """Minimal stand-in for FcmPushClientRunState (only STARTED is compared)."""
+
+    STARTED = "STARTED"
+
+
+class _DummyPc:
+    """Push client double exposing only the polled ``run_state`` attribute."""
+
+    def __init__(self, run_state: object) -> None:
+        self.run_state = run_state
+
+
+def _wire_manual_locate(
+    monkeypatch: pytest.MonkeyPatch,
+    receiver: FcmReceiverHA,
+    entry_id: str,
+    cache: DummyCache,
+) -> None:
+    """Stub every collaborator the readiness gate calls before the poll loop."""
+
+    async def _ensure_client(eid: str, c: Any, generation: int | None = None) -> object:
+        return object()
+
+    async def _start(eid: str, c: Any) -> None:
+        return None
+
+    async def _ensure_token(eid: str) -> str:
+        return "token-123"
+
+    async def _persist(eid: str, tok: str) -> None:
+        return None
+
+    monkeypatch.setattr(
+        receiver, "_select_manual_locate_entry", lambda cid: (entry_id, cache)
+    )
+    monkeypatch.setattr(receiver, "_ensure_client_for_entry", _ensure_client)
+    monkeypatch.setattr(receiver, "_start_supervisor_for_entry", _start)
+    monkeypatch.setattr(receiver, "_ensure_token_for_entry", _ensure_token)
+    monkeypatch.setattr(receiver, "_update_token_routing", lambda tok, ids: None)
+    monkeypatch.setattr(receiver, "_persist_routing_token", _persist)
+    monkeypatch.setattr(fcm_mod, "FcmPushClientRunState", _RunState)
+
+
+@pytest.mark.asyncio
+async def test_manual_locate_fails_closed_when_never_started(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A client that never reaches STARTED yields None and leaves no callback.
+
+    Regression for the deterministic first-run locate timeout: the gate used to
+    fall through to ``return token`` (fail-open), handing a token to a listener
+    that was not yet connected so the caller blocked until an opaque 30s timeout.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    device_id = "device-canonic"
+    cache = DummyCache()
+    _wire_manual_locate(monkeypatch, receiver, entry_id, cache)
+
+    receiver.pcs[entry_id] = _DummyPc(run_state="CONNECTING")  # type: ignore[assignment]
+
+    # Do not actually sleep through the readiness budget.
+    async def _no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    def manual_callback(canonic: str, payload_hex: str) -> None:
+        return None
+
+    token = await receiver.async_register_for_location_updates(
+        device_id, manual_callback
+    )
+
+    assert token is None
+    assert device_id not in receiver.location_update_callbacks
+
+
+@pytest.mark.asyncio
+async def test_manual_locate_returns_token_when_started(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """HA happy path: STARTED within budget returns the token, keeps the callback."""
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    device_id = "device-canonic"
+    cache = DummyCache()
+    _wire_manual_locate(monkeypatch, receiver, entry_id, cache)
+
+    receiver.pcs[entry_id] = _DummyPc(run_state=_RunState.STARTED)  # type: ignore[assignment]
+
+    def manual_callback(canonic: str, payload_hex: str) -> None:
+        return None
+
+    token = await receiver.async_register_for_location_updates(
+        device_id, manual_callback
+    )
+
+    assert token == "token-123"
+    assert receiver.location_update_callbacks[device_id] is manual_callback
+
+
+@pytest.mark.asyncio
+async def test_manual_locate_reads_replacement_client_during_poll(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A supervisor restart that swaps in a STARTED client mid-poll is honored.
+
+    Regression (Codex): the gate captured ``pc`` once before waiting.  When a
+    concurrent ``_start_supervisor_for_entry`` restart discards that client and
+    replaces ``self.pcs[entry_id]`` with a fresh one that reaches STARTED, the
+    stale object never transitions, so fail-closed used to abort a request the
+    replacement client could actually serve.  The loop must re-read the live
+    entry client during the poll.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    device_id = "device-canonic"
+    cache = DummyCache()
+    _wire_manual_locate(monkeypatch, receiver, entry_id, cache)
+
+    stale = _DummyPc(run_state="CONNECTING")
+    started = _DummyPc(run_state=_RunState.STARTED)
+    receiver.pcs[entry_id] = stale  # type: ignore[assignment]
+
+    # Simulate a concurrent supervisor restart swapping the entry client in
+    # while the readiness gate is between polls (on the first ``await sleep``).
+    swapped = {"done": False}
+
+    async def _swap_then_no_sleep(_seconds: float) -> None:
+        if not swapped["done"]:
+            receiver.pcs[entry_id] = started  # type: ignore[assignment]
+            swapped["done"] = True
+
+    monkeypatch.setattr(asyncio, "sleep", _swap_then_no_sleep)
+
+    def manual_callback(canonic: str, payload_hex: str) -> None:
+        return None
+
+    token = await receiver.async_register_for_location_updates(
+        device_id, manual_callback
+    )
+
+    assert token == "token-123"
+    assert receiver.location_update_callbacks[device_id] is manual_callback

--- a/tests/test_fcm_receiver_manual_locate.py
+++ b/tests/test_fcm_receiver_manual_locate.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from collections.abc import Callable
 from typing import Any
 
@@ -204,6 +205,13 @@ def _wire_manual_locate(
     monkeypatch.setattr(receiver, "_ensure_client_for_entry", _ensure_client)
     monkeypatch.setattr(receiver, "_start_supervisor_for_entry", _start)
     monkeypatch.setattr(receiver, "_ensure_token_for_entry", _ensure_token)
+    # The post-reconnect refresh reads the token strictly entry-scoped via
+    # ``_entry_scoped_fcm_token`` (production seam), which via
+    # ``_ensure_token_for_entry`` agrees with the token above.  Stub it to the
+    # same value so the refresh sees an unchanged token by default; rotation and
+    # fail-closed tests override this seam explicitly.  The cross-entry scoping
+    # test deliberately leaves it unstubbed to exercise the real strict read.
+    monkeypatch.setattr(receiver, "_entry_scoped_fcm_token", lambda eid: "token-123")
     monkeypatch.setattr(receiver, "_update_token_routing", lambda tok, ids: None)
     monkeypatch.setattr(receiver, "_persist_routing_token", _persist)
     monkeypatch.setattr(fcm_mod, "FcmPushClientRunState", _RunState)
@@ -311,3 +319,850 @@ async def test_manual_locate_reads_replacement_client_during_poll(
 
     assert token == "token-123"
     assert receiver.location_update_callbacks[device_id] is manual_callback
+
+
+# ---------------------------------------------------------------------------
+# First-locate delivery reconnect (AP1, T-A): a fresh session can reach STARTED
+# yet not deliver the first push until it reconnects.  The trigger fires only
+# for a *young* session that has *not yet delivered* a data message.
+# ---------------------------------------------------------------------------
+
+
+class _ReconnectPc:
+    """Push client double exposing run_state, persistent_ids and async stop()."""
+
+    def __init__(
+        self,
+        run_state: object,
+        persistent_ids: list[str] | None = None,
+        started_monotonic: float | None = None,
+    ) -> None:
+        self.run_state = run_state
+        self.persistent_ids = list(persistent_ids or [])
+        # STARTED-transition anchor consumed by ``_session_age_s``. Defaults to
+        # "just reached STARTED" (young session) so the common case is terse;
+        # the established-session test passes an old timestamp explicitly.
+        self._started_monotonic = (
+            time.monotonic() if started_monotonic is None else started_monotonic
+        )
+        self.stopped = False
+
+    async def stop(self) -> None:
+        self.stopped = True
+        self.run_state = "STOPPED"
+
+
+async def _no_sleep(_seconds: float) -> None:
+    return None
+
+
+@pytest.mark.asyncio
+async def test_manual_locate_forces_reconnect_for_fresh_nondelivering_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Young + no delivery: force one reconnect and serve from the replacement.
+
+    Regression for the deterministic first-locate timeout after a fresh FCM
+    registration: the first client reaches STARTED but never receives the push,
+    and only a reconnect (a session that subscribes after registration) heals it.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    device_id = "device-canonic"
+    cache = DummyCache()
+    _wire_manual_locate(monkeypatch, receiver, entry_id, cache)
+
+    # Young session: the double defaults to a just-now STARTED stamp, so the
+    # per-client age gate (``_session_age_s``) is open (age ~0 < _CHURN_WINDOW_S).
+    stale = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
+    fresh = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
+    receiver.pcs[entry_id] = stale  # type: ignore[assignment]
+
+    nudged: list[str | None] = []
+    monkeypatch.setattr(
+        receiver, "nudge_retry", lambda eid=None: bool(nudged.append(eid)) or True
+    )
+
+    # The forced-reconnect wait swaps in the replacement on its first sleep,
+    # mirroring the supervisor rebuild.  The first readiness wait does not sleep
+    # (stale is already STARTED).
+    async def _swap_then_no_sleep(_seconds: float) -> None:
+        if receiver.pcs[entry_id] is stale:
+            receiver.pcs[entry_id] = fresh  # type: ignore[assignment]
+
+    monkeypatch.setattr(asyncio, "sleep", _swap_then_no_sleep)
+
+    def manual_callback(canonic: str, payload_hex: str) -> None:
+        return None
+
+    token = await receiver.async_register_for_location_updates(
+        device_id, manual_callback
+    )
+
+    assert token == "token-123"
+    assert stale.stopped is True  # the reconnect actually happened
+    assert nudged == [entry_id]  # supervisor nudged to rebuild
+    assert receiver.pcs[entry_id] is fresh  # replacement client is live
+
+
+@pytest.mark.asyncio
+async def test_manual_locate_no_reconnect_for_established_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Old session (age >= window): no reconnect, token returned unchanged."""
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    device_id = "device-canonic"
+    cache = DummyCache()
+    _wire_manual_locate(monkeypatch, receiver, entry_id, cache)
+
+    # Established session: STARTED well beyond _CHURN_WINDOW_S (per-client age).
+    stale = _ReconnectPc(
+        run_state=_RunState.STARTED,
+        persistent_ids=[],
+        started_monotonic=time.monotonic() - 100.0,
+    )
+    receiver.pcs[entry_id] = stale  # type: ignore[assignment]
+
+    nudged: list[str | None] = []
+    monkeypatch.setattr(
+        receiver, "nudge_retry", lambda eid=None: bool(nudged.append(eid)) or True
+    )
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    def manual_callback(canonic: str, payload_hex: str) -> None:
+        return None
+
+    token = await receiver.async_register_for_location_updates(
+        device_id, manual_callback
+    )
+
+    assert token == "token-123"
+    assert stale.stopped is False
+    assert nudged == []
+    assert receiver.pcs[entry_id] is stale
+
+
+@pytest.mark.asyncio
+async def test_manual_locate_no_reconnect_when_already_delivered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Young but already-delivering session: the sharpening suppresses reconnect.
+
+    Protects a healthy HA multi-entry session that the aggregate age anchor might
+    otherwise mis-classify as young: a non-empty ``persistent_ids`` proves the
+    session already delivered a data message, so no needless reconnect fires.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    device_id = "device-canonic"
+    cache = DummyCache()
+    _wire_manual_locate(monkeypatch, receiver, entry_id, cache)
+
+    # Young (default STARTED stamp) but already delivered (persistent_ids set).
+    stale = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=["pid-1"])
+    receiver.pcs[entry_id] = stale  # type: ignore[assignment]
+
+    nudged: list[str | None] = []
+    monkeypatch.setattr(
+        receiver, "nudge_retry", lambda eid=None: bool(nudged.append(eid)) or True
+    )
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    def manual_callback(canonic: str, payload_hex: str) -> None:
+        return None
+
+    token = await receiver.async_register_for_location_updates(
+        device_id, manual_callback
+    )
+
+    assert token == "token-123"
+    assert stale.stopped is False
+    assert nudged == []
+
+
+@pytest.mark.asyncio
+async def test_manual_locate_reconnect_fails_closed_when_replacement_never_starts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Forced reconnect whose replacement never reaches STARTED fails closed."""
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    device_id = "device-canonic"
+    cache = DummyCache()
+    _wire_manual_locate(monkeypatch, receiver, entry_id, cache)
+
+    # Young (default STARTED stamp) and not delivered -> the trigger fires.
+    stale = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
+    receiver.pcs[entry_id] = stale  # type: ignore[assignment]
+
+    monkeypatch.setattr(receiver, "nudge_retry", lambda eid=None: True)
+    # No replacement ever appears; the post-reconnect wait exhausts its budget.
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    def manual_callback(canonic: str, payload_hex: str) -> None:
+        return None
+
+    token = await receiver.async_register_for_location_updates(
+        device_id, manual_callback
+    )
+
+    assert token is None
+    assert device_id not in receiver.location_update_callbacks
+    assert stale.stopped is True  # reconnect was attempted before failing closed
+
+
+@pytest.mark.asyncio
+async def test_force_first_locate_reconnect_swallows_stop_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stop() error on the dying client is swallowed; the rebuild still runs."""
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    monkeypatch.setattr(fcm_mod, "FcmPushClientRunState", _RunState)
+
+    class _BoomPc(_ReconnectPc):
+        async def stop(self) -> None:
+            self.stopped = True
+            raise RuntimeError("boom")
+
+    stale = _BoomPc(run_state="STOPPED", persistent_ids=[])
+    fresh = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
+    receiver.pcs[entry_id] = stale  # type: ignore[assignment]
+
+    nudged: list[str | None] = []
+    monkeypatch.setattr(
+        receiver, "nudge_retry", lambda eid=None: bool(nudged.append(eid)) or True
+    )
+
+    async def _swap(_seconds: float) -> None:
+        receiver.pcs[entry_id] = fresh  # type: ignore[assignment]
+
+    monkeypatch.setattr(asyncio, "sleep", _swap)
+
+    result = await receiver._force_first_locate_reconnect(entry_id, stale, 5.0)  # type: ignore[arg-type]
+
+    assert result is fresh
+    assert stale.stopped is True
+    assert nudged == [entry_id]
+
+
+@pytest.mark.asyncio
+async def test_force_reconnect_excludes_lingering_started_stale(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale client still STARTED after a failed stop() is not the replacement.
+
+    Hardens the ``exclude_pc`` guard: if ``stop()`` raised and the stale client
+    lingers in STARTED with no replacement swapped in, the post-reconnect wait
+    must reject the stale instance and let the budget expire (return ``None`` =
+    fail closed), rather than mistake the stale for the fresh client.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    monkeypatch.setattr(fcm_mod, "FcmPushClientRunState", _RunState)
+
+    class _LingeringPc(_ReconnectPc):
+        async def stop(self) -> None:
+            # stop() fails and does NOT transition run_state: it lingers STARTED.
+            self.stopped = True
+            raise RuntimeError("stop failed; client lingers STARTED")
+
+    stale = _LingeringPc(run_state=_RunState.STARTED, persistent_ids=[])
+    receiver.pcs[entry_id] = stale  # type: ignore[assignment]
+
+    monkeypatch.setattr(receiver, "nudge_retry", lambda eid=None: True)
+    # No replacement is ever swapped in; the stale lingers in STARTED.
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    result = await receiver._force_first_locate_reconnect(entry_id, stale, 1.0)  # type: ignore[arg-type]
+
+    assert result is None  # stale-but-STARTED must not be taken as the replacement
+    assert stale.stopped is True
+
+
+@pytest.mark.asyncio
+async def test_manual_locate_reconnect_for_slow_startup_fresh_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Slow-startup fresh session: churn age is measured from STARTED, not supervisor start.
+
+    Codex #1150 follow-up: the supervisor records ``last_start_monotonic`` before
+    ``pc.start()``, and the readiness gate allows a fresh MCS connection ~15-20s
+    to reach STARTED.  A session that starts slowly (supervisor start long ago)
+    but has only *just* reached STARTED and delivered nothing is exactly the case
+    the reconnect must heal.  Anchoring the age on the client's own STARTED stamp
+    fires the reconnect here; the old anchor (``last_start_monotonic``, set far in
+    the past) would compute age >= _CHURN_WINDOW_S and wrongly skip it.  Setting a
+    stale ``last_start_monotonic`` proves the decision no longer depends on it.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    device_id = "device-canonic"
+    cache = DummyCache()
+    _wire_manual_locate(monkeypatch, receiver, entry_id, cache)
+
+    # Client only just reached STARTED (young), though the supervisor began the
+    # start long ago (slow connection budget consumed before STARTED).
+    stale = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
+    fresh = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
+    receiver.pcs[entry_id] = stale  # type: ignore[assignment]
+    receiver.last_start_monotonic = time.monotonic() - 100.0  # stale supervisor stamp
+
+    nudged: list[str | None] = []
+    monkeypatch.setattr(
+        receiver, "nudge_retry", lambda eid=None: bool(nudged.append(eid)) or True
+    )
+
+    async def _swap_then_no_sleep(_seconds: float) -> None:
+        if receiver.pcs[entry_id] is stale:
+            receiver.pcs[entry_id] = fresh  # type: ignore[assignment]
+
+    monkeypatch.setattr(asyncio, "sleep", _swap_then_no_sleep)
+
+    def manual_callback(canonic: str, payload_hex: str) -> None:
+        return None
+
+    token = await receiver.async_register_for_location_updates(
+        device_id, manual_callback
+    )
+
+    assert token == "token-123"
+    assert stale.stopped is True  # reconnect fired despite the stale supervisor stamp
+    assert nudged == [entry_id]
+    assert receiver.pcs[entry_id] is fresh
+
+
+# ---------------------------------------------------------------------------
+# First-locate reconnect serialization (Codex #1150 follow-up): concurrent or
+# sequential manual locates for different trackers on the SAME entry must share
+# a single reconnect instead of each tearing down the fresh session.
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_first_locate_reconnect_reuses_replacement_on_sequential_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sequential second caller reuses the replacement instead of re-tearing.
+
+    After the first caller reconnects to ``fresh``, ``fresh`` is itself young
+    and has not delivered yet, so the naive age/no-delivery gate would fire
+    again and tear down the very replacement the first caller just built.  The
+    per-entry consumed-latch must make the second caller REUSE ``fresh``.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    monkeypatch.setattr(fcm_mod, "FcmPushClientRunState", _RunState)
+
+    stale = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
+    fresh = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
+    receiver.pcs[entry_id] = stale  # type: ignore[assignment]
+
+    nudged: list[str | None] = []
+    monkeypatch.setattr(
+        receiver, "nudge_retry", lambda eid=None: bool(nudged.append(eid)) or True
+    )
+
+    async def _swap_then_no_sleep(_seconds: float) -> None:
+        if receiver.pcs[entry_id] is stale:
+            receiver.pcs[entry_id] = fresh  # type: ignore[assignment]
+
+    monkeypatch.setattr(asyncio, "sleep", _swap_then_no_sleep)
+
+    first = await receiver._reconnect_for_first_locate(entry_id, 5.0)
+    assert first is fresh
+    assert stale.stopped is True
+    assert nudged == [entry_id]
+
+    second = await receiver._reconnect_for_first_locate(entry_id, 5.0)
+    assert second is fresh  # reused, not reconnected again
+    assert fresh.stopped is False  # replacement was NOT torn down
+    assert nudged == [entry_id]  # still exactly one reconnect
+
+
+@pytest.mark.asyncio
+async def test_first_locate_reconnect_serialized_across_concurrent_callers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two concurrent callers on the same entry share one reconnect.
+
+    Regression (Codex #1150): without per-entry serialization the second caller
+    entered the reconnect branch independently and stopped the replacement the
+    first caller had just waited for, so the first request timed out.  The
+    per-entry lock must block the second caller until the first completes, after
+    which the consumed-latch makes it reuse the replacement.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    monkeypatch.setattr(fcm_mod, "FcmPushClientRunState", _RunState)
+
+    nudged: list[str | None] = []
+    monkeypatch.setattr(
+        receiver, "nudge_retry", lambda eid=None: bool(nudged.append(eid)) or True
+    )
+
+    in_crit = asyncio.Event()
+    release = asyncio.Event()
+    fresh = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
+
+    class _BarrierPc:
+        """Stale client whose stop() parks inside the critical section."""
+
+        def __init__(self) -> None:
+            self.run_state: object = _RunState.STARTED
+            self.persistent_ids: list[str] = []
+            self._started_monotonic = time.monotonic()
+            self.stopped = False
+
+        async def stop(self) -> None:
+            self.stopped = True
+            in_crit.set()  # first caller holds the per-entry lock now
+            await release.wait()  # park so the second caller can try to enter
+            receiver.pcs[entry_id] = fresh  # type: ignore[assignment]
+
+    stale = _BarrierPc()
+    receiver.pcs[entry_id] = stale  # type: ignore[assignment]
+
+    task_a = asyncio.create_task(receiver._reconnect_for_first_locate(entry_id, 5.0))
+    await in_crit.wait()  # first caller is mid-reconnect, holding the lock
+    task_b = asyncio.create_task(receiver._reconnect_for_first_locate(entry_id, 5.0))
+    await asyncio.sleep(0)  # let the second caller run; it must block on the lock
+    # B has not completed: it is parked on the per-entry lock the first caller
+    # holds. (This alone is necessary, not sufficient -- the decisive proof of
+    # serialization is the single reconnect asserted via ``nudged`` below.)
+    assert not task_b.done()
+
+    release.set()  # let the first caller finish the single reconnect
+    result_a = await task_a
+    result_b = await task_b
+
+    assert result_a is fresh
+    assert result_b is fresh  # second caller reused the same replacement
+    assert fresh.stopped is False  # replacement never torn down
+    assert nudged == [entry_id]  # exactly one reconnect happened
+
+
+@pytest.mark.asyncio
+async def test_first_locate_reconnect_relatches_for_new_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A genuinely new session generation is allowed its own single reconnect.
+
+    The consumed-latch is keyed by client identity, not by ``entry_id``: once
+    the supervisor rebuilds a brand-new young client (a different object), the
+    stored replacement no longer matches, so the next caller may reconnect once
+    more.  A key-based latch would wrongly suppress this.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    monkeypatch.setattr(fcm_mod, "FcmPushClientRunState", _RunState)
+
+    nudged: list[str | None] = []
+    monkeypatch.setattr(
+        receiver, "nudge_retry", lambda eid=None: bool(nudged.append(eid)) or True
+    )
+
+    # State left by a prior reconnect: latch points at a now-superseded client,
+    # while the supervisor has installed a brand-new young session (new_pc).
+    old_fresh = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
+    receiver._first_locate_reconnect_done[entry_id] = old_fresh  # type: ignore[assignment]
+    new_pc = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
+    newest = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
+    receiver.pcs[entry_id] = new_pc  # type: ignore[assignment]
+
+    async def _swap_then_no_sleep(_seconds: float) -> None:
+        if receiver.pcs[entry_id] is new_pc:
+            receiver.pcs[entry_id] = newest  # type: ignore[assignment]
+
+    monkeypatch.setattr(asyncio, "sleep", _swap_then_no_sleep)
+
+    result = await receiver._reconnect_for_first_locate(entry_id, 5.0)
+
+    assert result is newest  # new generation got its own reconnect
+    assert new_pc.stopped is True
+    assert nudged == [entry_id]
+    assert receiver._first_locate_reconnect_done[entry_id] is newest
+
+
+@pytest.mark.asyncio
+async def test_first_locate_reconnect_fails_closed_when_client_gone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No live client under the lock yields None (fail closed).
+
+    A concurrent supervisor teardown can pop the entry client between the
+    branch pre-check and the lock acquisition; the serialized decision must then
+    return None so the caller fails closed instead of dereferencing nothing.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    monkeypatch.setattr(fcm_mod, "FcmPushClientRunState", _RunState)
+
+    nudged: list[str | None] = []
+    monkeypatch.setattr(
+        receiver, "nudge_retry", lambda eid=None: bool(nudged.append(eid)) or True
+    )
+
+    # self.pcs has no entry for entry_id -> current is None.
+    result = await receiver._reconnect_for_first_locate(entry_id, 5.0)
+
+    assert result is None
+    assert nudged == []  # no reconnect attempted
+
+
+@pytest.mark.asyncio
+async def test_first_locate_reconnect_uses_current_when_no_longer_fresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A client that has since delivered is used as-is, without a reconnect.
+
+    Between the cheap branch pre-check and acquiring the per-entry lock the
+    session may have delivered its first push (``persistent_ids`` filled).  The
+    authoritative re-check under the lock must then reuse it, never tear it down.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    monkeypatch.setattr(fcm_mod, "FcmPushClientRunState", _RunState)
+
+    nudged: list[str | None] = []
+    monkeypatch.setattr(
+        receiver, "nudge_retry", lambda eid=None: bool(nudged.append(eid)) or True
+    )
+
+    delivered = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=["pid-1"])
+    receiver.pcs[entry_id] = delivered  # type: ignore[assignment]
+
+    result = await receiver._reconnect_for_first_locate(entry_id, 5.0)
+
+    assert result is delivered  # reused as-is
+    assert delivered.stopped is False  # no reconnect
+    assert nudged == []
+
+
+@pytest.mark.asyncio
+async def test_first_locate_reconnect_fails_closed_on_unstarted_reuse(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-STARTED client reached via the reuse short-circuit fails closed.
+
+    Regression (Codex #1150 follow-up review): a concurrent supervisor swap can
+    install a fresh, not-yet-started client between the branch pre-check and the
+    per-entry lock. ``_needs_first_locate_reconnect`` is False for a never-
+    STARTED client (``_session_age_s`` is None), so the reuse path must NOT hand
+    this non-listening client back -- doing so reproduces the very locate
+    timeout the fix heals. It must fail closed instead, like the readiness gate.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    monkeypatch.setattr(fcm_mod, "FcmPushClientRunState", _RunState)
+
+    nudged: list[str | None] = []
+    monkeypatch.setattr(
+        receiver, "nudge_retry", lambda eid=None: bool(nudged.append(eid)) or True
+    )
+
+    # Fresh, not-yet-started client swapped in under the lock: run_state is not
+    # STARTED and it never reached STARTED, so the reuse path selects it.
+    unstarted = _ReconnectPc(run_state="CONNECTING", persistent_ids=[])
+    unstarted._started_monotonic = None  # type: ignore[assignment]  # never STARTED
+    receiver.pcs[entry_id] = unstarted  # type: ignore[assignment]
+
+    result = await receiver._reconnect_for_first_locate(entry_id, 5.0)
+
+    assert result is None  # fail closed, not a non-listening client
+    assert unstarted.stopped is False  # untouched
+    assert nudged == []
+
+
+@pytest.mark.asyncio
+async def test_is_started_false_when_runstate_enum_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_is_started`` fails safe when the library run-state enum is unavailable."""
+    receiver = FcmReceiverHA()
+    monkeypatch.setattr(fcm_mod, "FcmPushClientRunState", None)
+
+    pc = _ReconnectPc(run_state="STARTED", persistent_ids=[])
+
+    assert receiver._is_started(pc) is False  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# First-locate reconnect: refresh the FCM token after the forced reconnect.
+# The reconnect drives a supervisor rebuild that may re-register and rotate the
+# entry token; returning the stale token would send the locate to the old
+# registration while the live listener is subscribed with the new one (Codex
+# #1150 follow-up).
+# ---------------------------------------------------------------------------
+
+
+def _wire_forced_reconnect(
+    monkeypatch: pytest.MonkeyPatch,
+    receiver: FcmReceiverHA,
+    entry_id: str,
+) -> list[str | None]:
+    """Set up a young, non-delivering session that forces exactly one reconnect."""
+
+    stale = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
+    fresh = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
+    receiver.pcs[entry_id] = stale  # type: ignore[assignment]
+
+    nudged: list[str | None] = []
+    monkeypatch.setattr(
+        receiver, "nudge_retry", lambda eid=None: bool(nudged.append(eid)) or True
+    )
+
+    async def _swap_then_no_sleep(_seconds: float) -> None:
+        if receiver.pcs[entry_id] is stale:
+            receiver.pcs[entry_id] = fresh  # type: ignore[assignment]
+
+    monkeypatch.setattr(asyncio, "sleep", _swap_then_no_sleep)
+    return nudged
+
+
+@pytest.mark.asyncio
+async def test_manual_locate_refreshes_rotated_token_after_reconnect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rotated token: the refreshed token is returned and routing re-pointed.
+
+    Regression (Codex): the forced reconnect nudges a supervisor rebuild that can
+    re-register and rotate the entry FCM token after it was captured.  Returning
+    the stale token would hand the locate to the dead registration while the live
+    listener subscribes with the new one, reproducing the timeout.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    device_id = "device-canonic"
+    cache = DummyCache()
+    _wire_manual_locate(monkeypatch, receiver, entry_id, cache)
+    nudged = _wire_forced_reconnect(monkeypatch, receiver, entry_id)
+
+    # The supervisor rebuild rotated the token: _ensure_token_for_entry captured
+    # "token-123", but the entry-scoped read now reports the post-reconnect token.
+    monkeypatch.setattr(receiver, "_entry_scoped_fcm_token", lambda eid: "token-999")
+    routed: list[tuple[str, set[str]]] = []
+    monkeypatch.setattr(
+        receiver, "_update_token_routing", lambda tok, ids: routed.append((tok, ids))
+    )
+    persisted: list[tuple[str, str]] = []
+
+    async def _persist(eid: str, tok: str) -> None:
+        persisted.append((eid, tok))
+
+    monkeypatch.setattr(receiver, "_persist_routing_token", _persist)
+
+    def manual_callback(canonic: str, payload_hex: str) -> None:
+        return None
+
+    token = await receiver.async_register_for_location_updates(
+        device_id, manual_callback
+    )
+
+    assert token == "token-999"  # the fresh token, not the stale "token-123"
+    assert nudged == [entry_id]  # the reconnect actually happened
+    # Routing/persist re-pointed at the rotated token (the pre-reconnect path
+    # also routes the captured token once; the refresh adds the new one).
+    assert ("token-999", {entry_id}) in routed
+    assert (entry_id, "token-999") in persisted
+    assert receiver.location_update_callbacks[device_id] is manual_callback
+
+
+@pytest.mark.asyncio
+async def test_manual_locate_fails_closed_when_token_missing_after_reconnect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Token gone after reconnect: fail closed (None) and leave no callback."""
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    device_id = "device-canonic"
+    cache = DummyCache()
+    _wire_manual_locate(monkeypatch, receiver, entry_id, cache)
+    _wire_forced_reconnect(monkeypatch, receiver, entry_id)
+
+    # The re-registration during the rebuild left the entry without a token.
+    monkeypatch.setattr(receiver, "_entry_scoped_fcm_token", lambda eid: None)
+    routed: list[tuple[str, set[str]]] = []
+    monkeypatch.setattr(
+        receiver, "_update_token_routing", lambda tok, ids: routed.append((tok, ids))
+    )
+
+    def manual_callback(canonic: str, payload_hex: str) -> None:
+        return None
+
+    token = await receiver.async_register_for_location_updates(
+        device_id, manual_callback
+    )
+
+    assert token is None
+    assert device_id not in receiver.location_update_callbacks
+    # Fails closed before the rotation block: only the pre-reconnect path routed
+    # (the captured token once); a missing token is never routed.
+    assert routed == [("token-123", {entry_id})]
+
+
+@pytest.mark.asyncio
+async def test_manual_locate_unchanged_token_skips_routing_churn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unrotated token: return it unchanged and do not re-point routing.
+
+    Pins the rotation guard: routing is touched only when the token actually
+    changed, so a no-op reconnect does not churn the token map.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    device_id = "device-canonic"
+    cache = DummyCache()
+    _wire_manual_locate(monkeypatch, receiver, entry_id, cache)
+    _wire_forced_reconnect(monkeypatch, receiver, entry_id)
+
+    # The entry-scoped read still reports the captured token (no rotation).
+    monkeypatch.setattr(receiver, "_entry_scoped_fcm_token", lambda eid: "token-123")
+    routed: list[tuple[str, set[str]]] = []
+    monkeypatch.setattr(
+        receiver, "_update_token_routing", lambda tok, ids: routed.append((tok, ids))
+    )
+
+    def manual_callback(canonic: str, payload_hex: str) -> None:
+        return None
+
+    token = await receiver.async_register_for_location_updates(
+        device_id, manual_callback
+    )
+
+    assert token == "token-123"
+    # Only the pre-reconnect path routed the captured token once; the refresh
+    # added nothing because the token did not rotate (no churn).
+    assert routed == [("token-123", {entry_id})]
+
+
+@pytest.mark.asyncio
+async def test_manual_locate_refresh_stays_entry_scoped_across_accounts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Multi-account: the post-reconnect refresh stays strictly entry-scoped.
+
+    Regression (Codex #1150 follow-up): ``get_fcm_token``'s cross-entry fallback
+    returns the first token across all accounts.  If the forced reconnect leaves
+    *this* entry momentarily tokenless while a *different* entry still holds a
+    token, reading via ``get_fcm_token`` would hand the foreign account's token to
+    this entry (routed and returned).  The refresh must read strictly entry-scoped
+    and fail closed instead.
+
+    Uses real creds and the real ``_entry_scoped_fcm_token`` (unstubbed), so a
+    revert to ``get_fcm_token`` turns this test red.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    device_id = "device-canonic"
+    cache = DummyCache()
+
+    async def _ensure_client(eid: str, c: Any, generation: int | None = None) -> object:
+        return object()
+
+    async def _start(eid: str, c: Any) -> None:
+        return None
+
+    async def _ensure_token(eid: str) -> str:
+        return "token-123"
+
+    async def _persist(eid: str, tok: str) -> None:
+        return None
+
+    monkeypatch.setattr(
+        receiver, "_select_manual_locate_entry", lambda cid: (entry_id, cache)
+    )
+    monkeypatch.setattr(receiver, "_ensure_client_for_entry", _ensure_client)
+    monkeypatch.setattr(receiver, "_start_supervisor_for_entry", _start)
+    monkeypatch.setattr(receiver, "_ensure_token_for_entry", _ensure_token)
+    routed: list[tuple[str, set[str]]] = []
+    monkeypatch.setattr(
+        receiver, "_update_token_routing", lambda tok, ids: routed.append((tok, ids))
+    )
+    monkeypatch.setattr(receiver, "_persist_routing_token", _persist)
+    monkeypatch.setattr(fcm_mod, "FcmPushClientRunState", _RunState)
+
+    # Real creds: this entry is tokenless after the rebuild, a *different* account
+    # still holds a token.  The strict entry-scoped read must not leak it.  The
+    # ``_entry_scoped_fcm_token`` seam is left unstubbed on purpose.
+    receiver.creds = {  # type: ignore[assignment]
+        entry_id: {},
+        "entry-2": {"fcm": {"registration": {"token": "other-account-token"}}},
+    }
+
+    # Force exactly one reconnect; the fresh replacement double carries no
+    # per-client credentials, so the strict read falls through to creds only.
+    _wire_forced_reconnect(monkeypatch, receiver, entry_id)
+
+    def manual_callback(canonic: str, payload_hex: str) -> None:
+        return None
+
+    token = await receiver.async_register_for_location_updates(
+        device_id, manual_callback
+    )
+
+    # Fail closed: the foreign token is never returned to the caller ...
+    assert token is None
+    assert device_id not in receiver.location_update_callbacks
+    # ... and never routed for this entry (only the pre-reconnect path routed the
+    # captured token once; the foreign account's token must not appear at all).
+    assert ("other-account-token", {entry_id}) not in routed
+    assert routed == [("token-123", {entry_id})]
+
+
+def test_entry_scoped_fcm_token_never_leaks_across_entries() -> None:
+    """The strict entry-scoped read stays within its entry (no cross-entry fallback).
+
+    Directly pins the invariant that ``get_fcm_token`` and the post-reconnect token
+    refresh both rely on: read persisted creds, then the live client's credentials,
+    and fail closed with ``None`` when only *another* entry holds a token.
+    """
+    receiver = FcmReceiverHA()
+    receiver.creds = {  # type: ignore[assignment]
+        "entry-1": {"fcm": {"registration": {"token": "tok-1"}}},
+        "entry-2": {"fcm": {"registration": {"token": "tok-2"}}},
+    }
+    # Persisted-creds layer, strictly scoped (never entry-2's token for entry-1).
+    assert receiver._entry_scoped_fcm_token("entry-1") == "tok-1"
+    assert receiver._entry_scoped_fcm_token("entry-2") == "tok-2"
+
+    # No persisted creds for the entry, but a live client exposes credentials.
+    class _CredPc:
+        credentials = {"fcm": {"registration": {"token": "live-tok"}}}
+
+    receiver.creds = {  # type: ignore[assignment]
+        "entry-3": {},
+        "entry-2": {"fcm": {"registration": {"token": "tok-2"}}},
+    }
+    receiver.pcs["entry-3"] = _CredPc()  # type: ignore[assignment]
+    assert receiver._entry_scoped_fcm_token("entry-3") == "live-tok"
+
+    # A live client whose credentials access raises is swallowed (defensive path).
+    class _RaisingPc:
+        @property
+        def credentials(self) -> dict[str, Any]:
+            raise RuntimeError("creds unavailable")
+
+    receiver.creds = {  # type: ignore[assignment]
+        "entry-4": {},
+        "entry-2": {"fcm": {"registration": {"token": "tok-2"}}},
+    }
+    receiver.pcs["entry-4"] = _RaisingPc()  # type: ignore[assignment]
+    assert receiver._entry_scoped_fcm_token("entry-4") is None
+
+    # Live client exposes a credentials dict but with an empty token: fall through
+    # to None rather than leak another entry's token.
+    class _CredPcEmpty:
+        credentials = {"fcm": {"registration": {"token": ""}}}
+
+    receiver.creds = {  # type: ignore[assignment]
+        "entry-5": {},
+        "entry-2": {"fcm": {"registration": {"token": "tok-2"}}},
+    }
+    receiver.pcs["entry-5"] = _CredPcEmpty()  # type: ignore[assignment]
+    assert receiver._entry_scoped_fcm_token("entry-5") is None
+
+    # Entry is tokenless (no creds, no live client) while another entry has a
+    # token: must return None, never the foreign token.
+    receiver.pcs.pop("entry-4", None)
+    assert receiver._entry_scoped_fcm_token("entry-4") is None

--- a/tests/test_fcm_register.py
+++ b/tests/test_fcm_register.py
@@ -16,6 +16,7 @@ from custom_components.googlefindmy.Auth.firebase_messaging.const import (
     GCM_SERVER_KEY_B64,
 )
 from custom_components.googlefindmy.Auth.firebase_messaging.fcmregister import (
+    FcmCheckinTransientError,
     FcmRegister,
     FcmRegisterConfig,
     FcmRegisterHTTPError,
@@ -819,3 +820,156 @@ async def test_gcm_register_classifier_independent_of_logger_output(
     # Defense is independent of logger output: the silenced logger
     # captured nothing, yet the classifier still surfaced the fatal.
     assert "status=404" not in caplog.text
+
+
+# --------------------------------------------------------------------------
+# gcm_check_in transient-vs-permanent taxonomy (FcmCheckinTransientError)
+# --------------------------------------------------------------------------
+
+
+class _RaisingCheckinResponse:
+    """Async CM whose ``__aenter__`` raises a transport error (HTTP never reached)."""
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    async def __aenter__(self) -> _RaisingCheckinResponse:
+        raise self._exc
+
+    async def __aexit__(self, *_exc: object) -> None:
+        return None
+
+
+class _SequencedCheckinSession:
+    """Session stub yielding transport failures and/or HTTP responses in order.
+
+    Each configured item is either an ``Exception`` (simulating a transport-layer
+    failure such as a DNS timeout, so the endpoint is never reached) or a
+    ``_FakeResponse`` (the server answered at the HTTP layer).
+    """
+
+    def __init__(self, items: list[Exception | _FakeResponse]) -> None:
+        self._items = items
+        self.calls = 0
+
+    def post(self, **_kwargs: Any) -> _RaisingCheckinResponse | _FakeResponse:
+        self.calls += 1
+        if not self._items:
+            raise AssertionError("No more check-in items configured")
+        item = self._items.pop(0)
+        if isinstance(item, Exception):
+            return _RaisingCheckinResponse(item)
+        return item
+
+
+def _checkin_config() -> FcmRegisterConfig:
+    return FcmRegisterConfig(
+        project_id="proj",
+        app_id="app",
+        api_key="key",
+        messaging_sender_id="1234567890123",
+        bundle_id="bundle",
+    )
+
+
+async def _fast_sleep(_: float) -> None:
+    return None
+
+
+@pytest.mark.asyncio
+async def test_gcm_check_in_transient_exhaustion_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pure transport exhaustion (endpoint never reached) raises transient, not None."""
+    session = _SequencedCheckinSession([TimeoutError("DNS timeout")] * 8)
+    register = FcmRegister(_checkin_config(), http_client_session=session)
+    monkeypatch.setattr(asyncio, "sleep", _fast_sleep)
+
+    with pytest.raises(FcmCheckinTransientError):
+        await register.gcm_check_in(1, 2)
+    assert session.calls == 8  # full retry budget consumed
+
+
+@pytest.mark.asyncio
+async def test_gcm_check_in_authoritative_non_ok_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated non-OK HTTP responses (server reachable) still return None."""
+    session = _SequencedCheckinSession(
+        [_FakeResponse(500, "err", {"Content-Type": "text/plain"}) for _ in range(8)]
+    )
+    register = FcmRegister(_checkin_config(), http_client_session=session)
+    monkeypatch.setattr(asyncio, "sleep", _fast_sleep)
+
+    result = await register.gcm_check_in(1, 2)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_gcm_check_in_mixed_reached_server_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transport blip followed by non-OK HTTP is authoritative, not transient.
+
+    Guards the ``saw_http_response`` discriminator: once the endpoint answered at
+    the HTTP layer, exhaustion must return ``None`` (defer to the register
+    fallback), even though a transport exception was seen earlier.
+    """
+    session = _SequencedCheckinSession(
+        [TimeoutError("DNS blip"), TimeoutError("DNS blip")]
+        + [_FakeResponse(500, "err", {"Content-Type": "text/plain"}) for _ in range(6)]
+    )
+    register = FcmRegister(_checkin_config(), http_client_session=session)
+    monkeypatch.setattr(asyncio, "sleep", _fast_sleep)
+
+    result = await register.gcm_check_in(1, 2)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_reregister_keeping_identity_preserves_on_transient(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient check-in outage propagates without rotating the device identity."""
+    session = _SequencedCheckinSession([TimeoutError("DNS timeout")] * 8)
+    creds = {"gcm": {"android_id": 1, "security_token": 2}}
+    register = FcmRegister(_checkin_config(), creds, http_client_session=session)
+    monkeypatch.setattr(asyncio, "sleep", _fast_sleep)
+
+    register_called = False
+
+    async def _spy_register() -> Any:
+        nonlocal register_called
+        register_called = True
+        return None
+
+    monkeypatch.setattr(register, "register", _spy_register)
+
+    with pytest.raises(FcmCheckinTransientError):
+        await register.reregister_keeping_identity()
+    assert register_called is False  # no full register() -> identity kept
+    assert register.credentials == creds
+
+
+@pytest.mark.asyncio
+async def test_checkin_or_register_preserves_on_transient(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient check-in outage propagates instead of falling through to register()."""
+    session = _SequencedCheckinSession([TimeoutError("DNS timeout")] * 8)
+    creds = {"gcm": {"android_id": 1, "security_token": 2}}
+    register = FcmRegister(_checkin_config(), creds, http_client_session=session)
+    monkeypatch.setattr(asyncio, "sleep", _fast_sleep)
+
+    register_called = False
+
+    async def _spy_register() -> Any:
+        nonlocal register_called
+        register_called = True
+        return None
+
+    monkeypatch.setattr(register, "register", _spy_register)
+
+    with pytest.raises(FcmCheckinTransientError):
+        await register.checkin_or_register()
+    assert register_called is False

--- a/tests/test_fcmpushclient_started_stamp.py
+++ b/tests/test_fcmpushclient_started_stamp.py
@@ -1,0 +1,52 @@
+# tests/test_fcmpushclient_started_stamp.py
+"""Login-success path stamps the per-client STARTED-transition timestamp.
+
+Covers the ``LoginResponse`` success branch of ``FcmPushClient._handle_message``
+(the ``_started_monotonic`` stamp added alongside ``run_state = STARTED`` and the
+``persistent_ids`` reset). The supervisor's first-locate reconnect measures
+"session age since STARTED" from this field instead of the pre-start supervisor
+timestamp, so the stamp must be set exactly when the client reaches STARTED.
+
+Additive-composition discipline (same as ``FcmMessageSlim`` / ``FcmHandleSlim``):
+the real unbound async ``_handle_message`` runs against a light container that
+mirrors only the attributes the login-success branch touches, without the heavy
+production constructor. A real ``LoginResponse()`` is used (not a namespace) so
+the production ``isinstance(msg, LoginResponse)`` dispatch is exercised for real.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from custom_components.googlefindmy.Auth.firebase_messaging.fcmpushclient import (
+    ErrorType,
+    FcmPushClientRunState,
+    LoginResponse,
+)
+from tests.helpers.fcm_handle_stub import FcmMessageSlim
+
+
+@pytest.mark.asyncio
+async def test_login_success_stamps_started_monotonic() -> None:
+    """A successful login sets ``_started_monotonic``, STARTED and resets ids."""
+    slim = FcmMessageSlim()
+    # Attributes the login-success branch reads/writes beyond the Close preamble.
+    slim._reset_error_count = Mock()  # type: ignore[attr-defined]
+    slim.run_state = FcmPushClientRunState.CREATED  # type: ignore[attr-defined]
+    slim.persistent_ids = ["stale-pid"]  # type: ignore[attr-defined]
+    slim._started_monotonic = None  # type: ignore[attr-defined]
+
+    await slim._handle_message(LoginResponse())  # type: ignore[arg-type]
+
+    # The STARTED-transition stamp is set (was None) -> a real float timestamp.
+    assert isinstance(slim._started_monotonic, float)  # type: ignore[attr-defined]
+    # And the accompanying STARTED state + persistent-ids reset happened.
+    assert slim.run_state == FcmPushClientRunState.STARTED  # type: ignore[attr-defined]
+    assert slim.persistent_ids == []  # type: ignore[attr-defined]
+    slim._reset_error_count.assert_called_once_with(ErrorType.LOGIN)  # type: ignore[attr-defined]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_fcmpushclient_teardown_stream_race.py
+++ b/tests/test_fcmpushclient_teardown_stream_race.py
@@ -1,0 +1,119 @@
+# tests/test_fcmpushclient_teardown_stream_race.py
+"""Regression suite for the shutdown-race stream guards in ``FcmPushClient``.
+
+When a manual quit (or any ``stop()``) tears the connection down,
+``_do_writer_close`` nulls ``self.writer`` while the listener task may still be
+processing an in-flight inbound heartbeat. The resulting
+``_handle_ping -> _send_msg`` then reads a ``None`` writer. The historic
+``assert writer is not None`` raised ``AssertionError``, which -- being an
+``Exception`` subclass -- fell through the listener's generic arm and surfaced
+as an alarming ``"Unknown error in listener: StreamWriter is not initialized"``
+traceback for a benign shutdown.
+
+The guards now raise ``ConnectionError`` instead, which the listener already
+treats as a normal life-cycle stop (``except (ConnectionError, ssl.SSLError)``).
+These tests pin that contract for the whole error class: the send guard
+(``_send_msg``) and both read guards (``_read_varint32`` / ``_receive_msg``).
+Same additive-composition discipline as ``fcm_handle_stub.FcmMessageSlim`` --
+the real unbound methods run without the heavy production constructor.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.Auth.firebase_messaging.fcmpushclient import (
+    FcmPushClient,
+    HeartbeatAck,
+)
+
+
+class _SendSlim:
+    """Binds the real async ``_send_msg`` with a controllable ``writer``."""
+
+    def __init__(self, writer: object) -> None:
+        self.logger = logging.getLogger(__name__ + "._SendSlim")
+        self.writer = writer
+        self.first_message = False
+
+    def _log_verbose(self, msg: str, *args: object) -> None:
+        self.logger.debug(msg, *args)
+
+    def _msg_str(self, msg: object) -> str:  # noqa: PLR6301 - bound stub
+        return "<msg>"
+
+    _send_msg = FcmPushClient._send_msg  # type: ignore[assignment]
+
+
+class _ReadSlim:
+    """Binds the real async read helpers with a controllable ``reader``."""
+
+    def __init__(self, reader: object) -> None:
+        self.logger = logging.getLogger(__name__ + "._ReadSlim")
+        self.reader = reader
+        self.first_message = False
+
+    def _log_warn_with_limit(self, msg: str, *args: object) -> None:
+        self.logger.warning(msg, *args)
+
+    _read_varint32 = FcmPushClient._read_varint32  # type: ignore[assignment]
+    _receive_msg = FcmPushClient._receive_msg  # type: ignore[assignment]
+
+
+@pytest.mark.asyncio
+async def test_send_on_torn_down_writer_raises_connection_error() -> None:
+    """``_send_msg`` with a nulled writer -> ConnectionError, NOT AssertionError.
+
+    This is the exact teardown race from the bug report: an in-flight heartbeat
+    ack after ``stop()`` nulled ``self.writer``. ConnectionError routes into the
+    listener's clean-stop arm; AssertionError would surface as "Unknown error".
+    """
+    client = _SendSlim(writer=None)
+
+    with pytest.raises(ConnectionError, match="StreamWriter is not initialized"):
+        await client._send_msg(HeartbeatAck())
+
+
+@pytest.mark.asyncio
+async def test_send_on_live_writer_writes_and_drains() -> None:
+    """Happy path: a live writer still receives the packet and is drained."""
+    writer = MagicMock()
+    writer.drain = AsyncMock()
+    client = _SendSlim(writer=writer)
+
+    await client._send_msg(HeartbeatAck())
+
+    writer.write.assert_called_once()
+    writer.drain.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_read_varint32_on_unconnected_reader_raises_connection_error() -> None:
+    """Class sibling: ``_read_varint32`` with a ``None`` reader -> ConnectionError.
+
+    Note ``_do_writer_close`` only nulls ``self.writer``, never ``self.reader``,
+    so this guard fires in the not-yet-connected state rather than the exact
+    writer teardown race. It is fixed for class consistency (same assert-on-
+    stream pattern) so no sibling can surface the "Unknown error" traceback.
+    """
+    client = _ReadSlim(reader=None)
+
+    with pytest.raises(ConnectionError, match="StreamReader is not initialized"):
+        await client._read_varint32()
+
+
+@pytest.mark.asyncio
+async def test_receive_msg_on_unconnected_reader_raises_connection_error() -> None:
+    """Class sibling: ``_receive_msg`` with a ``None`` reader -> ConnectionError.
+
+    Like ``_read_varint32`` above, the reader is never nulled during teardown;
+    this covers the not-yet-connected state and keeps the whole assert-on-stream
+    class consistent (ConnectionError, not AssertionError).
+    """
+    client = _ReadSlim(reader=None)
+
+    with pytest.raises(ConnectionError, match="StreamReader is not initialized"):
+        await client._receive_msg()

--- a/tests/test_guard_async_test_marker.py
+++ b/tests/test_guard_async_test_marker.py
@@ -23,7 +23,6 @@ import pytest
 LEGACY_ALLOWLIST: set[str] = {
     "tests/test_aas_token_retrieval.py",
     "tests/test_api_location_selection.py",
-    "tests/test_cli_entry_selection.py",
     "tests/test_coordinator_locate_basics.py",
     "tests/test_coordinator_polling_basics.py",
     "tests/test_coordinator_polling_branches.py",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -688,10 +688,13 @@ class TestVaultKeysCompleteness:
         assert cache.data["owner_key"] == "owner-hex"
 
     @pytest.mark.asyncio
-    async def test_owner_key_failure_keeps_tokens(
+    async def test_owner_key_failure_is_non_fatal(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """An owner-key fetch failure exits cleanly and deletes no tokens."""
+        """An owner-key fetch failure is non-fatal: the run continues without a
+        ``SystemExit``, the shared key obtained beforehand survives, and the
+        durable tokens are left untouched (the owner key is re-derived lazily
+        at runtime, so secrets.json stays usable)."""
         from custom_components.googlefindmy import main as cli_main
 
         cache = _AsyncDictCache(
@@ -707,14 +710,42 @@ class TestVaultKeysCompleteness:
         monkeypatch.setattr(cli_main, "_ensure_shared_key", _set_shared)
         monkeypatch.setattr(cli_main, "_ensure_owner_key", _owner_boom)
 
-        with pytest.raises(SystemExit) as excinfo:
-            await cli_main._ensure_vault_keys(cache)
+        # No SystemExit: the owner-key boundary warns and continues.
+        await cli_main._ensure_vault_keys(cache)
 
-        assert excinfo.value.code == 1
         assert cache.data["oauth_token"] == "oauth"
         assert cache.data["aas_token"] == "aas"
-        # The shared key obtained before the failure also survives.
+        # The shared key obtained before the owner-key failure survives.
         assert cache.data["shared_key"] == "shared-hex"
+
+    @pytest.mark.asyncio
+    async def test_owner_key_failure_warns_with_exception_type(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The non-fatal owner-key note names the concrete exception type and
+        states that secrets.json is still usable (so the user is not misled into
+        a pointless re-login)."""
+        from custom_components.googlefindmy import main as cli_main
+
+        cache = _AsyncDictCache({"username": "u@example.com"})
+
+        async def _set_shared(_cache):  # type: ignore[no-untyped-def]
+            await _cache.set("shared_key", "shared-hex")
+
+        async def _owner_boom(_cache):  # type: ignore[no-untyped-def]
+            raise RuntimeError("SPOT failure")
+
+        monkeypatch.setattr(cli_main, "_ensure_shared_key", _set_shared)
+        monkeypatch.setattr(cli_main, "_ensure_owner_key", _owner_boom)
+
+        await cli_main._ensure_vault_keys(cache)
+
+        err = capsys.readouterr().err
+        assert "RuntimeError" in err
+        assert "non-fatal" in err
+        assert "secrets.json" in err
+        # The fatal shared-key wording must NOT appear on the owner-key path.
+        assert "vault key retrieval failed" not in err
 
 
 class TestPasteRoundTrip:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,6 +7,8 @@ it simply imports ``list_devices`` from ``nbe_list_devices`` and calls it.
 
 from __future__ import annotations
 
+import argparse
+import logging
 import subprocess
 import sys
 from unittest import mock
@@ -106,6 +108,9 @@ class TestDunderMain:
         )
         assert "--reauth" in result.stdout, (
             f"--reauth missing from --help output:\n{result.stdout}"
+        )
+        assert "--debug" in result.stdout, (
+            f"--debug missing from --help output:\n{result.stdout}"
         )
 
     def test_dunder_main_accepts_entry_flag(self) -> None:
@@ -899,3 +904,161 @@ class TestPasteRoundTrip:
         assert cache.saved[f"shared_key_{username}"] == "ddeeff"
         # The top-level field itself is preserved verbatim.
         assert cache.saved["owner_key"] == owner_hex
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point: parser surface, logging configuration, and call order
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCliParser:
+    """_build_cli_parser() exposes every documented flag."""
+
+    def test_help_lists_all_flags(self) -> None:
+        from custom_components.googlefindmy import main as cli_main
+
+        help_text = cli_main._build_cli_parser().format_help()
+        assert "--reauth" in help_text
+        assert "--entry" in help_text
+        assert "--debug" in help_text
+
+    def test_debug_defaults_to_false(self) -> None:
+        from custom_components.googlefindmy import main as cli_main
+
+        args = cli_main._build_cli_parser().parse_args([])
+        assert args.debug is False
+
+    def test_debug_flag_parses_true(self) -> None:
+        from custom_components.googlefindmy import main as cli_main
+
+        args = cli_main._build_cli_parser().parse_args(["--debug"])
+        assert args.debug is True
+
+
+class TestConfigureCliLogging:
+    """_configure_cli_logging() maps flag/env onto the basicConfig level."""
+
+    @staticmethod
+    def _captured_level(
+        monkeypatch: pytest.MonkeyPatch, *, debug_flag: bool, env: dict[str, str]
+    ) -> int:
+        from custom_components.googlefindmy import main as cli_main
+
+        captured: dict[str, object] = {}
+
+        def fake_basic_config(**kwargs: object) -> None:
+            # basicConfig is a no-op once pytest installed root handlers, so we
+            # assert on the requested level instead of the effective root level.
+            captured.update(kwargs)
+
+        monkeypatch.setattr(logging, "basicConfig", fake_basic_config)
+        cli_main._configure_cli_logging(debug_flag=debug_flag, env=env)
+        level = captured["level"]
+        assert isinstance(level, int)
+        return level
+
+    def test_flag_enables_debug(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        assert (
+            self._captured_level(monkeypatch, debug_flag=True, env={}) == logging.DEBUG
+        )
+
+    def test_env_truthy_enables_debug(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        assert (
+            self._captured_level(
+                monkeypatch, debug_flag=False, env={"GOOGLEFINDMY_DEBUG": "1"}
+            )
+            == logging.DEBUG
+        )
+
+    def test_env_falsy_stays_at_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # "0" must be treated as disabled, not merely "present" (mutation guard).
+        assert (
+            self._captured_level(
+                monkeypatch, debug_flag=False, env={"GOOGLEFINDMY_DEBUG": "0"}
+            )
+            == logging.WARNING
+        )
+
+    def test_default_is_warning(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        assert (
+            self._captured_level(monkeypatch, debug_flag=False, env={})
+            == logging.WARNING
+        )
+
+
+class TestCliMainCallOrder:
+    """_main() configures logging before authentication and bootstrap."""
+
+    def _run_main(self, monkeypatch: pytest.MonkeyPatch, *, reauth: bool) -> mock.Mock:
+        import asyncio
+
+        from custom_components.googlefindmy import main as cli_main
+
+        manager = mock.Mock()
+        namespace = argparse.Namespace(debug=True, reauth=reauth, entry=None)
+        fake_parser = mock.Mock()
+        fake_parser.parse_args.return_value = namespace
+
+        monkeypatch.setattr(cli_main, "_build_cli_parser", lambda: fake_parser)
+        monkeypatch.setattr(cli_main, "_configure_cli_logging", manager.configure)
+        monkeypatch.setattr(cli_main, "_clear_stale_tokens_for_reauth", manager.clear)
+        monkeypatch.setattr(cli_main, "_ensure_authenticated", manager.auth)
+        monkeypatch.setattr(
+            cli_main, "_resolve_effective_entry_id", lambda *a: "entry-x"
+        )
+        monkeypatch.setattr(cli_main, "_register_file_cache", lambda entry: object())
+        # Mock the coroutine factory too so no un-awaited coroutine is created
+        # (asyncio.run is mocked, so a real coroutine would leak a warning).
+        monkeypatch.setattr(cli_main, "_run_cli_bootstrap", manager.bootstrap)
+        monkeypatch.setattr(asyncio, "run", manager.run)
+
+        cli_main._main([])
+        return manager
+
+    def test_logging_configured_before_auth_and_bootstrap(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manager = self._run_main(monkeypatch, reauth=False)
+        call_names = [call[0] for call in manager.mock_calls]
+
+        assert "configure" in call_names, call_names
+        assert call_names.index("configure") < call_names.index("auth")
+        assert call_names.index("auth") < call_names.index("run")
+        # reauth was False, so the stale-token clear must NOT run.
+        assert "clear" not in call_names
+
+    def test_logging_receives_debug_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        manager = self._run_main(monkeypatch, reauth=False)
+        manager.configure.assert_called_once_with(debug_flag=True, env=mock.ANY)
+
+    def test_reauth_clears_before_auth(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        manager = self._run_main(monkeypatch, reauth=True)
+        call_names = [call[0] for call in manager.mock_calls]
+        assert call_names.index("clear") < call_names.index("auth")
+
+    def test_keyboard_interrupt_prints_exiting(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A Ctrl-C during the bootstrap is caught and reported, not propagated."""
+        import asyncio
+
+        from custom_components.googlefindmy import main as cli_main
+
+        namespace = argparse.Namespace(debug=False, reauth=False, entry=None)
+        fake_parser = mock.Mock()
+        fake_parser.parse_args.return_value = namespace
+
+        monkeypatch.setattr(cli_main, "_build_cli_parser", lambda: fake_parser)
+        monkeypatch.setattr(cli_main, "_configure_cli_logging", lambda **kwargs: None)
+        monkeypatch.setattr(cli_main, "_ensure_authenticated", lambda: None)
+        monkeypatch.setattr(cli_main, "_resolve_effective_entry_id", lambda *a: "")
+        monkeypatch.setattr(cli_main, "_register_file_cache", lambda entry: object())
+        monkeypatch.setattr(cli_main, "_run_cli_bootstrap", lambda *a: None)
+
+        def _raise(_coro: object) -> None:
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(asyncio, "run", _raise)
+
+        cli_main._main([])
+        assert "Exiting." in capsys.readouterr().out

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -293,6 +293,117 @@ class TestResolveEffectiveEntryId:
         assert _resolve_effective_entry_id("", "env_value") == ""
 
 
+class _TrackingSession:
+    """Fake ``aiohttp.ClientSession`` context manager that records closure.
+
+    ``__aexit__`` runs for ``BaseException`` (``SystemExit``) too, so a ``closed``
+    flag set to ``True`` after a vault ``sys.exit`` proves the session was not
+    leaked.  A list passed at construction time collects every instance so the
+    test can inspect the one the function created.
+    """
+
+    def __init__(
+        self, sink: list[_TrackingSession], *args: object, **kwargs: object
+    ) -> None:
+        self.closed = False
+        sink.append(self)
+
+    async def __aenter__(self) -> _TrackingSession:
+        return self
+
+    async def __aexit__(self, *exc: object) -> bool:
+        self.closed = True
+        return False  # do not suppress the propagating exception
+
+
+class TestRunCliBootstrapSessionLifecycle:
+    """`_run_cli_bootstrap` closes its aiohttp session on every exit path.
+
+    The session is opened with ``async with`` so ``__aexit__`` reaps it even when
+    ``_ensure_vault_keys`` raises ``SystemExit`` on a fatal shared-key failure.
+    A leaked session was the source of the 'Unclosed client session' / WinError-6
+    teardown noise.
+    """
+
+    @pytest.mark.asyncio
+    async def test_session_closed_on_vault_sys_exit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A ``sys.exit`` from the eager vault step still closes the session."""
+        import aiohttp
+
+        from custom_components.googlefindmy import main as cli_main
+
+        created: list[_TrackingSession] = []
+        monkeypatch.setattr(
+            aiohttp,
+            "ClientSession",
+            lambda *a, **k: _TrackingSession(created, *a, **k),
+        )
+        monkeypatch.setattr(aiohttp, "TCPConnector", lambda **k: object())
+
+        async def _ok(_cache: object) -> None:
+            return None
+
+        async def _vault_exit(_cache: object) -> None:
+            raise SystemExit(1)
+
+        monkeypatch.setattr(cli_main, "_ensure_aas_token", _ok)
+        monkeypatch.setattr(cli_main, "_ensure_vault_keys", _vault_exit)
+
+        with pytest.raises(SystemExit):
+            await cli_main._run_cli_bootstrap(object(), None)
+
+        assert created, "the function should have opened exactly one session"
+        assert created[0].closed is True
+
+    @pytest.mark.asyncio
+    async def test_session_and_fcm_closed_on_success(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """On the happy path the session closes and the FCM receiver is stopped."""
+        import aiohttp
+
+        from custom_components.googlefindmy import main as cli_main
+        from custom_components.googlefindmy.NovaApi.ListDevices import (
+            nbe_list_devices as nbe,
+        )
+
+        created: list[_TrackingSession] = []
+        monkeypatch.setattr(
+            aiohttp,
+            "ClientSession",
+            lambda *a, **k: _TrackingSession(created, *a, **k),
+        )
+        monkeypatch.setattr(aiohttp, "TCPConnector", lambda **k: object())
+
+        stopped: list[bool] = []
+
+        class _Fcm:
+            async def async_stop(self) -> None:
+                stopped.append(True)
+
+        async def _ok(_cache: object) -> None:
+            return None
+
+        async def _fcm(_cache: object) -> _Fcm:
+            return _Fcm()
+
+        async def _cli(*, entry_id: str | None, session: object) -> None:
+            return None
+
+        monkeypatch.setattr(cli_main, "_ensure_aas_token", _ok)
+        monkeypatch.setattr(cli_main, "_ensure_vault_keys", _ok)
+        monkeypatch.setattr(cli_main, "_clear_stale_adm_token", _ok)
+        monkeypatch.setattr(cli_main, "_setup_fcm_receiver", _fcm)
+        monkeypatch.setattr(nbe, "_async_cli_main", _cli)
+
+        await cli_main._run_cli_bootstrap(object(), "entry_x")
+
+        assert created and created[0].closed is True
+        assert stopped == [True]
+
+
 # ---------------------------------------------------------------------------
 # AP-B1: atomic JSON write + clean vault-failure exit
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Summary

This rolls up the next slice of the `jleinenbach` fork's `1.7` line (integration **1.7.7 → 1.7.8**) on top of the already-merged `1.7.7` contribution (#194). It is an **additive** contribution focused on the **bundled standalone CLI first-run experience** (the `python main.py` flow that creates `secrets.json` for Home Assistant) and on the **reliability of the very first device locate** after a fresh setup. It removes several misleading or alarming error messages, adds an opt-in `--debug` switch, and hardens a transient-network edge case so a temporary blip can no longer discard a working device identity. No existing behavior is removed for users; the diff is `+2545 / -143` across 17 files, including 2 new regression-test files and substantial new coverage in 6 existing test files.

- Type: ☑ fix ☑ feat ☑ test
- Scope/Area: standalone CLI bootstrap, FCM receiver / first-locate, chrome-driver teardown, GCM check-in classification, tests
- Linked issues: continues the first-run-setup / FCM-reliability theme; bundles fork PRs #1146, #1147, #1148, #1149, #1150, #1151

> **Note for reviewers:** unlike some earlier contributions, the two `1.7` branches **share a merge base here** (the merged #194 / `1.7.7` tip), so GitHub shows a **clean 6-commit, 17-file diff**, not a full tree diff. This PR **deletes no user-facing files and reverts nothing** from upstream. Each of the 6 commits was individually reviewed (Codex) and CI-green on the fork. The higher "commits behind" count GitHub may display is an artifact of BSkando's own merge commits of earlier `jleinenbach` PRs, whose content is already present here; it does not affect the diff above.

## Motivation

After the `1.7.7` contribution, the bundled standalone CLI and the first FCM locate still had several first-run rough edges:

1. Run from the **nested repo layout**, the CLI dead-ended in an opaque `MissingTokenCacheError` instead of provisioning `secrets.json`.
2. Key setup exited at `Retrieving owner key...` with a **misleading** `vault key retrieval failed` / re-login message, even though the essential shared key had already been written.
3. The **very first device locate** after a fresh registration deterministically timed out (30s), even though a later restart worked.
4. A benign shutdown surfaced an alarming `Unknown error in listener: StreamWriter is not initialized` traceback, plus `WinError 6` / unclosed-session noise on Windows.
5. A **transient** network failure (for example a DNS timeout) during GCM check-in could be misread as a broken identity and trigger a full re-registration that discarded working keys.
6. There was **no way to capture a debug log** from the CLI to diagnose any of the above.

---

## Change Log (human-readable)

### Added
- **Opt-in `--debug` logging for the standalone CLI (#1148).** A new `--debug` flag (surfaced in `--help`) plus a `GOOGLEFINDMY_DEBUG` env toggle. The package previously configured no logging at all, so every `debug`/`info` line in the bootstrap and FCM path was discarded and the first-run locate timeout was impossible to capture from a log file. Logging is configured **before** the auth/FCM steps; the default stays `WARNING` so normal runs remain quiet.
- **2 new regression-test files** (`test_fcmpushclient_started_stamp.py`, `test_fcmpushclient_teardown_stream_race.py`) plus substantial new coverage in 6 existing test files, pinning each fixed behavior.

### Fixed
- **Clearer, non-fatal key setup, misleading error removed (#1146).** The owner-key pre-fetch now has its own error boundary. The owner key is optional and is re-derived lazily at runtime, so a failed pre-fetch no longer aborts the whole run with a misleading `vault key retrieval failed` / re-login prompt at `Retrieving owner key...`; it warns with the concrete exception type and continues. The essential, browser-bound shared key still fails fatally with the sign-in hint. (Integration version bumped to **1.7.8**.)
- **Bundled CLI now provisions from any layout (#1147).** The bootstrap-vs-serve decision is keyed off the token-cache signal instead of the folder name, so `python main.py` creates `secrets.json` whether it is run from a flat folder or the nested Home Assistant path (previously the nested layout dead-ended in `MissingTokenCacheError`). `--reauth` is honored in any layout.
- **Deterministic, quiet CLI teardown (#1147).** The shared aiohttp session now closes on every exit path, including `sys.exit(1)` from a fatal key step (fixes the `Unclosed client session` / `WinError 6` leak). `undetected_chromedriver`'s garbage-collection re-quit is neutralized idempotently and guarded, so the benign `WinError 6` "handle is invalid" noise is gone, while uc's cleanup for a **failed** driver construction is preserved (Codex #1147 follow-up).
- **Reliable first device locate after a fresh setup (#1148, #1150).** The manual-locate readiness gate now derives its wait budget from the library's own connect-retry window and **fails closed** instead of fail-open, so a fresh FCM identity is no longer abandoned before it can connect. Before the first locate, a young, not-yet-delivering session is reconnected exactly once (per-entry serialized, identity-scoped, failing closed if the replacement never starts), because reaching `STARTED` alone does not guarantee push delivery. The FCM token is re-read **entry-scoped** after the reconnect, so a multi-account setup never routes another account's token.
- **No alarming traceback on a normal shutdown (#1149).** A manual quit could null the stream writer while an in-flight heartbeat was still being handled, raising an `AssertionError` that surfaced as `Unknown error in listener: StreamWriter is not initialized`. The stream guards now raise a clean `ConnectionError`, which the listener already treats as a normal connection life-cycle event and stops on quietly.
- **A transient network blip no longer discards a working identity (#1151).** A pure transport-layer GCM check-in exhaustion (for example a DNS timeout) was collapsed into `None`, indistinguishable from an authoritative empty response, so callers ran a full `register()` that discarded a working GCM/FCM identity, amplifying a temporary outage into identity loss. A new `FcmCheckinTransientError` distinguishes transport exhaustion from an authoritative response; the identity is preserved and the supervisor retries later.

### Removed
- Nothing user-facing. (Internally, an unreachable serve-only CLI branch was dropped in #1147.)

### Compatibility
- **No breaking changes expected.** The `config_entry` schema version is unchanged; existing working installs are unaffected. Version bumped **1.7.7 → 1.7.8**. The changes are confined to the standalone CLI bootstrap and the FCM first-locate / teardown paths.

### Security/Privacy
- No changes to redaction or stored data. The new `--debug` logging raises verbosity of the local CLI run only; the default level is unchanged.

---

## Tests

- ☑ Each of the 6 bundled commits shipped with its own new/updated **unit and integration tests**, all mutation-verified (reverting the fix turns the test red).
- ☑ For each bugfix a **minimal regression test** is included.
- Provenance note (honest): this PR **bundles already-merged, individually CI-green and Codex-reviewed fork commits** (#1146 to #1151) for upstream; **no new code was added in this bundling step**, so no separate full-suite run was performed here. `chrome_driver.py` stayed at 100% line/branch coverage and `mypy --strict` was clean on the relevant commits per their fork CI.

### Expected areas
- ☑ **Standalone CLI bootstrap**: layout-independent provisioning, non-fatal owner-key path, deterministic session/driver teardown, `--debug`.
- ☑ **FCM receiver / first locate**: readiness gate fail-closed + budget, one-shot fresh-session reconnect, entry-scoped token refresh.
- ☑ **GCM check-in**: transient transport exhaustion classified and identity preserved.

---

## Risk & Rollback
- Risk level: ☑ low
- Rollback plan: each change is an isolated, independently revertible commit. No schema or data migrations. The scope is the standalone CLI and the FCM first-locate / teardown paths; installed HA runtimes are unaffected apart from the more robust first locate and quieter logs.
