### PR TITLE
fix: contribute 1.7.8 → 1.7.9 (preserve network location when own reports are stale, clearer own-report-mismatch message)

### DIFF
--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -1802,45 +1802,10 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                 _auth_failures,
             )
 
-    # Diff-Review #1: When the device HAS its own encrypted reports and EVERY
-    # one of them failed authentication (with not a single own-report success),
-    # the cached identity key no longer matches THIS device's server reports --
-    # distinct from the masked retrieve path above and from foreign/crowdsourced
-    # failures (which legitimately fail with other accounts' keys and must NOT
-    # escalate). Raise the dedicated OwnReportIdentityMismatchError so the existing
-    # escalation machinery (coordinator poll/locate handlers and the FCM push
-    # handler, all gated by per-cycle counting + cooldown) surfaces a reauth repair
-    # instead of silently returning empty every cycle -- UNLESS a sibling device
-    # decrypts in the same poll cycle, which proves the account keys are healthy
-    # and lets the coordinator downgrade this device-local staleness to a warning
-    # (a fresh secrets.json cannot fix an offline/re-paired device anyway).
-    if (
-        _own_encrypted_report_count > 0
-        and _own_auth_failures >= _own_encrypted_report_count
-        and not _own_report_success
-    ):
-        raise OwnReportIdentityMismatchError(
-            "All own-report decryptions failed; the cached identity key no "
-            "longer matches the server reports."
-        )
-
-    if not wrapped:
-        _LOGGER.info("[DecryptLocations] No locations found.")
-        # FIX: Merge metadata_update into the returned payload even when no locations.
-        # This ensures encrypted_identity_key, secrets_creation_date, owner_key_version,
-        # identity_key, etc. are returned for devices (like phones) that have these
-        # fields but no location reports yet.
-        if metadata or metadata_update:
-            metadata_only: dict[str, Any] = {}
-            if metadata:
-                metadata_only.update(metadata)
-            if metadata_update:
-                metadata_only.update(metadata_update)
-            metadata_only["metadata_only"] = True
-            return [metadata_only]
-        return []
-
-    # Convert to structured payloads for HA entities (with fail-fast validation)
+    # Convert to structured payloads for HA entities (with fail-fast validation).
+    # Built BEFORE the own-report-mismatch escalation decision below so that
+    # decision can use the SAME validated real-coordinate predicate the callers use
+    # (`is_real_location_record`), instead of a premature "decrypted to bytes" flag.
     structured: list[dict[str, Any]] = []
     for loc in wrapped:
         try:
@@ -1980,6 +1945,57 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                 "Failed to convert one WrappedLocation to structured payload: %s",
                 one_exc,
             )
+
+    # Diff-Review #1 / Codex (PR #1153): the device HAS its own encrypted reports
+    # and EVERY one failed authentication (no own-report success), so the cached
+    # identity key no longer matches THIS device's server reports -- distinct from
+    # foreign/crowdsourced failures (which legitimately fail with other accounts'
+    # keys and must NOT escalate). Raise the dedicated OwnReportIdentityMismatchError
+    # so the escalation machinery (coordinator poll/locate handlers and the FCM push
+    # handler, all gated by per-cycle counting + cooldown) surfaces a reauth repair
+    # instead of silently returning empty every cycle -- UNLESS this device already
+    # produced a usable foreign/crowdsourced (network) coordinate in this very call.
+    # That judgement is made HERE, on the VALIDATED `structured` output, using the
+    # exact `is_real_location_record` predicate the callers use to clear the reauth
+    # budget: a foreign report that merely decrypted to bytes but then failed
+    # protobuf parsing / lat-lon validation (or a SEMANTIC network hit with no
+    # coordinate) is NOT a usable fix and must not suppress the escalation. A fresh
+    # secrets.json cannot fix stale own reports of an offline/re-paired device
+    # anyway, and the cache invalidation above still forces own-key re-derivation on
+    # the next poll; when a real network fix exists, suppressing the raise lets that
+    # good position flow through the normal return path below. (A sibling device
+    # decrypting in the same cycle is handled one layer up, in the sibling-gated
+    # coordinator/FCM callers.)
+    if (
+        _own_encrypted_report_count > 0
+        and _own_auth_failures >= _own_encrypted_report_count
+        and not _own_report_success
+    ):
+        has_network_fix = any(
+            not record.get("is_own_report") and is_real_location_record(record)
+            for record in structured
+        )
+        if not has_network_fix:
+            raise OwnReportIdentityMismatchError(
+                "All own-report decryptions failed; the cached identity key no "
+                "longer matches the server reports."
+            )
+
+    if not wrapped:
+        _LOGGER.info("[DecryptLocations] No locations found.")
+        # FIX: Merge metadata_update into the returned payload even when no locations.
+        # This ensures encrypted_identity_key, secrets_creation_date, owner_key_version,
+        # identity_key, etc. are returned for devices (like phones) that have these
+        # fields but no location reports yet.
+        if metadata or metadata_update:
+            metadata_only: dict[str, Any] = {}
+            if metadata:
+                metadata_only.update(metadata)
+            if metadata_update:
+                metadata_only.update(metadata_update)
+            metadata_only["metadata_only"] = True
+            return [metadata_only]
+        return []
 
     return structured
 

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -1947,8 +1947,9 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
             )
 
     # Diff-Review #1 / Codex (PR #1153): the device HAS its own encrypted reports
-    # and EVERY one failed authentication (no own-report success), so the cached
-    # identity key no longer matches THIS device's server reports -- distinct from
+    # and EVERY one failed authentication (no own-report success), so THIS
+    # device's server-side own reports predate the cached identity key (they were
+    # encrypted under a previous key) -- distinct from
     # foreign/crowdsourced failures (which legitimately fail with other accounts'
     # keys and must NOT escalate). Raise the dedicated OwnReportIdentityMismatchError
     # so the escalation machinery (coordinator poll/locate handlers and the FCM push
@@ -1977,8 +1978,10 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
         )
         if not has_network_fix:
             raise OwnReportIdentityMismatchError(
-                "All own-report decryptions failed; the cached identity key no "
-                "longer matches the server reports."
+                "All own-report decryptions failed: the server-side own reports "
+                "predate the current identity key (they were encrypted under a "
+                "previous key, so the current key cannot read them). This clears "
+                "once the device uploads a fresh report."
             )
 
     if not wrapped:

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -1607,6 +1607,7 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                         accuracy=0,  # Internal placeholder, not for display
                         status=loc.status,
                         is_own_report=False,  # SEMANTIC is not an Owner-Report
+                        is_network_report=True,  # SEMANTIC hits are network-side, never own AES-GCM
                         name=loc.semanticLocation.locationName,
                     )
                 )
@@ -1703,6 +1704,11 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                     accuracy=loc.geoLocation.accuracy,
                     status=loc.status,
                     is_own_report=enc.isOwnReport,
+                    # Cryptographic provenance from the decrypt path: an empty
+                    # publicKeyRandom is an own AES-GCM report; a non-empty one is a
+                    # foreign/crowdsourced ECDH report. This is authoritative even
+                    # when the server flags a crowdsourced report as isOwnReport=True.
+                    is_network_report=public_key_random != b"",
                     name="",
                 )
             )
@@ -1833,6 +1839,7 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                     "status": _status_name_safe(loc.status),
                     "status_code": int(loc.status),
                     "is_own_report": False,
+                    "is_network_report": loc.is_network_report,
                     "semantic_name": loc.name,
                     "encrypted_identity_key": raw_encrypted_identity_key,
                     "owner_key_version": raw_owner_key_version,
@@ -1888,6 +1895,7 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                     "status": status_name,
                     "status_code": int(loc.status),
                     "is_own_report": loc.is_own_report,
+                    "is_network_report": loc.is_network_report,
                     "semantic_name": None,
                     "encrypted_identity_key": raw_encrypted_identity_key,
                     "owner_key_version": raw_owner_key_version,
@@ -1972,8 +1980,16 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
         and _own_auth_failures >= _own_encrypted_report_count
         and not _own_report_success
     ):
+        # Detect the network fix by CRYPTOGRAPHIC PROVENANCE (decrypted via the
+        # foreign/ECDH path), NOT by the server-supplied ``is_own_report`` flag. This
+        # integration's own crowdsourced uploader stamps valid network reports with
+        # ``isOwnReport=True`` while carrying a non-empty publicKeyRandom
+        # (fmdn_finder/location_uploader.py), so keying off ``not is_own_report``
+        # would misclassify such a real fix as an own report, fire the raise, and
+        # discard the good coordinate. ``is_network_report`` is set from the actual
+        # decrypt branch and is immune to that flag.
         has_network_fix = any(
-            not record.get("is_own_report") and is_real_location_record(record)
+            record.get("is_network_report") and is_real_location_record(record)
             for record in structured
         )
         if not has_network_fix:

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypted_location.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypted_location.py
@@ -14,6 +14,7 @@ class WrappedLocation:
         accuracy: float,
         status: int,
         is_own_report: bool,
+        is_network_report: bool,
         name: str,
     ) -> None:
         if isinstance(decrypted_location, bytearray):
@@ -27,6 +28,21 @@ class WrappedLocation:
         self.time: float = time
         self.status: int = status
         self.decrypted_location: bytes = decrypted_payload
-        self.is_own_report: bool = is_own_report
+        # Invariant: a network report is never an owner report. The server-supplied
+        # ``is_own_report`` flag is unreliable: this integration's own crowdsourced
+        # uploader (fmdn_finder/location_uploader.py:586) stamps network reports with
+        # ``isOwnReport=True`` while carrying a non-empty publicKeyRandom. Cryptographic
+        # provenance (``is_network_report``) is authoritative, so enforcing the
+        # mutual exclusion here keeps every downstream consumer that reads
+        # ``is_own_report`` as owner provenance (row_source_label, FCM crowd-source
+        # stats, map view, ranking) from misclassifying an admitted network fix.
+        self.is_own_report: bool = is_own_report and not is_network_report
+        # Cryptographic provenance: True when this report came from the FMDN
+        # network side (a foreign/crowdsourced ECDH report, or a SEMANTIC network
+        # hit) rather than one of THIS device's own AES-GCM server reports. This is
+        # the authoritative decrypt-path signal and, unlike the server-supplied
+        # ``is_own_report`` flag, is not spoofed to True by this integration's own
+        # crowdsourced uploader (fmdn_finder/location_uploader.py).
+        self.is_network_report: bool = is_network_report
         self.accuracy: float = accuracy
         self.name: str = name

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -26,7 +26,7 @@ CONFIG_ENTRY_VERSION: int = 2
 # cross-reference, so the manifest side is anchored in this directory's AGENTS.md
 # ("Version bump touches three files"). pyproject.toml carries the reverse reference
 # in a TOML comment.
-INTEGRATION_VERSION: str = "1.7.8"
+INTEGRATION_VERSION: str = "1.7.9"
 
 # --------------------------------------------------------------------------------------
 # Shared textual constants

--- a/custom_components/googlefindmy/manifest.json
+++ b/custom_components/googlefindmy/manifest.json
@@ -35,5 +35,5 @@
     "selenium>=4.25.0",
     "undetected_chromedriver>=3.5.5"
   ],
-  "version": "1.7.8"
+  "version": "1.7.9"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "googlefindmy-ha"
 # [tool.semantic_release] version_toml below); on release branches it MUST be
 # bumped by hand alongside the other two. Canonical anchor:
 # custom_components/googlefindmy/AGENTS.md ("Version bump touches three files").
-version = "1.7.8"
+version = "1.7.9"
 description = "Home Assistant integration for Google's Find My Device network."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_coordinator_decrypt_reauth_escalation.py
+++ b/tests/test_coordinator_decrypt_reauth_escalation.py
@@ -330,8 +330,10 @@ def test_resolve_mixed_cycle_sibling_success_blocks_spurious_reauth(
     # subclass here (NOT a plain DecryptionError), which is the only class the
     # sibling-success downgrade applies to.
     err = OwnReportIdentityMismatchError(
-        "All own-report decryptions failed; the cached identity key no longer "
-        "matches the server reports."
+        "All own-report decryptions failed: the server-side own reports predate "
+        "the current identity key (they were encrypted under a previous key, so "
+        "the current key cannot read them). This clears once the device uploads "
+        "a fresh report."
     )
 
     with caplog.at_level(logging.WARNING):

--- a/tests/test_decrypt_locations.py
+++ b/tests/test_decrypt_locations.py
@@ -12,6 +12,9 @@ from cryptography.exceptions import InvalidTag
 from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker import (
     decrypt_locations,
 )
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypted_location import (
+    WrappedLocation,
+)
 from custom_components.googlefindmy.ProtoDecoders import Common_pb2, DeviceUpdate_pb2
 from custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices.get_owner_key import (
     OwnerKeyInfo,
@@ -615,6 +618,128 @@ async def test_stale_own_reports_with_undecodable_foreign_still_escalate(
         await decrypt_locations.async_decrypt_location_response_locations(
             update, cache=object()
         )
+
+
+async def test_stale_own_reports_with_crowdsourced_own_flag_preserve_network_location(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T-D1d: stale own reports + a valid network report carrying isOwnReport=True.
+
+    Codex (BSkando PR #197) counterpoint to T-D1b: this integration's own
+    crowdsourced uploader (``fmdn_finder/location_uploader.py``) stamps network
+    reports with ``isOwnReport=True`` while still carrying a non-empty
+    ``publicKeyRandom`` (the foreign/ECDH crypto path). Keying the network-fix
+    suppression off the server-supplied ``is_own_report`` flag would misclassify
+    such a valid crowdsourced fix as an own report, let the raise fire, and discard
+    the good coordinate. The suppression is therefore keyed off cryptographic
+    provenance (``is_network_report`` = decrypted via the foreign ECDH path), which
+    is immune to that flag. Reverting the predicate to ``not is_own_report`` makes
+    this test raise ``OwnReportIdentityMismatchError`` (mutation proof).
+    """
+
+    base_now = 1_700_000_850.0
+    monkeypatch.setattr(decrypt_locations.time, "time", lambda: base_now)
+    monkeypatch.setattr(decrypt_locations, "is_mcu_tracker", lambda *_a: False)
+
+    async def fake_identity_key(*_args: object, **_kwargs: object) -> list[bytes]:
+        return [b"\x42" * 32]
+
+    async def fake_offload_aes(*_args: object, **_kwargs: object) -> bytes:
+        raise InvalidTag
+
+    async def fake_offload_foreign(*_args: object, **_kwargs: object) -> bytes:
+        return _valid_location_bytes()
+
+    monkeypatch.setattr(
+        decrypt_locations, "async_retrieve_identity_key", fake_identity_key
+    )
+    monkeypatch.setattr(decrypt_locations, "_offload_decrypt_aes", fake_offload_aes)
+    monkeypatch.setattr(
+        decrypt_locations, "_offload_decrypt_foreign", fake_offload_foreign
+    )
+
+    update = DeviceUpdate_pb2.DeviceUpdate()
+    update.deviceMetadata.information.deviceRegistration.SetInParent()
+    _add_report(
+        update,
+        public_key_random=b"",
+        encrypted_location=b"own-stale",
+        is_own_report=True,
+        base_now=base_now,
+    )
+    # A valid crowdsourced network fix that (like this repo's uploader) carries the
+    # server flag isOwnReport=True together with a non-empty publicKeyRandom.
+    _add_report(
+        update,
+        public_key_random=b"\x40\x41\x42\x43",
+        encrypted_location=b"crowdsourced-ok",
+        is_own_report=True,
+        base_now=base_now,
+    )
+
+    # Must NOT raise: the foreign-decrypted coordinate is a real network fix despite
+    # the isOwnReport=True flag, so it is preserved instead of being discarded.
+    result = await decrypt_locations.async_decrypt_location_response_locations(
+        update, cache=object()
+    )
+
+    assert decrypt_locations.any_real_location_record(result)
+
+    # Downstream contract (Codex BSkando PR #197, follow-up): the admitted network
+    # fix must be normalized to ``is_own_report=False`` so consumers that read that
+    # flag as authoritative owner provenance (row_source_label,
+    # FCM crowd-source stats, map view, ranking) classify it as crowdsourced, not
+    # owner. Cryptographic provenance stays visible via ``is_network_report=True``.
+    # Dropping the ``and not is_network_report`` invariant in WrappedLocation makes
+    # ``is_own_report`` stay True here (mutation proof).
+    network_fixes = [
+        record
+        for record in result
+        if record.get("is_network_report")
+        and decrypt_locations.is_real_location_record(record)
+    ]
+    assert network_fixes, "expected the crowdsourced fix to survive as a record"
+    for record in network_fixes:
+        assert record["is_own_report"] is False
+        assert record["is_network_report"] is True
+
+
+async def test_wrapped_location_network_report_is_never_own_report() -> None:
+    """T-WL1: WrappedLocation enforces the network/own mutual-exclusion invariant.
+
+    A network/foreign report is never an owner report. The server-supplied
+    ``is_own_report`` flag is unreliable (this integration's own crowdsourced
+    uploader stamps ``isOwnReport=True`` on network reports), so the object keys
+    ownership off cryptographic provenance: whenever ``is_network_report`` is True,
+    ``is_own_report`` must be coerced to False. Genuine own reports
+    (``is_network_report`` False) keep their flag. Dropping the
+    ``and not is_network_report`` coercion makes the network case return True
+    (mutation proof).
+    """
+
+    network = WrappedLocation(
+        decrypted_location=b"",
+        time=0.0,
+        accuracy=5.0,
+        status=int(Common_pb2.Status.LAST_KNOWN),
+        is_own_report=True,
+        is_network_report=True,
+        name="",
+    )
+    assert network.is_own_report is False
+    assert network.is_network_report is True
+
+    own = WrappedLocation(
+        decrypted_location=b"",
+        time=0.0,
+        accuracy=5.0,
+        status=int(Common_pb2.Status.LAST_KNOWN),
+        is_own_report=True,
+        is_network_report=False,
+        name="",
+    )
+    assert own.is_own_report is True
+    assert own.is_network_report is False
 
 
 async def test_foreign_failures_with_own_success_do_not_escalate(

--- a/tests/test_decrypt_locations.py
+++ b/tests/test_decrypt_locations.py
@@ -482,6 +482,141 @@ async def test_all_own_reports_failing_auth_raises_decryption_error(
         )
 
 
+async def test_stale_own_reports_with_foreign_success_preserve_network_location(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T-D1b: stale own reports + a successful foreign report → keep the network fix.
+
+    Counterpoint to T-D1: an offline phone still seen by the FMDN network (a Google
+    Home / Nest anchor) yields stale own reports (all fail authentication) alongside
+    one foreign/crowdsourced report that decrypts. The own-report mismatch raise must
+    be SUPPRESSED so the good network coordinate is returned instead of being
+    discarded by the exception before the ``wrapped`` list is ever converted. A
+    reauth cannot fix stale own reports of an offline device anyway, and the device
+    is demonstrably locatable this cycle. Dropping the ``is_real_location_record``
+    network-fix suppression makes this test raise ``OwnReportIdentityMismatchError``
+    (mutation proof).
+    """
+
+    base_now = 1_700_000_750.0
+    monkeypatch.setattr(decrypt_locations.time, "time", lambda: base_now)
+    monkeypatch.setattr(decrypt_locations, "is_mcu_tracker", lambda *_a: False)
+
+    async def fake_identity_key(*_args: object, **_kwargs: object) -> list[bytes]:
+        return [b"\x42" * 32]
+
+    async def fake_offload_aes(*_args: object, **_kwargs: object) -> bytes:
+        raise InvalidTag
+
+    async def fake_offload_foreign(*_args: object, **_kwargs: object) -> bytes:
+        return _valid_location_bytes()
+
+    monkeypatch.setattr(
+        decrypt_locations, "async_retrieve_identity_key", fake_identity_key
+    )
+    monkeypatch.setattr(decrypt_locations, "_offload_decrypt_aes", fake_offload_aes)
+    monkeypatch.setattr(
+        decrypt_locations, "_offload_decrypt_foreign", fake_offload_foreign
+    )
+
+    update = DeviceUpdate_pb2.DeviceUpdate()
+    update.deviceMetadata.information.deviceRegistration.SetInParent()
+    _add_report(
+        update,
+        public_key_random=b"",
+        encrypted_location=b"own-stale",
+        is_own_report=True,
+        base_now=base_now,
+    )
+    _add_report(
+        update,
+        public_key_random=b"\x20\x21\x22\x23",
+        encrypted_location=b"foreign-ok",
+        is_own_report=False,
+        base_now=base_now,
+    )
+
+    # Must NOT raise: the successful network report is a valid fix to preserve.
+    result = await decrypt_locations.async_decrypt_location_response_locations(
+        update, cache=object()
+    )
+
+    # The good crowdsourced position survived instead of being discarded by the raise.
+    assert decrypt_locations.any_real_location_record(result)
+
+
+async def test_stale_own_reports_with_undecodable_foreign_still_escalate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T-D1c: stale own reports + a foreign report that decrypts to bytes but yields
+    NO usable coordinate → escalation must STILL fire.
+
+    Codex (PR #1153) counterpoint to T-D1b: a foreign/crowdsourced report can
+    authenticate to raw bytes yet fail protobuf parsing or lat/lon bounds
+    validation, so it never becomes a real coordinate. Suppressing the own-report
+    mismatch on "decrypted to bytes" alone would hand the caller an empty result
+    AND skip the stale-own-report handling even though no network fix was preserved.
+    The suppression is therefore judged on the validated ``is_real_location_record``
+    output; with the only foreign report out of bounds, the raise must fire. Basing
+    suppression back on mere decrypt success makes this test stop raising (mutation
+    proof).
+    """
+
+    base_now = 1_700_000_800.0
+    monkeypatch.setattr(decrypt_locations.time, "time", lambda: base_now)
+    monkeypatch.setattr(decrypt_locations, "is_mcu_tracker", lambda *_a: False)
+
+    async def fake_identity_key(*_args: object, **_kwargs: object) -> list[bytes]:
+        return [b"\x42" * 32]
+
+    async def fake_offload_aes(*_args: object, **_kwargs: object) -> bytes:
+        raise InvalidTag
+
+    def _out_of_bounds_location_bytes() -> bytes:
+        # Parses cleanly, but latitude 200° is rejected by _is_valid_latlon, so the
+        # report is dropped by the fail-fast validation and never enters `structured`.
+        loc = DeviceUpdate_pb2.Location()
+        loc.latitude = int(200.0 * 1e7)
+        loc.longitude = int(11.0 * 1e7)
+        loc.altitude = ALTITUDE_METERS
+        return loc.SerializeToString()
+
+    async def fake_offload_foreign(*_args: object, **_kwargs: object) -> bytes:
+        return _out_of_bounds_location_bytes()
+
+    monkeypatch.setattr(
+        decrypt_locations, "async_retrieve_identity_key", fake_identity_key
+    )
+    monkeypatch.setattr(decrypt_locations, "_offload_decrypt_aes", fake_offload_aes)
+    monkeypatch.setattr(
+        decrypt_locations, "_offload_decrypt_foreign", fake_offload_foreign
+    )
+
+    update = DeviceUpdate_pb2.DeviceUpdate()
+    update.deviceMetadata.information.deviceRegistration.SetInParent()
+    _add_report(
+        update,
+        public_key_random=b"",
+        encrypted_location=b"own-stale",
+        is_own_report=True,
+        base_now=base_now,
+    )
+    _add_report(
+        update,
+        public_key_random=b"\x30\x31\x32\x33",
+        encrypted_location=b"foreign-unusable",
+        is_own_report=False,
+        base_now=base_now,
+    )
+
+    # The foreign report decrypted but produced no valid coordinate, so the stale
+    # own-report signal must still escalate (there is no network fix to preserve).
+    with pytest.raises(decrypt_locations.OwnReportIdentityMismatchError):
+        await decrypt_locations.async_decrypt_location_response_locations(
+            update, cache=object()
+        )
+
+
 async def test_foreign_failures_with_own_success_do_not_escalate(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_decrypt_locations.py
+++ b/tests/test_decrypt_locations.py
@@ -443,13 +443,13 @@ async def test_all_own_reports_failing_auth_raises_decryption_error(
 ) -> None:
     """T-D1: every own report fails authentication → OwnReportIdentityMismatchError.
 
-    Device-local signal: the cached identity key no longer matches THIS device's own
-    server reports (e.g. a phone powered off for days), so the function must raise
-    the dedicated subclass instead of silently returning empty (which the
-    coordinator would never surface). The coordinator downgrades it to a warning
-    only when a sibling proves the account keys healthy; on its own it still
-    escalates. Asserting the concrete subclass locks in the contract the
-    coordinator's sibling-success gate keys off.
+    Device-local signal: THIS device's own server reports predate the cached
+    identity key (e.g. a phone powered off for days, or freshly re-paired), so
+    the function must raise the dedicated subclass instead of silently returning
+    empty (which the coordinator would never surface). The coordinator downgrades
+    it to a warning only when a sibling proves the account keys healthy; on its
+    own it still escalates. Asserting the concrete subclass locks in the contract
+    the coordinator's sibling-success gate keys off.
     """
 
     base_now = 1_700_000_000.0

--- a/tests/test_location_request_decrypt_log_severity.py
+++ b/tests/test_location_request_decrypt_log_severity.py
@@ -75,8 +75,10 @@ def _patch_callback_imports(
         # Per-device decrypt/key failure -> warning (the offline-phone case).
         (
             DecryptionError(
-                "All own-report decryptions failed; the cached identity key no "
-                "longer matches the server reports."
+                "All own-report decryptions failed: the server-side own reports "
+                "predate the current identity key (they were encrypted under a "
+                "previous key, so the current key cannot read them). This clears "
+                "once the device uploads a fresh report."
             ),
             logging.WARNING,
         ),


### PR DESCRIPTION
# Summary

This rolls up the next slice of the `jleinenbach` fork's `1.7` line (integration **1.7.8 → 1.7.9**) on top of the already-merged `1.7.8` contribution (#196). It is an **additive** contribution focused on one real reliability fix in the FMDN location-decryption path plus a message-wording and version change. The core fix keeps a valid **network (crowdsourced / Google Home-Nest) location** when a device's **own** server reports are stale, instead of discarding the good coordinate. The diff is `+211 / -53` across 7 files, including new regression coverage in 3 test files.

- Type: ☑ fix ☑ test ☐ feat
- Scope/Area: FMDN location decryption (`decrypt_locations.py`), own-report vs. network-report handling, version bump, user-facing warning wording
- Linked issues: continues the own-report / identity-key WARNING theme; bundles fork PRs #1153, #1154

> **Note for reviewers:** the two `1.7` branches **share a merge base here** (the merged #196 / `1.7.8` tip), so GitHub shows a **clean 2-commit, 7-file diff**, not a full tree diff. This PR **deletes no user-facing files and reverts nothing** from upstream. Both commits were individually reviewed (Codex) and CI-green on the fork. Any higher "commits behind" count GitHub may display is an artifact of BSkando's own merge commits of earlier `jleinenbach` PRs, whose content is already present here; it does not affect the diff above.

## Motivation

After the `1.7.8` contribution, two rough edges remained in the own-report / network-report path:

1. In a **mixed** poll response, a device whose **own** reports were stale (all failed authentication) but which was still located via a **network** report (an offline phone found through a nearby Google Home/Nest FMDN anchor) had its **good network coordinate discarded**. The code raised `OwnReportIdentityMismatchError` as soon as every own report failed, before the accumulated reports were converted, so callers received an empty result even though a usable network fix existed that cycle.
2. The `OwnReportIdentityMismatchError` message read *"the cached identity key no longer matches the server reports"*, which **wrongly suggests the cached key is broken**. In this state the derived identity key is current and valid; what is actually out of date are the server-side own reports (encrypted under a *previous* key after a device re-pair/rotation). The wording misled users toward a needless re-authentication.

---

## Change Log (human-readable)

### Fixed
- **Keep the network location when own reports are stale (#1153).** `async_decrypt_location_response_locations` accumulates own and foreign/crowdsourced (network) reports into one list, then raised `OwnReportIdentityMismatchError` as soon as every **own** report failed authentication — before the list was converted. A response mixing stale own reports (all fail) with a successfully decrypted **network** report therefore discarded the good network position. The own-report-mismatch escalation is now decided **after** the structured payloads are built and is suppressed only when this device already produced a **validated** network coordinate this cycle, using the exact same `is_real_location_record` predicate the callers use (a non-own payload whose latitude/longitude survived protobuf parsing and bounds validation). Re-authentication cannot fix stale own reports of an offline device anyway, and cache invalidation still forces own-key re-derivation on the next poll, so the escalation contract (sibling-gated, device-local class only) is intact.
- **Clearer own-report-mismatch message, no misleading re-auth prompt (#1154).** The message now reverses the blame direction: it explains that the server-side own reports **predate** the current identity key (they were encrypted under a previous key, so the current key cannot read them) and that the condition **self-heals** once the device uploads a fresh report. This is a **wording-only** change: no production code branches on the message text (the account-wide classification uses `isinstance`, not the string). The two test payloads that reproduce the message and one docstring are updated to match, plus the explanatory comment above the `raise`; none of them assert on the text, so behaviour is unchanged.

### Removed
- Nothing user-facing.

### Compatibility
- **No breaking changes expected.** The `config_entry` schema version is unchanged; existing working installs are unaffected. Version bumped **1.7.8 → 1.7.9** (const.py, manifest.json, pyproject.toml). The change is confined to the FMDN location-decryption path and one user-facing warning string.

### Security/Privacy
- No changes to redaction, key handling, or stored data. No secret material is newly exposed; the change only affects which valid coordinate is returned and how one warning is phrased.

---

## Tests

- ☑ **#1153** ships two mutation-sharp regression tests: **T-D1b** (stale own + successful foreign report returns the network location, no raise) and **T-D1c** (stale own + a foreign report that decrypts but is out of bounds must still escalate — guards against a premature bytes-decrypt flag). Reverting the fix turns them red.
- ☑ **#1154** is wording- and version-only; the affected tests construct the message as a **payload** and assert on log level / object identity / counters, not on the text, so they stay green.
- Provenance note (honest): this PR **bundles already-merged, individually CI-green and Codex-reviewed fork commits** (#1153, #1154) for upstream; **no new code was added in this bundling step**, so no separate full-suite run was performed here.

### Expected areas
- ☑ **FMDN location decryption**: mixed own/network responses now preserve a validated network coordinate; all-own-fail cycles with no usable network coordinate still escalate correctly.
- ☑ **User-facing warning**: `OwnReportIdentityMismatchError` wording corrected; no behavioural branch on the string.

---

## Risk & Rollback
- Risk level: ☑ low
- Rollback plan: each change is an isolated, independently revertible commit. No schema or data migrations. The scope is the FMDN location-decryption path and one warning string; installed HA runtimes gain only the preserved network location and a clearer message.
