### PR TITLE
fix: contribute 1.7.9 → 1.7.10 (harden reauth matchers, predictive poll cadence, non-finite ignored_at guard, reauth-reason diagnostics)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,7 +417,7 @@ jobs:
           PYTHONPATH: .
         run: |
           set -o pipefail
-          poetry run pytest -q --cov --cov-report=xml --cov-report=term --cov-fail-under=72 2>&1 | tee pytest_output.log
+          poetry run pytest -q --cov --cov-report=xml --cov-report=term --cov-fail-under=73 2>&1 | tee pytest_output.log
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/custom_components/googlefindmy/Auth/aas_token_retrieval.py
+++ b/custom_components/googlefindmy/Auth/aas_token_retrieval.py
@@ -30,8 +30,10 @@ Enhancements (defensive validation & retries):
   We **do not reuse** such values. Instead, we disqualify them for the OAuth→AAS
   exchange and fall back to the next available source. This avoids brittle shortcuts.
 - Retry policy: transient transport/library errors retry with bounded exponential
-  backoff; clear auth failures (e.g., "BadAuthentication", "invalid_grant", 401/403
-  semantics like "unauthorized"/"forbidden") are **not** retried.
+  backoff; clear auth failures (e.g., "BadAuthentication", "invalid_grant") are
+  **not** retried. Non-retryable auth is matched structurally via ``error_kind``,
+  not via broad HTTP substrings (401/403, "unauthorized"/"forbidden") in free-form
+  text.
 """
 
 from __future__ import annotations
@@ -140,13 +142,15 @@ _NON_RETRYABLE_KINDS: frozenset[str] = frozenset(
 )
 
 # Substrings that surface in ``_clip(err)`` for callers that raise
-# ``RuntimeError`` without the ``error_kind`` attribute (e.g. HTTP-status
-# surfaces in sibling modules and the existing test suite).
+# ``RuntimeError`` without the ``error_kind`` attribute (legacy paths and the
+# existing test suite). Only gpsoauth-specific vocabulary is matched here. The
+# HTTP-generic tokens ("unauthorized" / "forbidden") are deliberately NOT
+# listed: genuine HTTP auth denials are carried structurally (``error_kind``),
+# and a free-text substring must not force a network-adjacent error to be
+# treated as a permanent, non-retryable auth failure.
 _NON_RETRYABLE_PATTERNS: tuple[str, ...] = (
     "badauthentication",
     "invalid_grant",
-    "unauthorized",
-    "forbidden",
     "missing 'token' in gpsoauth response",
 )
 
@@ -491,8 +495,9 @@ async def async_get_aas_token(
         - Issuance timestamp stored under `aas_token_issued_at_<username>` for TTL learning.
 
     Retry policy:
-        - Non-retryable auth failures (e.g., "BadAuthentication", "invalid_grant",
-          "unauthorized"/"forbidden") abort immediately.
+        - Non-retryable auth failures (e.g., "BadAuthentication", "invalid_grant")
+          abort immediately, matched structurally via ``error_kind`` rather than via
+          broad HTTP substrings ("unauthorized"/"forbidden") in free-form text.
         - Transient errors (network/timeouts/library) retry with exponential backoff.
 
     Args:

--- a/custom_components/googlefindmy/Auth/adm_token_retrieval.py
+++ b/custom_components/googlefindmy/Auth/adm_token_retrieval.py
@@ -17,8 +17,9 @@ Design & Fix for BadAuthentication:
   the retriever expects the full OAuth2 scope.
 - **Retry policy**: Transient network/library errors are retried with bounded backoff.
   Clear, non-recoverable auth errors (e.g., "BadAuthentication") are NOT retried.
-  Additionally, HTTP-style signals such as 401/403 or "unauthorized"/"forbidden" in
-  error messages are treated as non-retryable as well.
+  Non-retryable auth is determined structurally via ``error_kind``; broad HTTP
+  substrings (401/403, "unauthorized"/"forbidden") are deliberately NOT matched in
+  free-form error text, to avoid misclassifying network-adjacent failures.
 - Blocking `gpsoauth` calls (isolated flow) are executed in a thread executor to
   avoid blocking Home Assistant's event loop.
 
@@ -158,18 +159,19 @@ _NON_RETRYABLE_KINDS: frozenset[str] = frozenset(
 
 # Substrings that surface in ``_clip(err)`` for callers that raise
 # ``RuntimeError`` without the ``error_kind`` attribute (legacy paths and the
-# existing test suite). HTTP-status substrings are kept here so plain text
-# surfaces like "server returned 401 unauthorized" stay non-retryable.
+# existing test suite). Only gpsoauth-specific vocabulary is matched here.
+# HTTP-generic tokens ("401", "403", "unauthorized", "forbidden") are
+# deliberately NOT listed: a transient message like "retry after 4012 ms"
+# contains "401" as a substring, so keying non-retryable auth on those would
+# misclassify network hiccups as permanent auth failures. Genuine HTTP auth
+# denials are already carried structurally (``error_kind`` and the typed
+# ``err.status`` check in ``api.py``), not via free-text substring matching.
 _NON_RETRYABLE_PATTERNS: tuple[str, ...] = (
     "badauthentication",
     "invalid_grant",
     "missing 'auth' in gpsoauth response",
     "neither 'token' nor 'auth' found",
     "missing 'token'/'auth' in gpsoauth response",
-    "unauthorized",
-    "forbidden",
-    "401",
-    "403",
 )
 
 

--- a/custom_components/googlefindmy/Auth/adm_token_retrieval.py
+++ b/custom_components/googlefindmy/Auth/adm_token_retrieval.py
@@ -49,6 +49,7 @@ import logging
 import secrets
 import time
 from collections.abc import Awaitable, Callable, Mapping
+from types import ModuleType
 from typing import Any, cast
 
 # Prefer relative imports inside the package for robustness
@@ -56,6 +57,7 @@ from ..const import CONF_OAUTH_TOKEN, DATA_AAS_TOKEN, DATA_AUTH_METHOD
 from .aas_token_retrieval import async_get_aas_token  # entry-scoped AAS provider
 from .gpsoauth_loader import (
     GpsoauthModule,
+    load_gpsoauth_exceptions,
     require_gpsoauth,
 )
 from .gpsoauth_loader import (
@@ -70,6 +72,13 @@ from .token_retrieval import (
 from .username_provider import async_get_username, username_string
 
 _LOGGER = logging.getLogger(__name__)
+
+# Optional gpsoauth exceptions module (``None`` when the dependency is absent).
+# Mirrors ``aas_token_retrieval.gpsoauth_exceptions`` / ``token_retrieval`` so the
+# ADM OAuth path can classify a typed gpsoauth ``AuthError`` structurally (by
+# type) instead of relying on its (HTTP-generic) message text, which
+# ``_is_non_retryable_auth`` deliberately does not treat as non-retryable.
+gpsoauth_exceptions: ModuleType | None = load_gpsoauth_exceptions()
 
 # Constants for gpsoauth (kept for compatibility/reference)
 _CLIENT_SIG: str = "38918a453d07199354f8b19af05ec6562ced5788"
@@ -639,14 +648,34 @@ async def _perform_oauth_with_provided_aas(
     def _run() -> str:
         gpsoauth: GpsoauthModule = require_gpsoauth()
 
-        resp = gpsoauth.perform_oauth(
-            username,
-            aas_token,
-            android_id,
-            service="oauth2:https://www.googleapis.com/auth/android_device_manager",
-            app=_APP_ID,
-            client_sig=_CLIENT_SIG,
-        )
+        try:
+            resp = gpsoauth.perform_oauth(
+                username,
+                aas_token,
+                android_id,
+                service="oauth2:https://www.googleapis.com/auth/android_device_manager",
+                app=_APP_ID,
+                client_sig=_CLIENT_SIG,
+            )
+        except Exception as oauth_err:  # noqa: BLE001
+            # A typed gpsoauth ``AuthError`` is a definitive credential rejection,
+            # independent of its message text. gpsoauth may raise it instead of
+            # returning an ``Error`` dict, and its text can be HTTP-generic only
+            # (e.g. "HTTP 403 Forbidden"), which ``_is_non_retryable_auth``
+            # deliberately does not treat as non-retryable. Promote it to the
+            # structured ``error_kind="auth_error"`` channel (in
+            # ``_NON_RETRYABLE_KINDS``), mirroring the AAS exchange path and the
+            # dict-``Error`` branch below, so the retry loop stops instead of
+            # hammering a rejected AAS token.
+            if gpsoauth_exceptions is not None and isinstance(
+                oauth_err, gpsoauth_exceptions.AuthError
+            ):
+                auth_err = RuntimeError(
+                    "gpsoauth authentication failed (kind=auth_error)"
+                )
+                auth_err.error_kind = "auth_error"  # type: ignore[attr-defined]
+                raise auth_err from oauth_err
+            raise
         if not isinstance(resp, dict):
             # Never include the raw `resp` in logs/errors
             non_dict_err = RuntimeError(

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -81,6 +81,7 @@ from cryptography.exceptions import InvalidTag
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
+from custom_components.googlefindmy._reauth_reason import ReauthReasonCode
 from custom_components.googlefindmy.Auth.firebase_messaging.fcmregister import (
     FcmRegisterHTTPError,
 )
@@ -3001,6 +3002,19 @@ class FcmReceiverHA:
             if escalate and hass is not None:
                 entry = getattr(coordinator, "config_entry", None)
                 if entry is not None:
+                    # FIX 3: direct reauth site (background decrypt escalation for
+                    # a stale shared key); record the classified reason on the
+                    # matching coordinator before starting the flow. This escalation
+                    # is only reached on the account-wide stale-shared-key decrypt
+                    # path (note_decrypt_failure returns False for stale=True), so it
+                    # maps to DECRYPT_STALE_KEY -- the same code the poll and locate
+                    # equivalents use -- not an AAS/token code.
+                    recorder = getattr(coordinator, "record_reauth_reason", None)
+                    if callable(recorder):
+                        recorder(
+                            ReauthReasonCode.DECRYPT_STALE_KEY,
+                            origin="fcm_receiver_ha.py:3004",
+                        )
                     entry.async_start_reauth(hass)
 
     def _note_decrypt_success_for_entry(self, entry_id: str) -> None:

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -3117,7 +3117,7 @@ class FcmReceiverHA:
                     if callable(recorder):
                         recorder(
                             ReauthReasonCode.DECRYPT_STALE_KEY,
-                            origin="fcm_receiver_ha.py:3004",
+                            origin="fcm_receiver_ha.py:_note_decrypt_failure_for_entry",
                         )
                     entry.async_start_reauth(hass)
 

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -119,9 +119,14 @@ try:
         FCM_ABORT_ON_SEQ_ERROR_COUNT,
         FCM_CLIENT_HEARTBEAT_INTERVAL_S,
         FCM_CONNECTION_RETRY_COUNT,
+        FCM_DATA_STARVATION_S,
         FCM_IDLE_RESET_AFTER_S,
         FCM_MONITOR_INTERVAL_S,
         FCM_SERVER_HEARTBEAT_INTERVAL_S,
+        FCM_ZOMBIE_CHECK_INTERVAL_S,
+        FCM_ZOMBIE_MAX_RECONNECTS,
+        FCM_ZOMBIE_RECONNECT_BACKOFF_BASE_S,
+        FCM_ZOMBIE_RECONNECT_BACKOFF_CAP_S,
         OPT_IGNORED_DEVICES,  # for ignore fallback via options
     )
 except ImportError:  # pragma: no cover
@@ -131,8 +136,39 @@ except ImportError:  # pragma: no cover
     FCM_CONNECTION_RETRY_COUNT = 5
     FCM_MONITOR_INTERVAL_S = 1
     FCM_ABORT_ON_SEQ_ERROR_COUNT = 3
+    FCM_DATA_STARVATION_S = 900
+    FCM_ZOMBIE_CHECK_INTERVAL_S = 30
+    FCM_ZOMBIE_RECONNECT_BACKOFF_BASE_S = 60
+    FCM_ZOMBIE_RECONNECT_BACKOFF_CAP_S = 900
+    FCM_ZOMBIE_MAX_RECONNECTS = 5
     DOMAIN = "googlefindmy"
     OPT_IGNORED_DEVICES = "ignored_devices"
+
+
+# Readiness budget (seconds) for a fresh FCM identity to reach the STARTED
+# state after a (re)connect.  Derived from the library's connection-retry
+# count rather than a fixed value: a brand-new identity's first MCS connect
+# can take the full retry budget (FCM_CONNECTION_RETRY_COUNT attempts at
+# ~_FCM_READY_WAIT_PER_ATTEMPT_S each) plus a small margin.  SINGLE SOURCE OF
+# TRUTH shared by the manual-/first-locate path and the zombie-starvation
+# watchdog so the two readiness budgets can never drift.  The watchdog in
+# particular must NOT wait the full FCM_DATA_STARVATION_S (900s) here: its
+# reconnect wrapper holds the shared per-entry first-locate lock while
+# waiting, so a 900s budget would block a concurrent manual locate on the
+# same entry for up to 15 minutes (Codex F1).  The 900s starvation threshold
+# still governs the *decision* to reconnect (``_is_data_starved``); only this
+# wait-for-STARTED budget is bounded by it.
+_FCM_READY_WAIT_PER_ATTEMPT_S: float = 4.0
+_FCM_READY_WAIT_MARGIN_S: float = 2.0
+
+
+def _max_ready_wait_s() -> float:
+    """Return the STARTED-readiness budget in seconds (see note above)."""
+    return (
+        int(FCM_CONNECTION_RETRY_COUNT) * _FCM_READY_WAIT_PER_ATTEMPT_S
+        + _FCM_READY_WAIT_MARGIN_S
+    )
+
 
 # Optional import of worker run-state enum (for robust state checks)
 if TYPE_CHECKING:
@@ -426,6 +462,33 @@ class FcmReceiverHA:
         self._activity_stale_after_s: float = float(FCM_IDLE_RESET_AFTER_S)
         self._entry_health: dict[str, bool] = {}
         self._entry_last_connected_wall: dict[str, float] = {}
+
+        # Data-starvation liveness watchdog (re-arming zombie self-heal).
+        #
+        # ``_entry_last_data_delivery_monotonic`` is a *separate* clock from the
+        # activity clock above: it advances ONLY on a real locate data delivery
+        # (the cb-hit branch of ``_handle_notification_async``), never on a bare
+        # heartbeat ack. This separation is the crux of the fix -- the activity
+        # clock is heartbeat-poisoned and therefore masks starvation, so the
+        # watchdog must not consult it for "data flowing". A missing entry means
+        # "no data delivered yet" (only starved once a locate has been sent).
+        self._entry_last_data_delivery_monotonic: dict[str, float] = {}
+        # ``_entry_last_locate_sent_monotonic`` records the last time a locate was
+        # dispatched for the entry (stamped in ``async_register_for_location_
+        # updates``). The predicate requires "at least one locate since the last
+        # delivery" so an empty account (no locates -> no expected delivery) is
+        # never mis-classified as a zombie.
+        self._entry_last_locate_sent_monotonic: dict[str, float] = {}
+        # Per-entry watchdog backoff state and throttle clock.
+        self._zombie_reconnect_attempts: dict[str, int] = {}
+        self._zombie_next_allowed_reconnect_monotonic: dict[str, float] = {}
+        self._zombie_next_eval_monotonic: dict[str, float] = {}
+        # Tracked in-flight watchdog reconnect tasks (one per entry). The reconnect
+        # runs in a SEPARATE task (never inline in the supervisor monitor loop,
+        # which would deadlock: ``_force_first_locate_reconnect`` awaits a fresh
+        # STARTED pc that only the supervisor's outer loop can build). Cancelled
+        # on teardown in ``_purge_entry_tokens``.
+        self._zombie_reconnect_tasks: dict[str, asyncio.Task[None]] = {}
 
         # One-shot first-locate reconnect (#1150) serialization. Concurrent
         # manual locates for different trackers on the *same* entry both enter
@@ -1689,6 +1752,19 @@ class FcmReceiverHA:
                         )
                         if not writes_suppressed:
                             self._update_entry_health(entry_id, healthy)
+                            # Data-starvation liveness watchdog (AP4). Evaluated
+                            # only when writes are not suppressed (never against a
+                            # superseded/tombstoned generation), and throttled to
+                            # FCM_ZOMBIE_CHECK_INTERVAL_S rather than every 1s
+                            # tick. Detection + scheduling only -- the reconnect
+                            # runs as its own task, so the loop is never blocked
+                            # (no ``break``, no inline ``await`` on the reconnect).
+                            next_eval = self._zombie_next_eval_monotonic.get(entry_id)
+                            if next_eval is None or monotonic_now >= next_eval:
+                                self._zombie_next_eval_monotonic[entry_id] = (
+                                    monotonic_now + FCM_ZOMBIE_CHECK_INTERVAL_S
+                                )
+                                self._maybe_reconnect_starved(entry_id, monotonic_now)
                         if state is None:
                             _LOGGER.info(
                                 "[entry=%s] FCM client state unknown; scheduling restart",
@@ -2512,6 +2588,10 @@ class FcmReceiverHA:
 
             cb = self.location_update_callbacks.get(canonic_id)
             if cb:
+                # Real locate data delivery: stamp the data-delivery clock for
+                # every routed target entry and clear any watchdog backoff state,
+                # since data is flowing again (re-arm on the next starvation).
+                self._stamp_data_delivery(target_entries)
                 self._log_push_received(canonic_id, target_entries, route_src, 1)
                 await self._run_callback_async(cb, canonic_id, hex_string)
                 return
@@ -2555,6 +2635,30 @@ class FcmReceiverHA:
             _LOGGER.exception("Failed to handle FCM notification safely")
 
     # -------------------- Routing helpers --------------------
+
+    def _stamp_data_delivery(self, target_entries: set[str] | None) -> None:
+        """Record a real locate data delivery for every routed target entry.
+
+        Called ONLY from the cb-hit branch of ``_handle_notification_async`` (a
+        genuine locate data message), never on heartbeat acks and never from
+        ``_log_push_received``. Token routing can fan out to several receiver
+        entries under multi-account setups, so all entries in ``target_entries``
+        are stamped; a ``None`` routing set (broadcast / unknown owner) is
+        conservatively left unstamped so it can never mask starvation on a
+        specific entry. Delivery also re-arms the watchdog by clearing any
+        backoff state (data is flowing again).
+        """
+        if not target_entries:
+            return
+        now = time.monotonic()
+        for eid in target_entries:
+            self._entry_last_data_delivery_monotonic[eid] = now
+            self._reset_zombie_backoff(eid)
+
+    def _reset_zombie_backoff(self, entry_id: str) -> None:
+        """Clear the watchdog backoff/count state for *entry_id* (re-arm)."""
+        self._zombie_reconnect_attempts.pop(entry_id, None)
+        self._zombie_next_allowed_reconnect_monotonic.pop(entry_id, None)
 
     def _extract_hex_payload(self, payload: Mapping[str, Any]) -> str | None:
         """Return the decoded hex payload or None when absent."""
@@ -3470,6 +3574,18 @@ class FcmReceiverHA:
     def _purge_entry_tokens(self, entry_id: str) -> None:
         """Remove all routing references and per-entry runtime state for an entry."""
         self._entry_last_activity_monotonic.pop(entry_id, None)
+        # Data-starvation watchdog state (LC-13): drop the data/locate clocks and
+        # the backoff/count/throttle records, and cancel any in-flight watchdog
+        # reconnect task so it cannot keep working against the torn-down ``pc``
+        # after the entry is purged.
+        self._entry_last_data_delivery_monotonic.pop(entry_id, None)
+        self._entry_last_locate_sent_monotonic.pop(entry_id, None)
+        self._zombie_reconnect_attempts.pop(entry_id, None)
+        self._zombie_next_allowed_reconnect_monotonic.pop(entry_id, None)
+        self._zombie_next_eval_monotonic.pop(entry_id, None)
+        zombie_task = self._zombie_reconnect_tasks.pop(entry_id, None)
+        if zombie_task is not None and not zombie_task.done():
+            zombie_task.cancel()
         # First-locate reconnect serialization state (#1150 follow-up): drop the
         # per-entry lock and the consumed-replacement record so a later reload
         # under the same entry_id starts from a clean slate.
@@ -3826,6 +3942,174 @@ class FcmReceiverHA:
                 self._first_locate_reconnect_done[entry_id] = fresh_pc
             return fresh_pc
 
+    # -------------------- Data-starvation liveness watchdog --------------------
+
+    def _is_data_starved(self, entry_id: str, now: float) -> bool:  # noqa: PLR0911
+        """True if *entry_id* is a data-starvation zombie at monotonic time *now*.
+
+        Pure and side-effect-free (no IO): safe to call every evaluation tick.
+        Returns True only when ALL hold:
+
+        * a live client exists and is ``STARTED`` (``_is_started``);
+        * the session is *established* (``age >= _CHURN_WINDOW_S``) -- a young
+          session is the one-shot first-locate reconnect's job, not the watchdog;
+        * the activity clock (K4) is *fresh* -- the heartbeat is alive, so this
+          is a "STARTED, heartbeating, but silent" zombie, not a dead socket
+          (that is the idle-reset's job);
+        * at least ``FCM_DATA_STARVATION_S`` elapsed since the last real data
+          delivery (a missing data clock counts as "never delivered", starved
+          only in combination with the locate-sent gate below); and
+        * a locate was sent for this entry AND it is at or after the last data
+          delivery (>= 1 locate since the last delivery) -- this is what rules
+          out an empty account with no pending locate.
+        """
+        pc = self.pcs.get(entry_id)
+        if pc is None or not self._is_started(pc):
+            return False
+        age = self._session_age_s(pc)
+        if age is None or age < _CHURN_WINDOW_S:
+            return False
+        last_activity = self._entry_last_activity_monotonic.get(entry_id)
+        stale_after = max(self._activity_stale_after_s, 0.0)
+        if last_activity is None:
+            return False
+        if stale_after > 0.0 and now - last_activity > stale_after:
+            # Heartbeat is not fresh: a dead session, not a data-starved zombie.
+            return False
+        last_locate = self._entry_last_locate_sent_monotonic.get(entry_id)
+        if last_locate is None:
+            # No locate ever dispatched for this entry: nothing to expect.
+            return False
+        last_delivery = self._entry_last_data_delivery_monotonic.get(entry_id)
+        if last_delivery is None:
+            # Never delivered, but a locate was sent: starved once the locate is
+            # old enough that a healthy session would have answered.
+            return now - last_locate >= FCM_DATA_STARVATION_S
+        if now - last_delivery < FCM_DATA_STARVATION_S:
+            return False
+        # Require >= 1 locate since the last delivery, else a quiet-but-healthy
+        # account (delivered, then no new locate) would look starved.
+        return last_locate >= last_delivery
+
+    async def _reconnect_for_starvation(self, entry_id: str, max_wait_s: float) -> None:
+        """Force one cooperative reconnect for a data-starved zombie session.
+
+        Runs in its OWN task (scheduled by ``_maybe_reconnect_starved``), never
+        inline in the supervisor monitor loop -- awaiting the reconnect there
+        would deadlock, because ``_force_first_locate_reconnect`` waits for a
+        fresh STARTED client that only the supervisor's outer loop can build.
+
+        Acquires the shared ``_get_first_locate_lock(entry_id)`` (serialises
+        against the first-/manual-locate reconnect so the same ``pc`` is never
+        torn down twice), re-reads the live client under the lock, and -- if it
+        is still a live STARTED session -- calls ``_force_first_locate_reconnect``
+        UNCONDITIONALLY. It deliberately does NOT go through
+        ``_reconnect_for_first_locate``: that method's reuse gate
+        (``not _needs_first_locate_reconnect(current)``) is always True for an
+        aged zombie (``_needs_first_locate_reconnect`` returns False once
+        ``age >= _CHURN_WINDOW_S``) and would return ``current`` WITHOUT
+        reconnecting. The backoff / count / one-in-flight guard has already made
+        the reconnect decision before this runs. ``_first_locate_reconnect_done``
+        is left untouched (that latch belongs to the first-locate path).
+        """
+        async with self._get_first_locate_lock(entry_id):
+            current = self.pcs.get(entry_id)
+            if current is None or not self._is_started(current):
+                # The supervisor tore the client down (or it is no longer
+                # STARTED) between scheduling and lock acquisition; nothing to do.
+                return
+            await self._force_first_locate_reconnect(entry_id, current, max_wait_s)
+
+    def _maybe_reconnect_starved(self, entry_id: str, now: float) -> None:
+        """Schedule a watchdog reconnect if *entry_id* is a starved zombie.
+
+        Called from the supervisor monitor loop (throttled to
+        ``FCM_ZOMBIE_CHECK_INTERVAL_S``). Detection + scheduling only: it never
+        awaits the reconnect (that runs as a separate task). Guards:
+
+        * predicate ``_is_data_starved`` must hold;
+        * the backoff window must be open
+          (``now >= _zombie_next_allowed_reconnect_monotonic``);
+        * the hard reconnect ceiling ``FCM_ZOMBIE_MAX_RECONNECTS`` must not be
+          reached; and
+        * no watchdog reconnect task may be in flight for this entry.
+
+        When all pass it schedules ``_reconnect_for_starvation`` via
+        ``hass.async_create_task`` and, only once that task is created, commits
+        the next (exponentially larger, capped) backoff window and the
+        incremented attempt count. If scheduling raises ``RuntimeError`` (event
+        loop closing during shutdown) it leaves all scheduler state untouched so
+        a later tick can retry, rather than spending an attempt with no task.
+        """
+        if self._hass is None:
+            return
+        existing = self._zombie_reconnect_tasks.get(entry_id)
+        if existing is not None and not existing.done():
+            return  # one-in-flight guard (b): a reconnect is already running.
+        if not self._is_data_starved(entry_id, now):
+            return
+        next_allowed = self._zombie_next_allowed_reconnect_monotonic.get(entry_id)
+        if next_allowed is not None and now < next_allowed:
+            return  # still inside the current backoff window.
+        attempts = self._zombie_reconnect_attempts.get(entry_id, 0)
+        if attempts >= FCM_ZOMBIE_MAX_RECONNECTS:
+            return  # hard ceiling reached for this starvation episode.
+        # Plan the next backoff window (exponential from BASE, doubled per
+        # attempt, capped) and record the attempt before scheduling.
+        backoff = min(
+            FCM_ZOMBIE_RECONNECT_BACKOFF_BASE_S * (2**attempts),
+            FCM_ZOMBIE_RECONNECT_BACKOFF_CAP_S,
+        )
+        # F1: bound the reconnect's wait-for-STARTED to the conservative
+        # readiness budget (~22s), NOT FCM_DATA_STARVATION_S (900s).
+        # ``_reconnect_for_starvation`` holds the shared per-entry first-locate
+        # lock while awaiting STARTED; a 900s budget would starve a concurrent
+        # manual locate on the same entry for up to 15 minutes.  The 900s
+        # starvation threshold still gates the reconnect *decision* above; only
+        # the STARTED-wait is capped here.  Shared SSOT with the native locate
+        # path via ``_max_ready_wait_s`` so the two budgets cannot drift.
+        max_wait_s = _max_ready_wait_s()
+        # F3: schedule the task FIRST and commit the backoff-window / attempt
+        # counter only once it is guaranteed created.  During HA shutdown the
+        # event loop is closing and ``async_create_task`` raises ``RuntimeError``
+        # (same failure mode guarded at the direct-schedule paths above); if the
+        # counter were bumped before that raise, this tick would "spend" a
+        # reconnect attempt with no task ever running, drifting the entry toward
+        # ``FCM_ZOMBIE_MAX_RECONNECTS`` while never actually reconnecting.  On
+        # failure we leave all scheduler state untouched so a post-restart tick
+        # can retry.  There is no ``await`` between task creation and return, so
+        # the task body cannot run before the state below is committed.
+        try:
+            task = self._hass.async_create_task(
+                self._reconnect_for_starvation(entry_id, max_wait_s),
+                name=f"fcm_zombie_reconnect_{entry_id}",
+            )
+        except RuntimeError:
+            _LOGGER.debug(
+                "[entry=%s] Deferred watchdog reconnect: event loop unavailable "
+                "(shutdown in progress); scheduler state left intact for a later "
+                "tick",
+                entry_id,
+            )
+            return
+        self._zombie_next_allowed_reconnect_monotonic[entry_id] = now + backoff
+        self._zombie_reconnect_attempts[entry_id] = attempts + 1
+        self._zombie_reconnect_tasks[entry_id] = task
+
+        def _clear_task(_done: asyncio.Task[None], _eid: str = entry_id) -> None:
+            if self._zombie_reconnect_tasks.get(_eid) is _done:
+                self._zombie_reconnect_tasks.pop(_eid, None)
+
+        task.add_done_callback(_clear_task)
+        _LOGGER.info(
+            "[entry=%s] FCM data starvation detected (attempt %d/%d); forcing a "
+            "watchdog reconnect (next backoff %ds)",
+            entry_id,
+            attempts + 1,
+            FCM_ZOMBIE_MAX_RECONNECTS,
+            backoff,
+        )
+
     async def _reconnect_and_refresh_token(
         self, entry_id: str, previous_token: str, max_wait_s: float
     ) -> str | None:
@@ -3904,6 +4188,10 @@ class FcmReceiverHA:
             return None
 
         self.location_update_callbacks[canonic_id] = callback
+        # Watchdog signal (AP2.5): a locate has now been dispatched for this
+        # entry. The starvation predicate requires >= 1 locate since the last
+        # delivery, so an empty account (no locates) never looks like a zombie.
+        self._entry_last_locate_sent_monotonic[entry_id] = time.monotonic()
 
         token: str | None = None
         try:
@@ -3943,12 +4231,7 @@ class FcmReceiverHA:
                 # small margin keeps a fresh registration from being abandoned
                 # prematurely, which is the root of the deterministic first-run
                 # locate timeout.
-                _PER_ATTEMPT_WAIT_S = 4.0
-                _READY_WAIT_MARGIN_S = 2.0
-                _MAX_READY_WAIT_S = (
-                    int(FCM_CONNECTION_RETRY_COUNT) * _PER_ATTEMPT_WAIT_S
-                    + _READY_WAIT_MARGIN_S
-                )
+                _MAX_READY_WAIT_S = _max_ready_wait_s()
                 started_pc = await self._await_entry_started(
                     entry_id, pc, _MAX_READY_WAIT_S
                 )

--- a/custom_components/googlefindmy/Auth/token_retrieval.py
+++ b/custom_components/googlefindmy/Auth/token_retrieval.py
@@ -250,9 +250,10 @@ def _perform_oauth_sync(
         # mirroring the AAS exchange path (``aas_token_retrieval`` treats
         # ``gpsoauth.AuthError`` by type), so the rejected AAS token is
         # invalidated/regenerated instead of being left in cache for a retry.
-        if gpsoauth_exceptions is not None and isinstance(
+        is_typed_autherror = gpsoauth_exceptions is not None and isinstance(
             err, gpsoauth_exceptions.AuthError
-        ):
+        )
+        if is_typed_autherror:
             raise InvalidAasTokenError(
                 f"gpsoauth rejected the AAS token while requesting scope '{scope}': {message}"
             ) from err
@@ -264,6 +265,34 @@ def _perform_oauth_sync(
             raise InvalidAasTokenError(
                 f"gpsoauth rejected the AAS token while requesting scope '{scope}': {message}"
             ) from err
+        # AP-2 field probe (typed-vs-untyped denial). The vendor auth endpoint is
+        # reverse-engineered: a genuine credential denial arrives as an ``Error``
+        # dict (handled above) or a typed ``gpsoauth.AuthError``; anything else
+        # reaching this fall-through is, by the vendor model, a transport or
+        # intermediary artifact and is (correctly) surfaced as a retryable
+        # ``RuntimeError``. Record the classification *signature* so a field
+        # occurrence of "untyped error whose text still carries an HTTP auth
+        # marker, treated as transient" -- the fingerprint of a *missed* denial
+        # slipping past ``allow_http_generic=False`` -- becomes observable.
+        # Redaction: only the exception type name, the typed-flag and which
+        # markers are present; never ``str(err)`` (may carry a token or email).
+        # ``is_typed_autherror`` is structurally False here (the typed branch
+        # raised above); it is logged verbatim so the fall-through signature is
+        # explicit rather than implied.
+        http_auth_markers = [
+            marker
+            for marker in ("401", "403", "unauthorized", "forbidden")
+            if marker in message.lower()
+        ]
+        _LOGGER.debug(
+            "Auth token fetch for scope %r fell through to a retryable "
+            "RuntimeError (err_type=%s, is_typed_autherror=%s, "
+            "http_auth_markers=%s)",
+            scope,
+            type(err).__name__,
+            is_typed_autherror,
+            http_auth_markers,
+        )
         raise RuntimeError(
             f"Failed to get auth token for scope '{scope}': {err}"
         ) from err

--- a/custom_components/googlefindmy/Auth/token_retrieval.py
+++ b/custom_components/googlefindmy/Auth/token_retrieval.py
@@ -10,6 +10,7 @@ import asyncio
 import logging
 import secrets
 from collections.abc import Awaitable, Callable
+from types import ModuleType
 from typing import Any
 
 from custom_components.googlefindmy.Auth.aas_token_retrieval import (
@@ -21,6 +22,7 @@ from custom_components.googlefindmy.exceptions import MissingTokenCacheError
 
 from .gpsoauth_loader import (
     GpsoauthModule,
+    load_gpsoauth_exceptions,
     require_gpsoauth,
 )
 from .gpsoauth_loader import (
@@ -28,6 +30,13 @@ from .gpsoauth_loader import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+# Optional gpsoauth exceptions module (``None`` when the dependency is absent).
+# Mirrors ``aas_token_retrieval.gpsoauth_exceptions`` so both credential-exchange
+# paths can classify a genuine gpsoauth ``AuthError`` structurally (by type),
+# independent of its (possibly HTTP-generic) message text. Kept at module scope
+# so tests can monkeypatch it, exactly like the AAS exchange path.
+gpsoauth_exceptions: ModuleType | None = load_gpsoauth_exceptions()
 
 
 class InvalidAasTokenError(RuntimeError):
@@ -233,6 +242,20 @@ def _perform_oauth_sync(
         raise
     except Exception as err:  # noqa: BLE001
         message: str = str(err)
+        # A typed gpsoauth ``AuthError`` is a definitive credential rejection,
+        # independent of its message text. gpsoauth may raise it instead of
+        # returning an ``Error`` dict, and its text can be HTTP-generic only
+        # (e.g. "HTTP 403 Forbidden"), which the text matcher deliberately
+        # gates off (``allow_http_generic=False``). Classify it structurally,
+        # mirroring the AAS exchange path (``aas_token_retrieval`` treats
+        # ``gpsoauth.AuthError`` by type), so the rejected AAS token is
+        # invalidated/regenerated instead of being left in cache for a retry.
+        if gpsoauth_exceptions is not None and isinstance(
+            err, gpsoauth_exceptions.AuthError
+        ):
+            raise InvalidAasTokenError(
+                f"gpsoauth rejected the AAS token while requesting scope '{scope}': {message}"
+            ) from err
         # Generic exception string: keep ``allow_http_generic=False`` so a
         # transport/network error whose text merely contains "unauthorized" or
         # "forbidden" cannot masquerade as an invalid AAS token. Only the

--- a/custom_components/googlefindmy/Auth/token_retrieval.py
+++ b/custom_components/googlefindmy/Auth/token_retrieval.py
@@ -43,15 +43,27 @@ def _gpsoauth() -> GpsoauthModule:
 gpsoauth = _gpsoauth_proxy
 
 
-def _is_invalid_aas_error_text(text: str) -> bool:
-    """Return True when the error string indicates an invalid AAS token."""
+def _is_invalid_aas_error_text(text: str, *, allow_http_generic: bool = False) -> bool:
+    """Return True when the error string indicates an invalid AAS token.
+
+    The gpsoauth-specific tokens (``badauthentication``, ``needsbrowser``, and
+    the ``invalid`` + credential vocabulary) are unique to the gpsoauth
+    ``Error`` field and stay active on every call. The HTTP-generic tokens
+    (``unauthorized`` / ``forbidden``) are only honoured when
+    ``allow_http_generic`` is set, because an arbitrary transport/network
+    exception string must not be able to masquerade as an invalid AAS token
+    and discard otherwise-valid credential material. Callers that pass the
+    structured gpsoauth ``Error`` field opt in via ``allow_http_generic=True``;
+    callers that pass a generic ``str(err)`` from an ``except Exception`` block
+    keep the safe default (``False``).
+    """
 
     lowered = text.lower()
     if "badauthentication" in lowered:
         return True
     if "needsbrowser" in lowered:
         return True
-    if "unauthorized" in lowered or "forbidden" in lowered:
+    if allow_http_generic and ("unauthorized" in lowered or "forbidden" in lowered):
         return True
     if "invalid" in lowered:
         if "token" in lowered or "auth" in lowered or "credential" in lowered:
@@ -210,7 +222,9 @@ def _perform_oauth_sync(
             return token_value
 
         error_detail = str(auth_response.get("Error", "")).strip()
-        if error_detail and _is_invalid_aas_error_text(error_detail):
+        if error_detail and _is_invalid_aas_error_text(
+            error_detail, allow_http_generic=True
+        ):
             raise InvalidAasTokenError(
                 f"gpsoauth rejected the AAS token while requesting scope '{scope}': {error_detail}"
             )
@@ -219,6 +233,10 @@ def _perform_oauth_sync(
         raise
     except Exception as err:  # noqa: BLE001
         message: str = str(err)
+        # Generic exception string: keep ``allow_http_generic=False`` so a
+        # transport/network error whose text merely contains "unauthorized" or
+        # "forbidden" cannot masquerade as an invalid AAS token. Only the
+        # gpsoauth-specific vocabulary may promote this to InvalidAasTokenError.
         if message and _is_invalid_aas_error_text(message):
             raise InvalidAasTokenError(
                 f"gpsoauth rejected the AAS token while requesting scope '{scope}': {message}"

--- a/custom_components/googlefindmy/SpotApi/GetEidInfoForE2eeDevices/get_owner_key.py
+++ b/custom_components/googlefindmy/SpotApi/GetEidInfoForE2eeDevices/get_owner_key.py
@@ -39,6 +39,7 @@ from typing import Any, NamedTuple
 from cryptography.exceptions import InvalidTag
 from homeassistant.exceptions import ConfigEntryAuthFailed
 
+from custom_components.googlefindmy._reauth_reason import ReauthReasonCode
 from custom_components.googlefindmy.Auth.token_cache import TokenCache
 from custom_components.googlefindmy.Auth.username_provider import (
     async_get_username,
@@ -160,9 +161,11 @@ async def _retrieve_owner_key(
         try:
             eid_info = await async_get_eid_info(cache=cache)
         except SpotAuthPermanentError as exc:
-            raise ConfigEntryAuthFailed(
+            reauth_exc = ConfigEntryAuthFailed(
                 "Owner key retrieval failed: Google session invalid; re-authentication required."
-            ) from exc
+            )
+            reauth_exc.reauth_code = ReauthReasonCode.OWNER_KEY_PERMANENT
+            raise reauth_exc from exc
         except SpotApiEmptyResponseError:
             _LOGGER.error(
                 "Owner key retrieval failed: SPOT returned an empty/trailers-only "
@@ -396,10 +399,12 @@ async def async_get_owner_key(  # noqa: PLR0912,PLR0915
         # UNCHANGED deliberately, because whether an empty/trailers-only response
         # is transient or auth is not yet proven. The captured gRPC status (R9a)
         # makes the next real incident diagnosable before any reclassification.
-        raise ConfigEntryAuthFailed(
+        reauth_exc = ConfigEntryAuthFailed(
             "Owner key retrieval failed: SPOT returned an empty/trailers-only "
             "response; the exact gRPC status is logged for diagnosis."
-        ) from exc
+        )
+        reauth_exc.reauth_code = ReauthReasonCode.OWNER_KEY_EMPTY_RESPONSE
+        raise reauth_exc from exc
 
     cache_version: int | None = None
     cache_key_value: str | None = None

--- a/custom_components/googlefindmy/_reauth_reason.py
+++ b/custom_components/googlefindmy/_reauth_reason.py
@@ -1,0 +1,91 @@
+# custom_components/googlefindmy/_reauth_reason.py
+"""Structured, redaction-safe reauth-reason model for coordinator diagnostics.
+
+This module defines the small, self-contained data model used to persist *why*
+a re-authentication was triggered so it becomes visible in the diagnostics
+download without requiring a ``--debug`` log capture.
+
+Design invariants (see PLAN AE-6/AE-7):
+
+- :class:`ReauthReasonCode` is a :class:`~enum.StrEnum` so serialization to the
+  diagnostics payload is trivial (``str(code)``) and every value is a stable,
+  literal identifier that is safe to expose verbatim.
+- :class:`ReauthReason` only ever carries *literal-only* inputs: a
+  :class:`ReauthReasonCode`, a constant literal ``origin`` string supplied at the
+  call site, integer counters, and an epoch timestamp. It never stores
+  ``str(err)``, tokens, e-mail addresses, or any other free-form/PII content.
+  This "literal-only input" invariant is what makes the diagnostics mirror
+  redaction-safe by construction (not a length cap).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+
+class ReauthReasonCode(StrEnum):
+    """Stable, redaction-safe identifiers for re-authentication triggers.
+
+    The values are literal identifiers only; they carry no request-specific or
+    user-specific content and are therefore safe to expose in diagnostics.
+    """
+
+    # api.py device-list / location HTTP 401/403 after a token refresh.
+    HTTP_401_AFTER_REFRESH = "http_401_after_refresh"
+    # api.py gpsoauth BadAuthentication / missing token.
+    BADAUTH_GPSOAUTH = "badauth_gpsoauth"
+    # Spot transport permanent auth failure (SpotAuthPermanentError from
+    # spot_request.py: AAS token invalid after refresh / gRPC UNAUTHENTICATED /
+    # PERMISSION_DENIED). General Spot-session-permanent, not owner-key specific.
+    SPOT_AUTH_PERMANENT = "spot_auth_permanent"
+    # get_owner_key permanent Spot session failure.
+    OWNER_KEY_PERMANENT = "owner_key_permanent"
+    # get_owner_key empty/trailers-only SPOT response (transient/auth unproven).
+    OWNER_KEY_EMPTY_RESPONSE = "owner_key_empty_response"
+    # api.py "TokenCache is closed" invalid-state escalation.
+    TOKENCACHE_CLOSED = "tokencache_closed"
+    # api.py transient/generic Nova auth failure (single, immediate escalation).
+    NOVA_AUTH_FAILED = "nova_auth_failed"
+    # poll-cycle transient Nova auth failure that persisted across
+    # _MAX_TRANSIENT_AUTH_FAILURES consecutive cycles before escalating. Distinct
+    # from NOVA_AUTH_FAILED because "flaky auth that exhausted its retries" is the
+    # primary poll-reauth signal (the reported intermittent-network case) and must
+    # stay separable from a single hard failure. The counters snapshot carries the
+    # consecutive/threshold counts.
+    NOVA_AUTH_TRANSIENT_EXHAUSTED = "nova_auth_transient_exhausted"
+    # api.py permanent Nova auth failure (NovaAuthPermanentError / is_permanent).
+    NOVA_AUTH_PERMANENT = "nova_auth_permanent"
+    # coordinator/polling FCM fatal auth error escalation.
+    FCM_AUTH_FATAL = "fcm_auth_fatal"
+    # poll-cycle account-wide location-decryption escalation: repeated decrypt
+    # failures across _MAX_DECRYPT_FAILURES consecutive cycles prove the shared
+    # key is stale and a fresh secrets.json is required. Distinct from the auth
+    # codes above because the trigger is a decryption verdict (not an auth-API
+    # error); it is the last poll-reauth cause that would otherwise record
+    # UNKNOWN in diagnostics.
+    DECRYPT_STALE_KEY = "decrypt_stale_key"
+    # Default when a catch site finds no ``reauth_code`` attribute on the
+    # exception, or a direct reauth site without a more specific classification.
+    UNKNOWN = "unknown"
+
+
+@dataclass(slots=True)
+class ReauthReason:
+    """Typed, redaction-safe record of the most recent re-authentication trigger.
+
+    Attributes:
+        code: The classified :class:`ReauthReasonCode`.
+        origin: A constant literal string identifying the call site (for
+            example ``"api.py:1099"``). Never derived from runtime introspection
+            and never carries request/user content.
+        counters: A snapshot of relevant integer counters at record time (for
+            example the consecutive-transient-auth-failure count and its
+            threshold). Values are plain ints only.
+        recorded_at: Epoch seconds (UTC wall clock) when the reason was recorded.
+    """
+
+    code: ReauthReasonCode
+    origin: str
+    counters: dict[str, int] = field(default_factory=dict)
+    recorded_at: float = 0.0

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -35,6 +35,7 @@ from aiohttp import ClientError, ClientSession
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
+from ._reauth_reason import ReauthReasonCode
 from .Auth.token_cache import TokenCache
 from .Auth.username_provider import username_string
 from .const import (
@@ -1059,7 +1060,9 @@ class GoogleFindMyAPI:
                     err.status,
                     _short_err(err),
                 )
-                raise ConfigEntryAuthFailed(_short_err(err)) from err
+                exc = ConfigEntryAuthFailed(_short_err(err))
+                exc.reauth_code = ReauthReasonCode.HTTP_401_AFTER_REFRESH
+                raise exc from err
             _LOGGER.warning(
                 "Device list temporarily unavailable (server error %s): %s",
                 err.status,
@@ -1068,10 +1071,27 @@ class GoogleFindMyAPI:
             raise UpdateFailed(_short_err(err)) from err
 
         except NovaAuthError as err:
-            _LOGGER.error(
-                "Authentication failed while listing devices: %s", _short_err(err)
-            )
-            raise ConfigEntryAuthFailed(_short_err(err)) from err
+            # Mirror the location path's base handler: a permanent credential
+            # failure (NovaAuthPermanentError subclass, or a base NovaAuthError
+            # flagged is_permanent=True after token refresh) must record the
+            # permanent reason, not the generic/transient one, so diagnostics
+            # point triage at the right credential layer. Control flow is
+            # unchanged (both cases raise ConfigEntryAuthFailed); only the
+            # reason code and log wording differ by permanence.
+            exc = ConfigEntryAuthFailed(_short_err(err))
+            if err.is_permanent:
+                _LOGGER.error(
+                    "Permanent authentication failure while listing devices: %s",
+                    _short_err(err),
+                )
+                exc.reauth_code = ReauthReasonCode.NOVA_AUTH_PERMANENT
+            else:
+                _LOGGER.error(
+                    "Authentication failed while listing devices: %s",
+                    _short_err(err),
+                )
+                exc.reauth_code = ReauthReasonCode.NOVA_AUTH_FAILED
+            raise exc from err
 
         except NovaProtobufDecodeError as err:
             # Protobuf decode failures indicate corrupted response or protocol mismatch
@@ -1096,7 +1116,9 @@ class GoogleFindMyAPI:
                 or "Bad Authentication" in msg
             ):
                 _LOGGER.error("Authentication failed (gpsoauth): %s", _short_err(msg))
-                raise ConfigEntryAuthFailed(_short_err(msg)) from err
+                exc = ConfigEntryAuthFailed(_short_err(msg))
+                exc.reauth_code = ReauthReasonCode.BADAUTH_GPSOAUTH
+                raise exc from err
 
             # TokenCache closed indicates the integration is in an invalid state
             # (e.g., after a failed reload or during shutdown). Trigger re-auth
@@ -1106,9 +1128,11 @@ class GoogleFindMyAPI:
                     "TokenCache is closed; integration state is invalid. "
                     "Triggering re-authentication to reinitialize."
                 )
-                raise ConfigEntryAuthFailed(
+                exc = ConfigEntryAuthFailed(
                     "Integration state invalid (cache closed); please re-authenticate"
-                ) from err
+                )
+                exc.reauth_code = ReauthReasonCode.TOKENCACHE_CLOSED
+                raise exc from err
 
             # Detect and tame the multi-entry guard (INFO once, DEBUG thereafter)
             if _is_multi_entry_guard_message(msg):
@@ -1275,7 +1299,9 @@ class GoogleFindMyAPI:
                 device_id,
                 _short_err(err),
             )
-            raise ConfigEntryAuthFailed(_short_err(err)) from err
+            exc = ConfigEntryAuthFailed(_short_err(err))
+            exc.reauth_code = ReauthReasonCode.NOVA_AUTH_PERMANENT
+            raise exc from err
 
         except NovaAuthError as err:
             # Transient auth failure - may self-heal in subsequent poll cycles.
@@ -1287,7 +1313,9 @@ class GoogleFindMyAPI:
                     device_id,
                     _short_err(err),
                 )
-                raise ConfigEntryAuthFailed(_short_err(err)) from err
+                exc = ConfigEntryAuthFailed(_short_err(err))
+                exc.reauth_code = ReauthReasonCode.NOVA_AUTH_PERMANENT
+                raise exc from err
 
             _LOGGER.warning(
                 "Transient authentication error for %s (%s): %s. May resolve in next poll cycle.",
@@ -1308,7 +1336,9 @@ class GoogleFindMyAPI:
                     device_id,
                     _short_err(err),
                 )
-                raise ConfigEntryAuthFailed(_short_err(err)) from err
+                exc = ConfigEntryAuthFailed(_short_err(err))
+                exc.reauth_code = ReauthReasonCode.HTTP_401_AFTER_REFRESH
+                raise exc from err
             _LOGGER.warning(
                 "Server error (%s) while getting location for %s (%s): %s",
                 err.status,

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -27,7 +27,7 @@ CONFIG_ENTRY_VERSION: int = 2
 # cross-reference, so the manifest side is anchored in this directory's AGENTS.md
 # ("Version bump touches three files"). pyproject.toml carries the reverse reference
 # in a TOML comment.
-INTEGRATION_VERSION: str = "1.7.9"
+INTEGRATION_VERSION: str = "1.7.10"
 
 # --------------------------------------------------------------------------------------
 # Shared textual constants

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -514,6 +514,50 @@ FCM_MONITOR_INTERVAL_S: int = 1
 FCM_ABORT_ON_SEQ_ERROR_COUNT: int = 3
 
 # --------------------------------------------------------------------------------------
+# FCM data-starvation liveness watchdog (re-arming zombie self-heal)
+# --------------------------------------------------------------------------------------
+# A "zombie" FCM session is STARTED and keeps acking heartbeats (so the activity
+# clock and readiness gate both look healthy), yet has stopped delivering
+# ``push_received`` data messages despite locates being sent. The one-shot
+# first-locate reconnect only covers a *young* session (age < _CHURN_WINDOW_S);
+# a long-running session that goes silent is only healed by a manual reload
+# today (empirically sometimes twice). The watchdog below detects this and
+# forces a cooperative, backoff-limited reconnect that re-arms after each cycle.
+#
+# FCM_DATA_STARVATION_S: minimum gap (seconds) since the last real data delivery
+# before a STARTED, heartbeating, locate-active session is treated as starved.
+# Calibration (live DEBUG capture 2026-07-04, 2h23m healthy window): normal gaps
+# between data messages reach ~349s (they grow with the observation window; only
+# ~305s over a 71-min window), so the threshold must be a *generous* multiple of
+# the poll cycle, well above 349s, never a value near it. 900s ≈ 3 default poll
+# cycles (300s) and ≈ 30× the 30s locate timeout — conservatively large so the
+# watchdog reacts later, never more aggressively (storm-safe by construction).
+# The MCS session lifetime is ~2h, so 15-minute detection is fast enough.
+FCM_DATA_STARVATION_S: int = 900
+
+# FCM_ZOMBIE_CHECK_INTERVAL_S: how often the watchdog *evaluates* starvation.
+# The supervisor monitor loop ticks every FCM_MONITOR_INTERVAL_S (1s); evaluating
+# the predicate every tick is wasteful, so the watchdog is throttled to run at
+# most once per this interval (30× rarer than the tick, far denser than the
+# starvation window, so detection latency stays well under a minute).
+FCM_ZOMBIE_CHECK_INTERVAL_S: int = 30
+
+# FCM_ZOMBIE_RECONNECT_BACKOFF_BASE_S: first backoff window after the first
+# watchdog reconnect. Subsequent windows double (60 → 120 → 240 → …) up to the
+# cap below, so a session that stays starved is retried with growing patience.
+FCM_ZOMBIE_RECONNECT_BACKOFF_BASE_S: int = 60
+
+# FCM_ZOMBIE_RECONNECT_BACKOFF_CAP_S: upper bound of the exponential backoff
+# (equals the starvation window: never retry faster than the detection cadence).
+FCM_ZOMBIE_RECONNECT_BACKOFF_CAP_S: int = 900
+
+# FCM_ZOMBIE_MAX_RECONNECTS: hard ceiling on watchdog reconnects per starvation
+# episode. The count (and backoff) reset on the first successful data delivery
+# after a reconnect. Together with the cap and the one-in-flight lock this bounds
+# the worst case to a slow, finite series — never a reconnect storm / self-DoS.
+FCM_ZOMBIE_MAX_RECONNECTS: int = 5
+
+# --------------------------------------------------------------------------------------
 # Feature Flags (compile-time toggles for optional functionality)
 # --------------------------------------------------------------------------------------
 # FMDN Finder: Upload location reports to Google for FMDN beacons detected by Bermuda.
@@ -687,6 +731,11 @@ __all__ = [
     "FCM_CONNECTION_RETRY_COUNT",
     "FCM_MONITOR_INTERVAL_S",
     "FCM_ABORT_ON_SEQ_ERROR_COUNT",
+    "FCM_DATA_STARVATION_S",
+    "FCM_ZOMBIE_CHECK_INTERVAL_S",
+    "FCM_ZOMBIE_RECONNECT_BACKOFF_BASE_S",
+    "FCM_ZOMBIE_RECONNECT_BACKOFF_CAP_S",
+    "FCM_ZOMBIE_MAX_RECONNECTS",
     "EVENT_AUTH_ERROR",
     "EVENT_AUTH_OK",
     "TRANSLATION_KEY_AUTH_STATUS",

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -8,6 +8,7 @@ Keep comments and docstrings in English; user-facing strings belong in translati
 from __future__ import annotations
 
 import hashlib
+import math
 import time
 from collections.abc import Mapping, Sequence
 from typing import Final, Literal
@@ -290,6 +291,27 @@ def _coerce_aliases(value: object) -> list[str]:
     return []
 
 
+def _finite_int_or_none(value: object) -> int | None:
+    """Convert a finite ``int``/``float`` to ``int``; return ``None`` otherwise.
+
+    ``bool``, non-numeric types, and non-finite floats (``NaN``/``±inf``) all
+    yield ``None``. This exists because ``int(float("nan"))`` raises
+    ``ValueError`` and ``int(float("inf"))`` raises ``OverflowError`` -- either
+    would defeat the drop-invalid, never-raise contract of the coercer below
+    when a corrupt ``.storage`` edit or a direct-options writer stores such a
+    value. Guarding on ``math.isfinite`` keeps that coercer total.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            return None
+        return int(value)
+    return None
+
+
 def coerce_ignored_mapping(raw: object) -> tuple[IgnoredMapping, bool]:
     """Coerce various legacy shapes into v2 mapping.
     Accepted inputs:
@@ -346,8 +368,9 @@ def coerce_ignored_mapping(raw: object) -> tuple[IgnoredMapping, bool]:
                         name = name_value
                     aliases = _coerce_aliases(str_meta.get(_IGN_KEY_ALIASES))
                     ignored_value = str_meta.get(_IGN_KEY_IGNORED_AT)
-                    if isinstance(ignored_value, (int, float)):
-                        ignored_at = int(ignored_value)
+                    coerced_at = _finite_int_or_none(ignored_value)
+                    if coerced_at is not None:
+                        ignored_at = coerced_at
                     source_value = str_meta.get(_IGN_KEY_SOURCE)
                     if isinstance(source_value, str) and source_value:
                         source = source_value

--- a/custom_components/googlefindmy/coordinator/_mixin_typing.py
+++ b/custom_components/googlefindmy/coordinator/_mixin_typing.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers import device_registry as dr
 
+    from .._reauth_reason import ReauthReason, ReauthReasonCode
     from ..api import GoogleFindMyAPI
     from .subentry import SubentryMetadata
 
@@ -103,6 +104,8 @@ class _MixinBase:
     _fcm_defer_started_mono: float
     _consecutive_transient_auth_failures: int
     _last_transient_auth_error: str | None
+    # Structured, redaction-safe record of the most recent reauth trigger (FIX 3).
+    _reauth_reason: ReauthReason | None
     _consecutive_decrypt_failures: int
     _last_decrypt_reauth_monotonic: float | None
     _last_decrypt_error: str | None
@@ -156,6 +159,15 @@ class _MixinBase:
 
     def note_error(
         self, exc: Exception, *, where: str = "", device: str | None = None
+    ) -> None:
+        raise NotImplementedError
+
+    def record_reauth_reason(
+        self,
+        code: ReauthReasonCode,
+        origin: str,
+        *,
+        counters: Mapping[str, int] | None = None,
     ) -> None:
         raise NotImplementedError
 

--- a/custom_components/googlefindmy/coordinator/helpers/update.py
+++ b/custom_components/googlefindmy/coordinator/helpers/update.py
@@ -217,7 +217,10 @@ def is_poll_cycle_due(
     Poll is due when:
     1. Cold start (first poll with no location data) - always due
     2. Elapsed time >= effective_interval AND not predictively blocked
-    3. Predictive due AND hard limit passed
+    3. Predictive due AND hard limit passed AND elapsed >= effective_interval
+       (min_poll_interval alone no longer triggers a poll below the chosen
+       cadence; effective_interval governs the cadence, min_poll_interval
+       stays a pure API safety floor)
 
     Args:
         elapsed: Time since last poll in seconds.
@@ -238,8 +241,13 @@ def is_poll_cycle_due(
     if elapsed >= effective_interval and not predictive_block:
         return True
 
-    # Predictive due with hard limit passed
-    if predictive_due and hard_limit_passed:
+    # Predictive due, but never below the chosen cadence. min_poll_interval
+    # stays a pure API safety floor; effective_interval governs the cadence,
+    # so predictive pre-fetch no longer pulls polling below effective_interval.
+    # hard_limit_passed is redundant while callers keep the invariant
+    # effective_interval >= min_poll_interval, but is retained so this pure
+    # function stays correct for any caller (do not "simplify" it away).
+    if predictive_due and hard_limit_passed and elapsed >= effective_interval:
         return True
 
     return False

--- a/custom_components/googlefindmy/coordinator/helpers/update.py
+++ b/custom_components/googlefindmy/coordinator/helpers/update.py
@@ -14,8 +14,17 @@ All functions are pure (no side effects) for easy testing and reuse.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Any
+
+# Word-boundary matchers for HTTP status codes. Using ``\b`` prevents a
+# transient message like "retry after 4012 ms" (which contains the substring
+# "401") from being misread as an HTTP 401, while still matching a genuine
+# "401"/"404" that appears as a standalone token (e.g. "HTTP 401 Unauthorized",
+# "Error code: 401", "404 credential not found").
+_HTTP_401_TOKEN = re.compile(r"\b401\b")
+_HTTP_404_TOKEN = re.compile(r"\b404\b")
 
 __all__ = [
     "calculate_presence_ttl",
@@ -48,12 +57,15 @@ def is_fatal_fcm_auth_error(error: Any) -> bool:
 
     error_lower = error.lower()
 
-    # 401 errors are always fatal
-    if "401" in error:
+    # 401 errors are always fatal. Match the status code on a word boundary so a
+    # transient throttling message such as "retry after 4012 ms" (substring
+    # "401") is not misclassified as an authentication failure.
+    if _HTTP_401_TOKEN.search(error):
         return True
 
-    # 404 with credential mention is fatal
-    if "404" in error and "credential" in error_lower:
+    # 404 with credential mention is fatal. Same word-boundary guard so e.g.
+    # "retry after 40412 ms" (substring "404") cannot false-fire.
+    if _HTTP_404_TOKEN.search(error) and "credential" in error_lower:
         return True
 
     # Explicit credential/auth failure messages

--- a/custom_components/googlefindmy/coordinator/locate.py
+++ b/custom_components/googlefindmy/coordinator/locate.py
@@ -517,7 +517,7 @@ class LocateOperations(_MixinBase):
                 # poll-cycle equivalent uses (polling.py) -- not an owner-key code.
                 self.record_reauth_reason(
                     ReauthReasonCode.SPOT_AUTH_PERMANENT,
-                    origin="locate.py:521",
+                    origin="locate.py:async_locate_device:spot_auth",
                 )
                 entry = getattr(self, "config_entry", None)
                 reauth_started = False
@@ -663,7 +663,7 @@ class LocateOperations(_MixinBase):
                 # (polling.py, _finalize_cycle_decrypt_state) -- not an AAS/token code.
                 self.record_reauth_reason(
                     ReauthReasonCode.DECRYPT_STALE_KEY,
-                    origin="locate.py:656",
+                    origin="locate.py:async_locate_device:decrypt_stale_key",
                 )
                 entry = getattr(self, "config_entry", None)
                 reauth_started = False

--- a/custom_components/googlefindmy/coordinator/locate.py
+++ b/custom_components/googlefindmy/coordinator/locate.py
@@ -24,6 +24,7 @@ from typing import Any
 from aiohttp import ClientConnectionError, ClientError
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 
+from .._reauth_reason import ReauthReasonCode
 from ..const import DEFAULT_MIN_POLL_INTERVAL
 from ..NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     DecryptionError,
@@ -508,6 +509,16 @@ class LocateOperations(_MixinBase):
                     failed=True,
                     reason=f"Auth failed during manual locate: {auth_err}",
                 )
+                # FIX 3: direct reauth site (no exception bubbles to a coordinator
+                # catch), so record the classified reason directly. The condition
+                # is a generic Spot-transport auth failure (SpotAuthPermanentError
+                # is raised only in spot_request.py, e.g. "AAS token invalid after
+                # refresh"), so it maps to SPOT_AUTH_PERMANENT -- the same code the
+                # poll-cycle equivalent uses (polling.py) -- not an owner-key code.
+                self.record_reauth_reason(
+                    ReauthReasonCode.SPOT_AUTH_PERMANENT,
+                    origin="locate.py:521",
+                )
                 entry = getattr(self, "config_entry", None)
                 reauth_started = False
                 if entry is not None:
@@ -644,6 +655,15 @@ class LocateOperations(_MixinBase):
                         "the shared key is stale and a fresh secrets.json "
                         "(re-authentication) is required"
                     ),
+                )
+                # FIX 3: direct reauth site (a stale shared key needs fresh
+                # credentials); record the classified reason directly. This is the
+                # account-wide stale-shared-key decrypt condition, so it maps to
+                # DECRYPT_STALE_KEY -- the same code the poll-cycle equivalent uses
+                # (polling.py, _finalize_cycle_decrypt_state) -- not an AAS/token code.
+                self.record_reauth_reason(
+                    ReauthReasonCode.DECRYPT_STALE_KEY,
+                    origin="locate.py:656",
                 )
                 entry = getattr(self, "config_entry", None)
                 reauth_started = False

--- a/custom_components/googlefindmy/coordinator/main.py
+++ b/custom_components/googlefindmy/coordinator/main.py
@@ -66,6 +66,8 @@ from datetime import datetime, timedelta
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
+from .._reauth_reason import ReauthReason, ReauthReasonCode
+
 # Operations classes - currently empty mixins for future method extraction
 from .cache import CacheOperations
 from .helpers.cache import (
@@ -892,6 +894,14 @@ class GoogleFindMyCoordinator(
         self._consecutive_transient_auth_failures: int = 0
         self._last_transient_auth_error: str | None = None
 
+        # FIX 3: structured, redaction-safe record of the most recent reauth
+        # trigger, mirrored into diagnostics so the reason is visible without a
+        # debug log capture. ``None`` until the first reauth is recorded.
+        self._reauth_reason: ReauthReason | None = None
+        # De-dup set for the once-per (code, origin) WARNING emitted by
+        # ``record_reauth_reason`` so a repeating trigger does not spam the log.
+        self._reauth_reason_logged: set[tuple[str, str]] = set()
+
         # Stale/missing shared-key decryption failures escalate to a reauth flow
         # only after several consecutive cycles, with a cooldown so the flow is not
         # re-fired on every poll once it is already open. Mirrors the transient-auth
@@ -1472,6 +1482,64 @@ class GoogleFindMyCoordinator(
             prefix += f"({device})"
         err_type = type(exc).__name__
         self._append_recent_error(err_type, f"{prefix}: {exc}")
+
+    def record_reauth_reason(
+        self,
+        code: ReauthReasonCode,
+        origin: str,
+        *,
+        counters: Mapping[str, int] | None = None,
+    ) -> None:
+        """Persist a structured, redaction-safe reason for a reauth trigger.
+
+        This is the single choke point that turns a classified reauth trigger
+        into diagnosable state. It stores a :class:`ReauthReason` on the
+        coordinator (mirrored into diagnostics) and emits a **once-per**
+        ``(code, origin)`` WARNING with structured ``extra=`` fields so a
+        repeating trigger does not spam the log.
+
+        The inputs are literal-only by contract: ``code`` is a
+        :class:`ReauthReasonCode`, ``origin`` is a constant literal string
+        supplied at the call site, and ``counters`` (defaulting to a snapshot of
+        the transient-auth-failure counter and its threshold) are plain ints.
+        No token, e-mail, or ``str(err)`` content is ever stored or logged here.
+
+        Args:
+            code: The classified reauth reason code.
+            origin: A constant literal string identifying the call site.
+            counters: Optional counter snapshot; when omitted the current
+                transient-auth-failure count and its threshold are captured.
+        """
+        if counters is None:
+            snapshot: dict[str, int] = {
+                "consecutive_transient_auth_failures": int(
+                    self._consecutive_transient_auth_failures
+                ),
+                "max_transient_auth_failures": int(_MAX_TRANSIENT_AUTH_FAILURES),
+            }
+        else:
+            snapshot = {key: int(value) for key, value in counters.items()}
+
+        self._reauth_reason = ReauthReason(
+            code=code,
+            origin=origin,
+            counters=snapshot,
+            recorded_at=time.time(),
+        )
+
+        dedup_key = (str(code), origin)
+        if dedup_key not in self._reauth_reason_logged:
+            self._reauth_reason_logged.add(dedup_key)
+            _LOGGER.warning(
+                "Re-authentication triggered (%s at %s)",
+                code,
+                origin,
+                extra={
+                    "reauth_code": str(code),
+                    "reauth_origin": origin,
+                    "reauth_counters": snapshot,
+                },
+            )
 
     # Safe getters for durations based on keys that __init__.py may set.
     def get_metric(self, key: str) -> float | None:

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -45,6 +45,7 @@ from homeassistant.core import Event
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
+from .._reauth_reason import ReauthReasonCode
 from ..Auth.fcm_receiver_ha import CRASH_LOOP_FATAL_PREFIX
 from ..const import (
     DEVICE_LIST_POLL_INTERVAL,
@@ -615,6 +616,7 @@ class PollingOperations(_MixinBase):
                 "is stale; a fresh secrets.json (re-authentication) "
                 "is required"
             )
+            reauth_exc.reauth_code = ReauthReasonCode.DECRYPT_STALE_KEY
             return True, reauth_exc, reauth_exc
         if self._decrypt_failure_is_account_wide(
             cycle_decrypt_error, cycle_had_successful_decrypt
@@ -1111,7 +1113,13 @@ class PollingOperations(_MixinBase):
                             fatal_error,
                         )
                         self._set_auth_state(failed=True, reason=fatal_error)
-                        raise ConfigEntryAuthFailed(fatal_error)
+                        # F-4: this raise is caught by the ConfigEntryAuthFailed
+                        # handler in _async_update_data (single recording choke
+                        # point), so only tag the exception here; do NOT record
+                        # directly to avoid a double record.
+                        fcm_exc = ConfigEntryAuthFailed(fatal_error)
+                        fcm_exc.reauth_code = ReauthReasonCode.FCM_AUTH_FATAL
+                        raise fcm_exc
 
                     # Track consecutive FCM errors for transient issues
                     if fatal_error != self._fcm_last_error:
@@ -1129,7 +1137,12 @@ class PollingOperations(_MixinBase):
                             fatal_error,
                         )
                         self._set_auth_state(failed=True, reason=fatal_error)
-                        raise ConfigEntryAuthFailed(fatal_error)
+                        # F-4: caught by the _async_update_data
+                        # ConfigEntryAuthFailed handler (single recording choke
+                        # point); tag only, do not record here.
+                        fcm_exc = ConfigEntryAuthFailed(fatal_error)
+                        fcm_exc.reauth_code = ReauthReasonCode.FCM_AUTH_FATAL
+                        raise fcm_exc
                     else:
                         _LOGGER.warning(
                             "FCM error detected (%d/%d): %s. Will retry before triggering re-auth.",
@@ -1546,6 +1559,14 @@ class PollingOperations(_MixinBase):
                 failed=True,
                 reason=f"Auth failed while fetching device list: {reason}",
             )
+            # FIX 3: single recording choke point for the awaited-refresh path.
+            # The reason code rides on the exception attribute (set at the raise
+            # site, e.g. api.py / polling FCM-fatal); default to UNKNOWN when the
+            # exception carries none.
+            self.record_reauth_reason(
+                getattr(auth_exc, "reauth_code", ReauthReasonCode.UNKNOWN),
+                origin="polling.py:1541",
+            )
             raise auth_exc
         except UpdateFailed as update_err:
             # Let pre-wrapped UpdateFailed bubble as-is after updating status
@@ -1574,6 +1595,14 @@ class PollingOperations(_MixinBase):
         records ``reauth_exc`` as ``last_exception`` so the ``finally`` block marks
         the update failed via ``async_set_update_error``.
         """
+        # FIX 3: single recording choke point for the fire-and-forget poll path.
+        # All six poll-cycle reauth sites (including the 2074 pre-converted
+        # ConfigEntryAuthFailed catch) funnel through here, so record exactly
+        # once. The reason code rides on the exception attribute when present.
+        self.record_reauth_reason(
+            getattr(reauth_exc, "reauth_code", ReauthReasonCode.UNKNOWN),
+            origin="polling.py:1565",
+        )
         entry = getattr(self, "config_entry", None)
         if entry is None:
             _LOGGER.debug("Cannot start reauth from poll cycle: no config entry bound.")
@@ -1985,6 +2014,7 @@ class PollingOperations(_MixinBase):
                         reauth_exc = ConfigEntryAuthFailed(
                             "Google session invalid; re-authentication required"
                         )
+                        reauth_exc.reauth_code = ReauthReasonCode.SPOT_AUTH_PERMANENT
                         last_exception = reauth_exc
                         self._request_poll_reauth(reauth_exc)
                         return
@@ -2002,6 +2032,9 @@ class PollingOperations(_MixinBase):
                         self._consecutive_timeouts = 0
                         reauth_exc = ConfigEntryAuthFailed(
                             "Google session invalid; re-authentication required"
+                        )
+                        reauth_exc.reauth_code = (
+                            ReauthReasonCode.OWNER_KEY_EMPTY_RESPONSE
                         )
                         last_exception = reauth_exc
                         self._request_poll_reauth(reauth_exc)
@@ -2024,6 +2057,7 @@ class PollingOperations(_MixinBase):
                         reauth_exc = ConfigEntryAuthFailed(
                             "Google credentials invalid; re-authentication required"
                         )
+                        reauth_exc.reauth_code = ReauthReasonCode.NOVA_AUTH_PERMANENT
                         last_exception = reauth_exc
                         self._request_poll_reauth(reauth_exc)
                         return
@@ -2053,6 +2087,9 @@ class PollingOperations(_MixinBase):
                             self._consecutive_timeouts = 0
                             reauth_exc = ConfigEntryAuthFailed(
                                 f"Authentication failed after {self._consecutive_transient_auth_failures} attempts; re-authentication required"
+                            )
+                            reauth_exc.reauth_code = (
+                                ReauthReasonCode.NOVA_AUTH_TRANSIENT_EXHAUSTED
                             )
                             last_exception = reauth_exc
                             self._request_poll_reauth(reauth_exc)

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -1565,7 +1565,7 @@ class PollingOperations(_MixinBase):
             # exception carries none.
             self.record_reauth_reason(
                 getattr(auth_exc, "reauth_code", ReauthReasonCode.UNKNOWN),
-                origin="polling.py:1541",
+                origin="polling.py:_async_update_data",
             )
             raise auth_exc
         except UpdateFailed as update_err:
@@ -1601,7 +1601,7 @@ class PollingOperations(_MixinBase):
         # once. The reason code rides on the exception attribute when present.
         self.record_reauth_reason(
             getattr(reauth_exc, "reauth_code", ReauthReasonCode.UNKNOWN),
-            origin="polling.py:1565",
+            origin="polling.py:_request_poll_reauth",
         )
         entry = getattr(self, "config_entry", None)
         if entry is None:

--- a/custom_components/googlefindmy/diagnostics.py
+++ b/custom_components/googlefindmy/diagnostics.py
@@ -252,6 +252,50 @@ def _status_snapshot_to_dict(snapshot: Any) -> dict[str, Any] | None:
     }
 
 
+def _reauth_reason_block(coordinator: Any) -> dict[str, Any] | None:
+    """Serialize the coordinator's structured reauth reason for diagnostics.
+
+    Mirrors :func:`_status_snapshot_to_dict`: returns ``None`` when no reauth has
+    been recorded yet so the coordinator block stays structurally unchanged.
+
+    Redaction is guaranteed by the *literal-only input* invariant of
+    :class:`~._reauth_reason.ReauthReason` (see AE-7): ``code`` is a
+    ``StrEnum`` value, ``origin`` is a constant literal string, and ``counters``
+    are plain ints. No token, e-mail, or free-form ``str(err)`` content is ever
+    stored on the reason, so nothing sensitive can reach this payload.
+    """
+    reason = getattr(coordinator, "_reauth_reason", None)
+    if reason is None:
+        return None
+
+    try:
+        code = getattr(reason, "code", None)
+        origin = getattr(reason, "origin", None)
+        raw_counters = getattr(reason, "counters", None)
+        recorded_at = getattr(reason, "recorded_at", None)
+    except Exception:
+        return None
+
+    counters: dict[str, int] = {}
+    if isinstance(raw_counters, Mapping):
+        for key, value in raw_counters.items():
+            if (
+                isinstance(key, str)
+                and isinstance(value, int)
+                and not isinstance(value, bool)
+            ):
+                counters[key] = value
+
+    return {
+        "code": str(code) if code is not None else None,
+        "origin": _safe_truncate(origin) if origin is not None else None,
+        "counters": counters,
+        "recorded_at": _iso_utc(
+            recorded_at if isinstance(recorded_at, (int, float)) else None
+        ),
+    }
+
+
 def _sanitize_diag_entry(payload: Any) -> dict[str, Any]:
     """Return a diagnostics-friendly snapshot of a buffer entry."""
     if not isinstance(payload, dict):
@@ -669,6 +713,11 @@ async def async_get_config_entry_diagnostics(
             coordinator_block["setup_performance"] = setup_perf
         if recent_errors:
             coordinator_block["recent_errors"] = recent_errors
+
+        # FIX 3: structured, redaction-safe reauth reason (only when recorded).
+        reauth_reason_block = _reauth_reason_block(coordinator)
+        if reauth_reason_block is not None:
+            coordinator_block["reauth_reason"] = reauth_reason_block
 
         # Anonymized per-device telemetry (P1-3): opaque index plus seven coarse
         # fields, no names/IDs/coordinates/keys. Resilient: [] on any failure.

--- a/custom_components/googlefindmy/manifest.json
+++ b/custom_components/googlefindmy/manifest.json
@@ -35,5 +35,5 @@
     "selenium>=4.25.0",
     "undetected_chromedriver>=3.5.5"
   ],
-  "version": "1.7.9"
+  "version": "1.7.10"
 }

--- a/custom_components/googlefindmy/repairs.py
+++ b/custom_components/googlefindmy/repairs.py
@@ -12,6 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 
 from ._reauth_reason import ReauthReasonCode
+from .coordinator import GoogleFindMyCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -116,10 +117,25 @@ class FcmReauthRepairFlow(RepairsFlow):  # type: ignore[misc]
         # coordinator is reachable only via ``entry.runtime_data`` and only when
         # the entry is loaded, so record defensively and never let a missing
         # coordinator break the repair UI.
-        coordinator = getattr(getattr(entry, "runtime_data", None), "coordinator", None)
+        #
+        # RUNTIME_DATA DUALITY (mirrors the ``isinstance`` handling in
+        # ``__init__.py``): in the normal case ``runtime_data`` is a wrapper
+        # whose ``.coordinator`` attribute holds the coordinator, but on the
+        # legacy sub-entry path ``runtime_data`` *is* a bare
+        # ``GoogleFindMyCoordinator``. Resolve both shapes so the reauth reason
+        # is never silently dropped on legacy sub-entries.
+        rd = getattr(entry, "runtime_data", None)
+        coordinator = (
+            rd
+            if isinstance(rd, GoogleFindMyCoordinator)
+            else getattr(rd, "coordinator", None)
+        )
         recorder = getattr(coordinator, "record_reauth_reason", None)
         if callable(recorder):
-            recorder(ReauthReasonCode.FCM_AUTH_FATAL, origin="repairs.py:112")
+            recorder(
+                ReauthReasonCode.FCM_AUTH_FATAL,
+                origin="repairs.py:_async_start_reauth",
+            )
 
         try:
             entry.async_start_reauth(self.hass)

--- a/custom_components/googlefindmy/repairs.py
+++ b/custom_components/googlefindmy/repairs.py
@@ -11,6 +11,8 @@ from homeassistant.components.repairs import RepairsFlow
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 
+from ._reauth_reason import ReauthReasonCode
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -107,6 +109,17 @@ class FcmReauthRepairFlow(RepairsFlow):  # type: ignore[misc]
                 self._entry_id,
             )
             return False
+
+        # FIX 3: direct reauth site. NOTE (SA-11): the plan's AE-5 assumed a
+        # coordinator ``self`` is available here, but this method lives on the
+        # ``FcmReauthRepairFlow`` (a RepairsFlow), not on the coordinator. The
+        # coordinator is reachable only via ``entry.runtime_data`` and only when
+        # the entry is loaded, so record defensively and never let a missing
+        # coordinator break the repair UI.
+        coordinator = getattr(getattr(entry, "runtime_data", None), "coordinator", None)
+        recorder = getattr(coordinator, "record_reauth_reason", None)
+        if callable(recorder):
+            recorder(ReauthReasonCode.FCM_AUTH_FATAL, origin="repairs.py:112")
 
         try:
             entry.async_start_reauth(self.hass)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "googlefindmy-ha"
 # [tool.semantic_release] version_toml below); on release branches it MUST be
 # bumped by hand alongside the other two. Canonical anchor:
 # custom_components/googlefindmy/AGENTS.md ("Version bump touches three files").
-version = "1.7.9"
+version = "1.7.10"
 description = "Home Assistant integration for Google's Find My Device network."
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -368,7 +368,10 @@ skip_covered = true
 # 1.7 fix series; the floor takes effect on the next pull request (a direct push
 # to 1.7 does not run the coverage gate, which is gated on pull_request and push
 # to main).
-fail_under = 72
+# Raised to 73 per maintainer request to lock in the coverage from the typed
+# gpsoauth AuthError classification tests; measured CI total is 73.26 %, so the
+# jitter margin is intentionally tightened to 0.26 Pp headroom here.
+fail_under = 73
 exclude_lines = [
     "if __name__ == \"__main__\":",
     "pragma: no cover",

--- a/tests/helpers/locate_mixin_stub.py
+++ b/tests/helpers/locate_mixin_stub.py
@@ -86,6 +86,10 @@ class LocateStub(LocateOperations):
         self._api_push_ready = MagicMock(return_value=True)
         self._ensure_device_name_cache = MagicMock(return_value={})
         self._set_auth_state = MagicMock(return_value=None)
+        # FIX 3: cross-mixin choke point (real impl lives on the full
+        # coordinator, not on ``LocateOperations``); mock like its siblings so
+        # the direct locate-reauth sites can record without NotImplementedError.
+        self.record_reauth_reason = MagicMock(return_value=None)
         self._record_semantic_label = MagicMock(return_value=None)
         self._apply_semantic_mapping = MagicMock(return_value=False)
         self._get_google_home_filter = MagicMock(return_value=None)

--- a/tests/helpers/main_coordinator_stub.py
+++ b/tests/helpers/main_coordinator_stub.py
@@ -80,6 +80,12 @@ class MainCoordinatorStub(GoogleFindMyCoordinator):
         self._auth_error_active: bool = False
         self._auth_error_message: str | None = None
 
+        # Reauth-reason state (FIX 3), mirroring production ``__init__`` defaults
+        # so ``record_reauth_reason`` and the diagnostics mirror work here.
+        self._consecutive_transient_auth_failures: int = 0
+        self._reauth_reason: Any = None
+        self._reauth_reason_logged: set[tuple[str, str]] = set()
+
         # Force-refresh state
         self._force_device_list_refresh: bool = False
         self._force_device_list_reason: str | None = None

--- a/tests/test_aas_token_retrieval.py
+++ b/tests/test_aas_token_retrieval.py
@@ -328,12 +328,27 @@ def test_is_non_retryable_auth_invalid_grant() -> None:
     assert aas_token_retrieval._is_non_retryable_auth(err) is True
 
 
-def test_is_non_retryable_auth_unauthorized_forbidden() -> None:
-    """401/403-style errors should not be retryable."""
+def test_is_non_retryable_auth_unauthorized_forbidden_now_retryable() -> None:
+    """FIX 5: bare HTTP-generic "unauthorized"/"forbidden" strings are retryable.
+
+    These tokens were removed from ``_NON_RETRYABLE_PATTERNS`` because a
+    free-text HTTP surface must not force a network-adjacent error to be treated
+    as a permanent auth failure. Genuine denials are carried via ``error_kind``.
+    """
     assert (
-        aas_token_retrieval._is_non_retryable_auth(RuntimeError("unauthorized")) is True
+        aas_token_retrieval._is_non_retryable_auth(RuntimeError("unauthorized"))
+        is False
     )
-    assert aas_token_retrieval._is_non_retryable_auth(RuntimeError("forbidden")) is True
+    assert (
+        aas_token_retrieval._is_non_retryable_auth(RuntimeError("forbidden")) is False
+    )
+
+
+def test_is_non_retryable_auth_http_denial_via_error_kind() -> None:
+    """A structured HTTP auth denial surfaced via error_kind stays non-retryable."""
+    err = RuntimeError("server returned 401 unauthorized")
+    err.error_kind = "auth_error"  # type: ignore[attr-defined]
+    assert aas_token_retrieval._is_non_retryable_auth(err) is True
 
 
 def test_is_non_retryable_auth_missing_token() -> None:

--- a/tests/test_adm_token_retrieval.py
+++ b/tests/test_adm_token_retrieval.py
@@ -216,12 +216,20 @@ def test_is_non_retryable_auth_via_error_kind_badauthentication() -> None:
     assert adm_token_retrieval._is_non_retryable_auth(err) is True
 
 
-def test_is_non_retryable_auth_string_fallback_still_works() -> None:
-    """RuntimeError without error_kind attribute still matches via substring."""
+def test_is_non_retryable_auth_string_fallback_gpsoauth_vocabulary() -> None:
+    """RuntimeError without error_kind still matches gpsoauth-specific vocabulary.
 
-    err = RuntimeError("server returned 401 unauthorized")
+    FIX 5: the substring fallback now only recognizes gpsoauth-specific tokens.
+    A generic HTTP surface such as "server returned 401 unauthorized" is
+    retryable (no ``error_kind``, no gpsoauth token), while a genuine
+    ``badauthentication`` surface stays non-retryable.
+    """
 
-    assert adm_token_retrieval._is_non_retryable_auth(err) is True
+    http_surface = RuntimeError("server returned 401 unauthorized")
+    assert adm_token_retrieval._is_non_retryable_auth(http_surface) is False
+
+    gpsoauth_surface = RuntimeError("gpsoauth rejected: BadAuthentication")
+    assert adm_token_retrieval._is_non_retryable_auth(gpsoauth_surface) is True
 
 
 def test_is_non_retryable_auth_falsy_error_kind_falls_back_to_string() -> None:
@@ -1074,10 +1082,23 @@ def test_normalize_service_whitespace() -> None:
     )
 
 
-def test_is_non_retryable_auth_http_signals() -> None:
-    """HTTP-style auth denials should not be retryable."""
-    assert adm_token_retrieval._is_non_retryable_auth(RuntimeError("401")) is True
-    assert adm_token_retrieval._is_non_retryable_auth(RuntimeError("403")) is True
+def test_is_non_retryable_auth_http_status_substrings_are_retryable() -> None:
+    """FIX 5: bare HTTP-status substrings are no longer non-retryable.
+
+    A message like "retry after 4012 ms" contains "401" as a substring; keying
+    non-retryable auth on that substring misclassified transient throttling as a
+    permanent auth failure. Genuine HTTP auth denials are carried structurally
+    (``error_kind`` / typed ``err.status``), not via free-text substrings, so a
+    plain ``RuntimeError("401")`` / ``("403")`` must now be treated as
+    retryable.
+    """
+    assert adm_token_retrieval._is_non_retryable_auth(RuntimeError("401")) is False
+    assert adm_token_retrieval._is_non_retryable_auth(RuntimeError("403")) is False
+    # The concrete false-fire the fix targets: a transient throttling message.
+    assert (
+        adm_token_retrieval._is_non_retryable_auth(RuntimeError("retry after 4012 ms"))
+        is False
+    )
 
 
 def test_is_non_retryable_auth_neither_marker() -> None:

--- a/tests/test_adm_token_retrieval.py
+++ b/tests/test_adm_token_retrieval.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -2048,3 +2049,74 @@ def test_async_get_adm_token_isolated_without_cache_get(
     # Metadata should still be persisted
     assert "adm_token_issued_at_user@example.com" in persisted
     assert "adm_probe_startup_left_user@example.com" in persisted
+
+
+class _MockAuthError(Exception):
+    """Stand-in for ``gpsoauth.exceptions.AuthError`` (gpsoauth is absent in CI)."""
+
+
+@pytest.mark.asyncio
+async def test_isolated_oauth_typed_autherror_is_non_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A typed gpsoauth AuthError raised by ``perform_oauth`` on the isolated ADM
+    path must be promoted to the structured ``error_kind='auth_error'`` channel so
+    the retry loop treats it as non-retryable, even when its text is only
+    HTTP-generic (which ``_is_non_retryable_auth`` deliberately ignores). Mirrors
+    the AAS exchange path and ``token_retrieval``; without the structural promotion
+    the rejected AAS token would be hammered in the retry loop."""
+
+    monkeypatch.setattr(
+        adm_token_retrieval,
+        "gpsoauth_exceptions",
+        SimpleNamespace(AuthError=_MockAuthError),
+    )
+
+    def _raise(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise _MockAuthError("HTTP 403 Forbidden")
+
+    monkeypatch.setattr(
+        adm_token_retrieval,
+        "require_gpsoauth",
+        lambda: SimpleNamespace(perform_oauth=_raise),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await adm_token_retrieval._perform_oauth_with_provided_aas(
+            "user@example.com",
+            "aas_et/fake",
+            android_id=0x1234,
+        )
+    # The typed AuthError is promoted to the structured auth_error channel ...
+    assert getattr(excinfo.value, "error_kind", "") == "auth_error"
+    # ... and is therefore classified non-retryable by the isolated retry loop.
+    assert adm_token_retrieval._is_non_retryable_auth(excinfo.value) is True
+
+
+@pytest.mark.asyncio
+async def test_isolated_oauth_typed_channel_absent_stays_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the gpsoauth exceptions module is unavailable, an HTTP-generic-only
+    failure keeps the safe default: no structural promotion, and
+    ``_is_non_retryable_auth`` stays False (retryable)."""
+
+    monkeypatch.setattr(adm_token_retrieval, "gpsoauth_exceptions", None)
+
+    def _raise(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise RuntimeError("HTTP 403 Forbidden")
+
+    monkeypatch.setattr(
+        adm_token_retrieval,
+        "require_gpsoauth",
+        lambda: SimpleNamespace(perform_oauth=_raise),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await adm_token_retrieval._perform_oauth_with_provided_aas(
+            "user@example.com",
+            "aas_et/fake",
+            android_id=0x1234,
+        )
+    assert getattr(excinfo.value, "error_kind", "") != "auth_error"
+    assert adm_token_retrieval._is_non_retryable_auth(excinfo.value) is False

--- a/tests/test_api_basics.py
+++ b/tests/test_api_basics.py
@@ -23,6 +23,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from custom_components.googlefindmy import api as api_module
+from custom_components.googlefindmy._reauth_reason import ReauthReasonCode
 from custom_components.googlefindmy.api import (
     GoogleFindMyAPI,
     _build_can_ring_index,
@@ -933,10 +934,37 @@ class TestAsyncBasicDeviceListErrorMapping:
     def test_nova_auth_error_maps_to_auth_failed(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        # Transient NovaAuthError (is_permanent=False) records the generic code.
         self._patch_request(monkeypatch, NovaAuthError(401, "auth"))
         api = _make_api_with_session()
-        with pytest.raises(ConfigEntryAuthFailed):
+        with pytest.raises(ConfigEntryAuthFailed) as excinfo:
             run_coro(api.async_get_basic_device_list())
+        assert (
+            getattr(excinfo.value, "reauth_code", None)
+            is ReauthReasonCode.NOVA_AUTH_FAILED
+        )
+
+    @pytest.mark.parametrize(
+        "err",
+        [
+            NovaAuthError(401, "perm-flag", is_permanent=True),
+            api_module.NovaAuthPermanentError(401, "perm-subclass"),
+        ],
+    )
+    def test_permanent_nova_auth_error_records_permanent_code(
+        self, monkeypatch: pytest.MonkeyPatch, err: NovaAuthError
+    ) -> None:
+        # Cross-site consistency (RV-G2e): the device-list path must record the
+        # same permanent code the location path uses for a permanent failure,
+        # not the generic NOVA_AUTH_FAILED. Mirrors api.py location handler.
+        self._patch_request(monkeypatch, err)
+        api = _make_api_with_session()
+        with pytest.raises(ConfigEntryAuthFailed) as excinfo:
+            run_coro(api.async_get_basic_device_list())
+        assert (
+            getattr(excinfo.value, "reauth_code", None)
+            is ReauthReasonCode.NOVA_AUTH_PERMANENT
+        )
 
     def test_protobuf_decode_maps_to_update_failed(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_coordinator_decrypt_reauth_escalation.py
+++ b/tests/test_coordinator_decrypt_reauth_escalation.py
@@ -25,6 +25,7 @@ from unittest.mock import MagicMock
 import pytest
 from homeassistant.config_entries import ConfigEntryAuthFailed
 
+from custom_components.googlefindmy._reauth_reason import ReauthReasonCode
 from custom_components.googlefindmy.coordinator import polling as polling_mod
 from custom_components.googlefindmy.coordinator.helpers.stats import CryptoStatus
 from custom_components.googlefindmy.coordinator.polling import (
@@ -760,6 +761,35 @@ def test_finalize_escalates_at_threshold_with_reauth_exc() -> None:
     assert isinstance(reauth_exc, ConfigEntryAuthFailed)
     assert last_exception is reauth_exc
     stub._set_auth_state.assert_called_once()
+
+
+def test_finalize_escalation_reauth_exc_carries_decrypt_stale_key_code() -> None:
+    """The escalation ``reauth_exc`` is tagged ``DECRYPT_STALE_KEY`` so the poll
+    diagnostics classify the account-wide stale-shared-key escalation instead of
+    falling back to ``UNKNOWN``.
+
+    This is the last of the poll-cycle reauth sites to carry a structured code.
+    ``_request_poll_reauth`` records ``getattr(reauth_exc, "reauth_code",
+    UNKNOWN)`` at the fixed ``polling.py:1565`` origin, so an untagged escalation
+    would persist ``UNKNOWN`` for the most common stale-key reauth cause.
+
+    Mutation gate: dropping the tag (leaving the plain ``ConfigEntryAuthFailed``)
+    makes the ``getattr`` fall back to ``UNKNOWN`` and turns this assert red.
+    """
+    stub = _make_stub()
+    stub._consecutive_decrypt_failures = _MAX_DECRYPT_FAILURES - 1
+    err = SharedKeyMismatchError("stale shared key")
+
+    _cycle_failed, _last_exception, reauth_exc = stub._finalize_cycle_decrypt_state(
+        cycle_decrypt_error=err,
+        cycle_had_successful_decrypt=True,
+        cycle_had_stale_key=False,
+        cycle_failed=False,
+        last_exception=None,
+    )
+
+    assert isinstance(reauth_exc, ConfigEntryAuthFailed)
+    assert reauth_exc.reauth_code is ReauthReasonCode.DECRYPT_STALE_KEY
 
 
 def test_finalize_clean_cycle_stays_success() -> None:

--- a/tests/test_coordinator_predictive_polling.py
+++ b/tests/test_coordinator_predictive_polling.py
@@ -149,10 +149,17 @@ async def test_predictive_polling_defers_until_predicted_window(
 
 
 @pytest.mark.asyncio
-async def test_predictive_polling_triggers_overdue_poll(
+async def test_predictive_overdue_does_not_poll_below_cadence_floor(
     coordinator: GoogleFindMyCoordinator, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Overdue predictions trigger an immediate poll when limits allow."""
+    """An overdue prediction must not pull polling below the cadence floor.
+
+    Stage 1 makes ``effective_interval`` govern the cadence: predictive
+    pre-fetch no longer fires while ``elapsed < effective_interval``. Here
+    ``elapsed == min_poll_interval`` (the API safety floor) but stays below
+    ``effective_interval``, so no poll is scheduled even though the device's
+    prediction is overdue.
+    """
 
     wall_now = time.time()
     coordinator._device_update_history["dev-id"] = deque(
@@ -160,7 +167,73 @@ async def test_predictive_polling_triggers_overdue_poll(
         maxlen=4,
     )
     _prime_cached_devices(coordinator, wall_now)
+    # elapsed == min_poll_interval < effective_interval → below the cadence floor.
     coordinator._last_poll_mono = time.monotonic() - coordinator.min_poll_interval
+    baseline_polls = sum(
+        1 for _, name in coordinator.hass.created if name == f"{DOMAIN}.poll_cycle"
+    )
+
+    monkeypatch.setattr(coordinator, "_ensure_service_device_exists", lambda: None)
+    monkeypatch.setattr(
+        coordinator, "_ensure_registry_for_devices", lambda *_args, **_kwargs: 0
+    )
+    monkeypatch.setattr(
+        coordinator, "_refresh_subentry_index", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        coordinator,
+        "_async_build_device_snapshot_with_fallbacks",
+        AsyncMock(return_value=[]),
+    )
+    monkeypatch.setattr(coordinator, "_store_subentry_snapshots", lambda _snap: None)
+
+    poll_cycle = AsyncMock(return_value=None)
+    coordinator._async_start_poll_cycle = poll_cycle
+
+    short_retries: list[float] = []
+    coordinator._schedule_short_retry = short_retries.append
+
+    await coordinator._async_update_data()
+    poll_tasks = [
+        task
+        for task, name in coordinator.hass.created
+        if name == f"{DOMAIN}.poll_cycle"
+    ]
+    # Below the cadence floor the overdue prediction is suppressed: no poll,
+    # and no short retry is scheduled (that only happens on predictive_block).
+    assert len(poll_tasks) == baseline_polls
+    assert not short_retries
+    assert poll_cycle.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_predictive_overdue_polls_at_cadence_floor(
+    coordinator: GoogleFindMyCoordinator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An overdue prediction does not suppress the poll at the cadence floor.
+
+    Guard companion to the below-floor case: with ``elapsed >= effective_interval``
+    the regular cadence branch admits the poll, and this test proves the overdue
+    prediction (``predictive_due``) neither blocks it nor triggers a short retry.
+    The discriminating coverage of the new ``elapsed >= effective_interval`` term
+    on the predictive branch itself lives in the pure-function unit tests
+    (``test_coordinator_update.py``); at integration level ``predictive_block``
+    is not freely settable, so the cadence branch is the only realistic path.
+    Uses the same ``max(location_poll_interval, min_poll_interval)`` the
+    coordinator computes (no magic value).
+    """
+
+    wall_now = time.time()
+    coordinator._device_update_history["dev-id"] = deque(
+        [wall_now - 900, wall_now - 600, wall_now - 350],
+        maxlen=4,
+    )
+    _prime_cached_devices(coordinator, wall_now)
+    effective_interval = max(
+        coordinator.location_poll_interval, coordinator.min_poll_interval
+    )
+    # elapsed == effective_interval → the cadence floor is satisfied.
+    coordinator._last_poll_mono = time.monotonic() - effective_interval
     baseline_polls = sum(
         1 for _, name in coordinator.hass.created if name == f"{DOMAIN}.poll_cycle"
     )

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -7,7 +7,9 @@ from unittest.mock import MagicMock
 
 import pytest
 from homeassistant.config_entries import ConfigEntryAuthFailed
+from homeassistant.exceptions import HomeAssistantError
 
+from custom_components.googlefindmy._reauth_reason import ReauthReasonCode
 from custom_components.googlefindmy.const import OPT_SEMANTIC_LOCATIONS
 from custom_components.googlefindmy.coordinator import (
     CryptoStatus,
@@ -24,6 +26,12 @@ from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_
 from custom_components.googlefindmy.NovaApi.nova_request import (
     NovaAuthError,
     NovaAuthPermanentError,
+)
+from custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices.get_eid_info_request import (
+    SpotApiEmptyResponseError,
+)
+from custom_components.googlefindmy.SpotApi.spot_request import (
+    SpotAuthPermanentError,
 )
 from tests.helpers.homeassistant import GoogleFindMyConfigEntryStub
 
@@ -92,6 +100,10 @@ def _base_coordinator(
     coordinator._consecutive_timeouts = 0
     coordinator._consecutive_transient_auth_failures = 0
     coordinator._last_transient_auth_error = None
+    # FIX 3: reauth-reason state normally seeded by ``__init__`` (bypassed via
+    # ``__new__`` here); the poll-reauth choke point records through these.
+    coordinator._reauth_reason = None
+    coordinator._reauth_reason_logged = set()
     coordinator._consecutive_decrypt_failures = 0
     coordinator._last_decrypt_reauth_monotonic = None
     coordinator._last_decrypt_error = None
@@ -750,6 +762,48 @@ async def test_poll_cycle_nova_permanent_auth_starts_reauth() -> None:
         coordinator.hass
     )
     assert any(kw.get("failed") for kw in auth_calls)
+    # The poll site tags the exception so diagnostics record the specific cause.
+    assert coordinator._reauth_reason is not None
+    assert coordinator._reauth_reason.code is ReauthReasonCode.NOVA_AUTH_PERMANENT
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_spot_auth_permanent_tags_reauth_code() -> None:
+    """A permanent Spot/AAS auth failure in the poll cycle records
+    SPOT_AUTH_PERMANENT (a general Spot-transport condition, not owner-key)."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptFailAPI(
+        SpotAuthPermanentError("AAS token invalid after refresh.")
+    )
+    coordinator.config_entry.async_start_reauth = MagicMock()
+
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+
+    coordinator.config_entry.async_start_reauth.assert_called_once_with(
+        coordinator.hass
+    )
+    assert coordinator._reauth_reason is not None
+    assert coordinator._reauth_reason.code is ReauthReasonCode.SPOT_AUTH_PERMANENT
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_spot_empty_response_tags_reauth_code() -> None:
+    """An empty SPOT GetEidInfo response in the poll cycle records
+    OWNER_KEY_EMPTY_RESPONSE (SpotApiEmptyResponseError is raised only from the
+    EID/owner-key retrieval layer, so the owner-key code names the same root)."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptFailAPI(
+        SpotApiEmptyResponseError("SPOT returned an empty response")
+    )
+    coordinator.config_entry.async_start_reauth = MagicMock()
+
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+
+    coordinator.config_entry.async_start_reauth.assert_called_once_with(
+        coordinator.hass
+    )
+    assert coordinator._reauth_reason is not None
+    assert coordinator._reauth_reason.code is ReauthReasonCode.OWNER_KEY_EMPTY_RESPONSE
 
 
 @pytest.mark.asyncio
@@ -770,6 +824,17 @@ async def test_poll_cycle_transient_nova_auth_starts_reauth_after_threshold() ->
     await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
     coordinator.config_entry.async_start_reauth.assert_called_once_with(
         coordinator.hass
+    )
+    # Distinct code from the immediate NOVA_AUTH_FAILED: this is the
+    # retries-exhausted case, and the counter snapshot proves the escalation.
+    assert coordinator._reauth_reason is not None
+    assert (
+        coordinator._reauth_reason.code
+        is ReauthReasonCode.NOVA_AUTH_TRANSIENT_EXHAUSTED
+    )
+    assert (
+        coordinator._reauth_reason.counters["consecutive_transient_auth_failures"]
+        == _MAX_TRANSIENT_AUTH_FAILURES
     )
 
 
@@ -952,3 +1017,52 @@ async def test_poll_cycle_mixed_stale_and_success_keeps_last_decrypt_error() -> 
     assert coordinator.crypto_status.state == CryptoStatus.TRACKER_KEY_OUTDATED
     assert coordinator._last_decrypt_error is not None
     assert coordinator._last_decrypt_error.split(":", 1)[0] == "StaleOwnerKeyError"
+
+
+@pytest.mark.asyncio
+async def test_manual_locate_spot_auth_permanent_tags_reauth_code() -> None:
+    """The direct manual-locate SpotAuthPermanentError site records
+    SPOT_AUTH_PERMANENT, the SAME canonical code the poll-cycle equivalent uses
+    (polling.py) for the same exception type. It must NOT record an owner-key code:
+    SpotAuthPermanentError is a generic Spot-transport auth failure. Guards the
+    poll-vs-direct code-consistency invariant (a mislabel would point diagnostics
+    triage at the wrong credential layer)."""
+    coordinator = _base_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptFailAPI(
+        SpotAuthPermanentError("AAS token invalid after refresh.")
+    )
+    coordinator.config_entry.async_start_reauth = MagicMock()
+
+    with pytest.raises(HomeAssistantError):
+        await coordinator.async_locate_device("device-1")
+
+    coordinator.config_entry.async_start_reauth.assert_called_once_with(
+        coordinator.hass
+    )
+    assert coordinator._reauth_reason is not None
+    assert coordinator._reauth_reason.code is ReauthReasonCode.SPOT_AUTH_PERMANENT
+
+
+@pytest.mark.asyncio
+async def test_manual_locate_stale_shared_key_tags_reauth_code() -> None:
+    """The direct manual-locate account-wide DecryptionError site records
+    DECRYPT_STALE_KEY, the SAME canonical code the poll-cycle equivalent uses
+    (_finalize_cycle_decrypt_state). It must NOT record an AAS/token code: the
+    condition is a stale shared key, a different credential layer. Guards the
+    poll-vs-direct code-consistency invariant (the Codex finding on PR #1160)."""
+    coordinator = _base_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptFailAPI(SharedKeyMismatchError("stale shared key"))
+    # Seed the account-wide counter one below the threshold so this single locate
+    # call crosses it and escalates (the first escalation always fires: the
+    # cooldown sentinel is None).
+    coordinator._consecutive_decrypt_failures = _MAX_DECRYPT_FAILURES - 1
+    coordinator.config_entry.async_start_reauth = MagicMock()
+
+    with pytest.raises(HomeAssistantError):
+        await coordinator.async_locate_device("device-1")
+
+    coordinator.config_entry.async_start_reauth.assert_called_once_with(
+        coordinator.hass
+    )
+    assert coordinator._reauth_reason is not None
+    assert coordinator._reauth_reason.code is ReauthReasonCode.DECRYPT_STALE_KEY

--- a/tests/test_coordinator_status.py
+++ b/tests/test_coordinator_status.py
@@ -13,6 +13,7 @@ import pytest
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import issue_registry as ir
 
+from custom_components.googlefindmy._reauth_reason import ReauthReasonCode
 from custom_components.googlefindmy.Auth.fcm_receiver_ha import (
     CRASH_LOOP_FATAL_PREFIX,
 )
@@ -233,6 +234,37 @@ def test_fatal_fcm_registration_triggers_reauth(
             "message": fatal_error,
         },
     )
+
+
+def test_threshold_fcm_fatal_tags_reauth_code(
+    coordinator: GoogleFindMyCoordinator, dummy_api: _DummyAPI
+) -> None:
+    """FIX 3: a non-immediate FCM fatal that persists to the retry threshold
+    escalates to ConfigEntryAuthFailed tagged with FCM_AUTH_FATAL."""
+
+    # Non-auth, non-crash-loop fatal ⇒ counter path, not the immediate raise.
+    fatal_error = "Transient FCM error: connection reset"
+
+    class _DummyFcm:
+        def __init__(self, message: str) -> None:
+            self._fatal_error = message
+            self._fatal_errors = {coordinator.config_entry.entry_id: message}
+
+    dummy_api.fcm = _DummyFcm(fatal_error)
+    coordinator.config_entry.runtime_data = SimpleNamespace(
+        coordinator=coordinator, fcm_receiver=dummy_api.fcm
+    )
+    coordinator._is_fcm_ready_soft = lambda: False
+    # One short of the threshold; the same recurring fatal tips it over.
+    coordinator._fcm_last_error = fatal_error
+    coordinator._fcm_error_count = 2
+
+    loop = coordinator.hass.loop
+    with pytest.raises(ConfigEntryAuthFailed) as excinfo:
+        loop.run_until_complete(coordinator._async_update_data())
+
+    # Mutation-sharp: the wrong (or missing) tag fails this identity check.
+    assert excinfo.value.reauth_code is ReauthReasonCode.FCM_AUTH_FATAL
 
 
 def test_global_fatal_error_ignored_for_clean_entry(

--- a/tests/test_coordinator_update.py
+++ b/tests/test_coordinator_update.py
@@ -77,6 +77,25 @@ class TestIsFatalFcmAuthError:
         assert is_fatal_fcm_auth_error("HTTP 500 Server Error") is False
         assert is_fatal_fcm_auth_error("Network unreachable") is False
 
+    def test_retry_after_4012_ms_not_fatal(self) -> None:
+        """FIX 5: a throttling message must not false-fire the 401 matcher.
+
+        "retry after 4012 ms" contains "401" as a raw substring. The
+        word-boundary matcher (\\b401\\b) must NOT treat it as an HTTP 401, so
+        transient throttling stays retryable instead of forcing re-auth.
+        """
+        assert is_fatal_fcm_auth_error("retry after 4012 ms") is False
+        # Analogous 404 substring guard: "retry after 40412 ms" contains "404".
+        assert (
+            is_fatal_fcm_auth_error("retry after 40412 ms; credential refresh") is False
+        )
+
+    def test_genuine_401_still_fatal_after_hardening(self) -> None:
+        """FIX 5: a genuine standalone 401 auth signal remains fatal."""
+        assert is_fatal_fcm_auth_error("401 unauthorized") is True
+        assert is_fatal_fcm_auth_error("HTTP 401 Unauthorized") is True
+        assert is_fatal_fcm_auth_error("Error code: 401") is True
+
     def test_empty_string_not_fatal(self) -> None:
         """Empty string should not be fatal."""
         assert is_fatal_fcm_auth_error("") is False

--- a/tests/test_coordinator_update.py
+++ b/tests/test_coordinator_update.py
@@ -420,8 +420,14 @@ class TestIsPollCycleDue:
         )
         assert result is False
 
-    def test_due_on_predictive_due_with_hard_limit(self) -> None:
-        """Should be due on predictive_due when hard limit passed."""
+    def test_not_due_on_predictive_due_below_cadence(self) -> None:
+        """Predictive due must not trigger below the chosen cadence.
+
+        Stage-1 cadence fix: min_poll_interval (reflected here by
+        hard_limit_passed=True) alone no longer pulls a poll below
+        effective_interval. Predictive pre-fetch only fires once
+        elapsed >= effective_interval.
+        """
         result = is_poll_cycle_due(
             elapsed=30.0,
             effective_interval=60.0,
@@ -430,7 +436,7 @@ class TestIsPollCycleDue:
             hard_limit_passed=True,
             is_cold_start=False,
         )
-        assert result is True
+        assert result is False
 
     def test_not_due_on_predictive_due_without_hard_limit(self) -> None:
         """Should not be due on predictive_due without hard limit."""
@@ -487,6 +493,73 @@ class TestIsPollCycleDue:
             effective_interval=60.0,
             predictive_block=False,
             predictive_due=False,
+            hard_limit_passed=False,
+            is_cold_start=False,
+        )
+        assert result is False
+
+    def test_predictive_due_below_real_cadence_not_due(self) -> None:
+        """Cadence fix: predictive due below effective_interval must not poll.
+
+        Discriminating case for the Stage-1 fix using the reported real-world
+        cadence (effective_interval=241s). elapsed=100 is past the raw
+        min_poll_interval floor (hard_limit_passed=True) but below the chosen
+        cadence, so the poll must NOT fire. Reverting the fix
+        (dropping ``and elapsed >= effective_interval``) flips this to True,
+        which keeps the mutation gegenprobe sharp.
+        """
+        result = is_poll_cycle_due(
+            elapsed=100.0,
+            effective_interval=241.0,
+            predictive_block=False,
+            predictive_due=True,
+            hard_limit_passed=True,
+            is_cold_start=False,
+        )
+        assert result is False
+
+    def test_predictive_due_at_cadence_due_via_interval(self) -> None:
+        """At/above the cadence, the normal interval branch fires (branch 2)."""
+        result = is_poll_cycle_due(
+            elapsed=245.0,
+            effective_interval=241.0,
+            predictive_block=False,
+            predictive_due=True,
+            hard_limit_passed=True,
+            is_cold_start=False,
+        )
+        assert result is True
+
+    def test_predictive_due_past_cadence_due_when_blocked(self) -> None:
+        """Predictive branch 3 fires past cadence even when interval branch is blocked.
+
+        With predictive_block=True the normal interval branch (2) is skipped,
+        so this exercises the TRUE path of the new ``elapsed >= effective_interval``
+        term inside branch 3 (predictive due, past cadence -> poll).
+        """
+        result = is_poll_cycle_due(
+            elapsed=245.0,
+            effective_interval=241.0,
+            predictive_block=True,
+            predictive_due=True,
+            hard_limit_passed=True,
+            is_cold_start=False,
+        )
+        assert result is True
+
+    def test_hard_limit_gate_still_blocks_branch_three(self) -> None:
+        """hard_limit_passed must still gate branch 3, even past cadence.
+
+        Pins the retained ``hard_limit_passed`` term: with it False, branch 3
+        must not fire even though elapsed >= effective_interval and the interval
+        branch is blocked. Dropping ``hard_limit_passed`` from branch 3 flips
+        this to True, so the contract stays locked (caller-independence).
+        """
+        result = is_poll_cycle_due(
+            elapsed=245.0,
+            effective_interval=241.0,
+            predictive_block=True,
+            predictive_due=True,
             hard_limit_passed=False,
             is_cold_start=False,
         )

--- a/tests/test_device_identifier_normalization.py
+++ b/tests/test_device_identifier_normalization.py
@@ -7,6 +7,7 @@ import asyncio
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
 from homeassistant.config_entries import ConfigSubentry
 
 from custom_components.googlefindmy import (
@@ -20,6 +21,7 @@ from custom_components.googlefindmy.const import (
     OPT_OPTIONS_SCHEMA_VERSION,
     SUBENTRY_TYPE_TRACKER,
     TRACKER_SUBENTRY_KEY,
+    coerce_ignored_mapping,
 )
 from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
 from tests.helpers.config_flow import ConfigEntriesDomainUniqueIdLookupMixin
@@ -198,3 +200,36 @@ def test_migrate_entry_identifier_namespaces_updates_subentries() -> None:
     managed = manager.get(TRACKER_SUBENTRY_KEY)
     assert managed is not None
     assert tuple(managed.data.get("visible_device_ids", ())) == ("device-1",)
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [
+        float("nan"),  # int(nan) -> ValueError
+        float("inf"),  # int(inf) -> OverflowError
+        float("-inf"),  # int(-inf) -> OverflowError
+        True,  # bool is an int subclass; a truthy epoch of 1 is garbage
+    ],
+    ids=["nan", "inf", "-inf", "bool"],
+)
+def test_coerce_ignored_mapping_survives_invalid_ignored_at(bad_value: object) -> None:
+    """An invalid ``ignored_at`` is dropped to the default, never raised.
+
+    ``int()`` on a non-finite float raises (``ValueError``/``OverflowError``),
+    which would break the ignored-devices coercion on a corrupt ``.storage``
+    value; a ``bool`` would silently become the absurd epoch ``1``. Every one of
+    these must instead fall back to the finite default without raising.
+    """
+    result, _changed = coerce_ignored_mapping(
+        {"device-1": {"name": "Dev", "ignored_at": bad_value}}
+    )
+
+    assert "device-1" in result
+    metadata = result["device-1"]
+    assert metadata["name"] == "Dev"
+    # ignored_at fell back to the finite _now_epoch() default: a positive epoch,
+    # never NaN, never 0/None, and never the bool-derived 1 (a "return 0 instead
+    # of None" or dropped-guard helper mutation would leave a wrong value here).
+    ignored_at = metadata["ignored_at"]
+    assert isinstance(ignored_at, int)
+    assert ignored_at > 1

--- a/tests/test_diagnostics_buffer_summary.py
+++ b/tests/test_diagnostics_buffer_summary.py
@@ -9,6 +9,10 @@ from types import SimpleNamespace
 import pytest
 
 from custom_components.googlefindmy import diagnostics
+from custom_components.googlefindmy._reauth_reason import (
+    ReauthReason,
+    ReauthReasonCode,
+)
 from custom_components.googlefindmy.const import (
     CONF_OAUTH_TOKEN,
     DOMAIN,
@@ -231,3 +235,39 @@ def test_diagnostics_merge_entry_data_and_options(
     assert config_summary["google_home_filter_keywords_count"] == 3
     assert config_summary["ignored_devices_count"] == 2
     assert "movement_threshold" not in config_summary
+
+
+def test_diagnostics_includes_reauth_reason_when_recorded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """FIX 3: a recorded reauth reason surfaces in the coordinator block."""
+
+    coordinator = _StubCoordinator()
+    coordinator._reauth_reason = ReauthReason(
+        code=ReauthReasonCode.HTTP_401_AFTER_REFRESH,
+        origin="polling.py:1541",
+        counters={"consecutive_transient_auth_failures": 3},
+        recorded_at=1_700_000_000.0,
+    )
+    entry = _StubEntry(coordinator)
+    hass = _StubHass(entry, coordinator)
+
+    async def _fake_get_integration(_hass, _domain):
+        return SimpleNamespace(name="Test Integration", version="1.2.3")
+
+    monkeypatch.setattr(diagnostics, "async_get_integration", _fake_get_integration)
+    monkeypatch.setattr(
+        diagnostics.dr, "async_get", lambda _hass: SimpleNamespace(devices={})
+    )
+    monkeypatch.setattr(
+        diagnostics.er, "async_get", lambda _hass: SimpleNamespace(entities={})
+    )
+    monkeypatch.setattr(diagnostics, "async_redact_data", _redact)
+
+    payload = _run(diagnostics.async_get_config_entry_diagnostics(hass, entry))
+
+    reauth = payload["coordinator"]["reauth_reason"]
+    assert reauth["code"] == "http_401_after_refresh"
+    assert reauth["origin"] == "polling.py:1541"
+    assert reauth["counters"] == {"consecutive_transient_auth_failures": 3}
+    # Mutation counter-check: skipping the wiring line drops this key entirely.

--- a/tests/test_diagnostics_buffer_summary.py
+++ b/tests/test_diagnostics_buffer_summary.py
@@ -245,7 +245,7 @@ def test_diagnostics_includes_reauth_reason_when_recorded(
     coordinator = _StubCoordinator()
     coordinator._reauth_reason = ReauthReason(
         code=ReauthReasonCode.HTTP_401_AFTER_REFRESH,
-        origin="polling.py:1541",
+        origin="polling.py:_async_update_data",
         counters={"consecutive_transient_auth_failures": 3},
         recorded_at=1_700_000_000.0,
     )
@@ -268,6 +268,6 @@ def test_diagnostics_includes_reauth_reason_when_recorded(
 
     reauth = payload["coordinator"]["reauth_reason"]
     assert reauth["code"] == "http_401_after_refresh"
-    assert reauth["origin"] == "polling.py:1541"
+    assert reauth["origin"] == "polling.py:_async_update_data"
     assert reauth["counters"] == {"consecutive_transient_auth_failures": 3}
     # Mutation counter-check: skipping the wiring line drops this key entirely.

--- a/tests/test_fcm_receiver_decrypt_escalation.py
+++ b/tests/test_fcm_receiver_decrypt_escalation.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from custom_components.googlefindmy._reauth_reason import ReauthReasonCode
 from custom_components.googlefindmy.Auth import fcm_receiver_ha
 from custom_components.googlefindmy.Auth.fcm_receiver_ha import FcmReceiverHA
 from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
@@ -49,6 +50,24 @@ def test_push_decrypt_failure_starts_reauth_when_threshold_reached() -> None:
 
     coordinator.note_decrypt_failure.assert_called_once_with(stale=False, error=err)
     entry.async_start_reauth.assert_called_once_with(receiver._hass)
+
+
+def test_push_decrypt_failure_records_decrypt_stale_key_reason() -> None:
+    """The background-push escalation records DECRYPT_STALE_KEY, the SAME canonical
+    code the poll and locate equivalents use for the account-wide stale-shared-key
+    decrypt condition. This escalation is only reached on the stale=False path
+    (note_decrypt_failure returns False for stale=True), so it must NOT record an
+    AAS/token code. Guards the poll-vs-direct code-consistency invariant."""
+    receiver, coordinator, entry = _receiver_with_coordinator(escalate=True)
+    err = DecryptionError("stale shared key")
+
+    receiver._note_decrypt_failure_for_entry("entry-1", stale=False, error=err)
+
+    coordinator.record_reauth_reason.assert_called_once()
+    assert (
+        coordinator.record_reauth_reason.call_args.args[0]
+        is ReauthReasonCode.DECRYPT_STALE_KEY
+    )
 
 
 def test_push_decrypt_failure_below_threshold_does_not_start_reauth() -> None:

--- a/tests/test_fcm_receiver_liveness_watchdog.py
+++ b/tests/test_fcm_receiver_liveness_watchdog.py
@@ -1,0 +1,874 @@
+# tests/test_fcm_receiver_liveness_watchdog.py
+"""Data-starvation liveness watchdog (re-arming FCM zombie self-heal).
+
+Covers the AP1-AP4 additions to ``FcmReceiverHA``:
+
+* AP1  the separate ``_entry_last_data_delivery_monotonic`` clock and the
+  ``_stamp_data_delivery`` helper (stamped only on a real locate data delivery),
+* AP2  the pure ``_is_data_starved`` predicate,
+* AP2.5 the entry-scoped ``_entry_last_locate_sent_monotonic`` signal,
+* AP3  the re-arming reconnect (``_reconnect_for_starvation`` wrapper +
+  ``_maybe_reconnect_starved`` scheduler, backoff/cap/max, one-in-flight), and
+* AP4  the throttled supervisor wiring + ``_purge_entry_tokens`` reset/cancel.
+
+The tests exercise the real predicate/scheduler/stamp/reset logic against a
+light push-client double, never ``asyncio.run()`` (tests/AGENTS.md). Coroutine
+tests are ``async def`` and awaited directly under pytest's managed loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+import pytest
+
+from custom_components.googlefindmy.Auth import fcm_receiver_ha as fcm_mod
+from custom_components.googlefindmy.Auth.fcm_receiver_ha import FcmReceiverHA
+from custom_components.googlefindmy.const import (
+    FCM_DATA_STARVATION_S,
+    FCM_ZOMBIE_MAX_RECONNECTS,
+    FCM_ZOMBIE_RECONNECT_BACKOFF_BASE_S,
+    FCM_ZOMBIE_RECONNECT_BACKOFF_CAP_S,
+)
+
+
+class _RunState:
+    """Minimal stand-in for FcmPushClientRunState (only STARTED is compared)."""
+
+    STARTED = "STARTED"
+
+
+class _WatchdogPc:
+    """Push-client double: run_state, STARTED-age anchor, and async stop()."""
+
+    def __init__(
+        self,
+        run_state: object = _RunState.STARTED,
+        *,
+        started_monotonic: float | None = None,
+        age_s: float = 100.0,
+    ) -> None:
+        self.run_state = run_state
+        # Default: established session well past _CHURN_WINDOW_S (age ~100s).
+        self._started_monotonic = (
+            (time.monotonic() - age_s)
+            if started_monotonic is None
+            else started_monotonic
+        )
+        self.persistent_ids: list[str] = []
+        self.stopped = False
+
+    async def stop(self) -> None:
+        self.stopped = True
+        self.run_state = "STOPPED"
+
+
+class _DummyHass:
+    """Lightweight hass stub whose ``async_create_task`` uses the live loop."""
+
+    def __init__(self) -> None:
+        self.created: list[str | None] = []
+
+    def async_create_task(
+        self, coro: Any, *, name: str | None = None
+    ) -> asyncio.Task[Any]:
+        self.created.append(name)
+        return asyncio.get_event_loop().create_task(coro, name=name)
+
+
+class _FakeTask:
+    """Minimal task stand-in: reports not-done and swallows the done-callback."""
+
+    def done(self) -> bool:
+        return False
+
+    def add_done_callback(self, _cb: Any) -> None:
+        return None
+
+
+class _RecordingHass:
+    """Hass stub that records scheduling but never runs the coroutine.
+
+    Used by the synchronous scheduler tests (no running loop): it closes the
+    passed coroutine to avoid "coroutine was never awaited" warnings and returns
+    a ``_FakeTask`` so no real asyncio task leaks between tests.
+    """
+
+    def __init__(self) -> None:
+        self.created: list[str | None] = []
+
+    def async_create_task(self, coro: Any, *, name: str | None = None) -> _FakeTask:
+        self.created.append(name)
+        coro.close()
+        return _FakeTask()
+
+
+def _make_receiver(monkeypatch: pytest.MonkeyPatch) -> FcmReceiverHA:
+    """Return a receiver with the run-state enum wired to the local stub."""
+    receiver = FcmReceiverHA()
+    monkeypatch.setattr(fcm_mod, "FcmPushClientRunState", _RunState)
+    return receiver
+
+
+def _arm_starved(
+    receiver: FcmReceiverHA,
+    entry_id: str,
+    now: float,
+    *,
+    pc: _WatchdogPc | None = None,
+) -> _WatchdogPc:
+    """Set up the canonical starved-zombie state at monotonic time *now*.
+
+    Fixed offsets (T0/T1/T3 oracle): data clock = now - (STARVATION + 1),
+    activity clock = now - 1 (heartbeat fresh), a locate sent after the last
+    delivery, and an established STARTED session (age >= churn).
+    """
+    live_pc = pc if pc is not None else _WatchdogPc(age_s=100.0)
+    receiver.pcs[entry_id] = live_pc  # type: ignore[assignment]
+    receiver._entry_last_data_delivery_monotonic[entry_id] = now - (
+        FCM_DATA_STARVATION_S + 1.0
+    )
+    receiver._entry_last_activity_monotonic[entry_id] = now - 1.0
+    receiver._entry_last_locate_sent_monotonic[entry_id] = now - 0.5
+    return live_pc
+
+
+# ---------------------------------------------------------------------------
+# T0 -- Anti-zombie target proof (BLOCKING). Three asserted mutant vectors.
+# ---------------------------------------------------------------------------
+
+
+def test_t0a_watchdog_disabled_never_reconnects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T0a: a disabled watchdog (scheduler no-op) schedules 0 reconnects -> red.
+
+    The mutant disables ``_maybe_reconnect_starved``; the positive path below
+    proves the real code schedules exactly one reconnect for the same setup.
+    """
+    receiver = _make_receiver(monkeypatch)
+    hass = _RecordingHass()
+    receiver._hass = hass  # type: ignore[assignment]
+    entry_id = "entry-1"
+    now = time.monotonic()
+    _arm_starved(receiver, entry_id, now)
+
+    # Mutant: watchdog disabled.
+    monkeypatch.setattr(receiver, "_maybe_reconnect_starved", lambda eid, n: None)
+    receiver._maybe_reconnect_starved(entry_id, now)
+    assert hass.created == []  # disabled -> no reconnect (asserted mutant)
+
+    # Positive control (real code) schedules exactly one.
+    real = FcmReceiverHA._maybe_reconnect_starved
+    real(receiver, entry_id, now)
+    assert hass.created == [f"fcm_zombie_reconnect_{entry_id}"]
+
+
+def test_t0b_predicate_on_activity_clock_never_fires(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T0b: keying starvation on the activity clock (K4) never fires -> red.
+
+    The activity clock is fresh (heartbeat alive), so a predicate that consults
+    it instead of the data clock returns False and no reconnect is scheduled.
+    """
+    receiver = _make_receiver(monkeypatch)
+    hass = _RecordingHass()
+    receiver._hass = hass  # type: ignore[assignment]
+    entry_id = "entry-1"
+    now = time.monotonic()
+    _arm_starved(receiver, entry_id, now)
+
+    def _mutant_activity_predicate(eid: str, n: float) -> bool:
+        last_activity = receiver._entry_last_activity_monotonic.get(eid)
+        if last_activity is None:
+            return False
+        return n - last_activity >= FCM_DATA_STARVATION_S
+
+    monkeypatch.setattr(receiver, "_is_data_starved", _mutant_activity_predicate)
+    receiver._maybe_reconnect_starved(entry_id, now)
+    assert hass.created == []  # activity-clock predicate stays False -> no heal
+
+    # The real data-clock predicate DOES classify this as starved.
+    assert FcmReceiverHA._is_data_starved(receiver, entry_id, now) is True
+
+
+def test_t0c_starvation_threshold_infinite_never_fires(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T0c: an unreachable starvation threshold (inf) never fires -> red."""
+    receiver = _make_receiver(monkeypatch)
+    hass = _RecordingHass()
+    receiver._hass = hass  # type: ignore[assignment]
+    entry_id = "entry-1"
+    now = time.monotonic()
+    _arm_starved(receiver, entry_id, now)
+
+    monkeypatch.setattr(fcm_mod, "FCM_DATA_STARVATION_S", float("inf"))
+    assert receiver._is_data_starved(entry_id, now) is False
+    receiver._maybe_reconnect_starved(entry_id, now)
+    assert hass.created == []
+
+
+# ---------------------------------------------------------------------------
+# T1 -- detected + healed + reset
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_t1_zombie_detected_healed_and_reset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A starved zombie is detected, one reconnect fires, delivery resets state."""
+    receiver = _make_receiver(monkeypatch)
+    hass = _DummyHass()
+    receiver._hass = hass  # type: ignore[assignment]
+    entry_id = "entry-1"
+    now = time.monotonic()
+    stale = _arm_starved(receiver, entry_id, now)
+    fresh = _WatchdogPc(age_s=0.0)
+
+    monkeypatch.setattr(receiver, "nudge_retry", lambda eid=None: True)
+
+    async def _swap(_seconds: float) -> None:
+        if receiver.pcs[entry_id] is stale:
+            receiver.pcs[entry_id] = fresh  # type: ignore[assignment]
+
+    monkeypatch.setattr(asyncio, "sleep", _swap)
+
+    receiver._maybe_reconnect_starved(entry_id, now)
+    assert receiver._zombie_reconnect_attempts[entry_id] == 1
+    task = receiver._zombie_reconnect_tasks[entry_id]
+    await task
+
+    assert stale.stopped is True  # the reconnect actually tore down the zombie
+    assert receiver.pcs[entry_id] is fresh
+
+    # A real data delivery re-arms: clock advances, backoff/count cleared.
+    receiver._stamp_data_delivery({entry_id})
+    assert entry_id in receiver._entry_last_data_delivery_monotonic
+    assert entry_id not in receiver._zombie_reconnect_attempts
+    assert entry_id not in receiver._zombie_next_allowed_reconnect_monotonic
+
+
+# ---------------------------------------------------------------------------
+# T2 -- healthy session -> no reconnect
+# ---------------------------------------------------------------------------
+
+
+def test_t2_healthy_session_no_reconnect(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fresh data clock -> predicate False (mutation-inverting it fires -> red)."""
+    receiver = _make_receiver(monkeypatch)
+    entry_id = "entry-1"
+    now = time.monotonic()
+    _arm_starved(receiver, entry_id, now)
+    # Override: data delivered just now -> healthy.
+    receiver._entry_last_data_delivery_monotonic[entry_id] = now - 1.0
+    receiver._entry_last_locate_sent_monotonic[entry_id] = now - 0.5
+
+    assert receiver._is_data_starved(entry_id, now) is False
+
+    # Mutation counter-check: a stale data clock would flip it to True.
+    receiver._entry_last_data_delivery_monotonic[entry_id] = now - (
+        FCM_DATA_STARVATION_S + 1.0
+    )
+    assert receiver._is_data_starved(entry_id, now) is True
+
+
+# ---------------------------------------------------------------------------
+# T3 -- core bug regression: heartbeats do NOT advance the data clock
+# ---------------------------------------------------------------------------
+
+
+def test_t3_heartbeat_does_not_advance_data_clock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bare heartbeat advances the activity clock but not the data clock.
+
+    ``_stamp_data_delivery`` is the ONLY writer of the data clock; the activity
+    clock (K4) is advanced elsewhere by heartbeats. Simulate a heartbeat by
+    refreshing only the activity clock: the predicate must stay True.
+    """
+    receiver = _make_receiver(monkeypatch)
+    entry_id = "entry-1"
+    now = time.monotonic()
+    _arm_starved(receiver, entry_id, now)
+
+    # "Heartbeat" tick: only the activity clock moves forward.
+    receiver._entry_last_activity_monotonic[entry_id] = now
+    assert receiver._is_data_starved(entry_id, now) is True
+
+    # Mutation counter-check: wiring the data clock to the heartbeat clears it.
+    receiver._entry_last_data_delivery_monotonic[entry_id] = now
+    assert receiver._is_data_starved(entry_id, now) is False
+
+
+# ---------------------------------------------------------------------------
+# T4 -- backoff growth + cap + max ceiling + reset
+# ---------------------------------------------------------------------------
+
+
+def test_t4_backoff_grows_caps_and_hits_max(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated starvation grows backoff up to the cap and stops at MAX; reset works."""
+    receiver = _make_receiver(monkeypatch)
+    hass = _RecordingHass()
+    receiver._hass = hass  # type: ignore[assignment]
+    entry_id = "entry-1"
+
+    # Never actually reconnect; keep the entry pinned starved so we can drive the
+    # scheduler through every backoff window deterministically.
+    async def _noop_reconnect(eid: str, max_wait_s: float) -> None:
+        return None
+
+    monkeypatch.setattr(receiver, "_reconnect_for_starvation", _noop_reconnect)
+
+    windows: list[float] = []
+    now = 1000.0
+    _arm_starved(receiver, entry_id, now)
+    # Re-pin data/activity/locate relative to the synthetic clock each step so
+    # the predicate stays True as ``now`` advances.
+    for _ in range(FCM_ZOMBIE_MAX_RECONNECTS + 2):
+        receiver._entry_last_data_delivery_monotonic[entry_id] = now - (
+            FCM_DATA_STARVATION_S + 1.0
+        )
+        receiver._entry_last_activity_monotonic[entry_id] = now - 1.0
+        receiver._entry_last_locate_sent_monotonic[entry_id] = now - 0.5
+        # Clear any completed task so the one-in-flight guard does not block.
+        receiver._zombie_reconnect_tasks.pop(entry_id, None)
+        before = receiver._zombie_reconnect_attempts.get(entry_id, 0)
+        receiver._maybe_reconnect_starved(entry_id, now)
+        after = receiver._zombie_reconnect_attempts.get(entry_id, 0)
+        if after > before:
+            windows.append(
+                receiver._zombie_next_allowed_reconnect_monotonic[entry_id] - now
+            )
+            # Advance past the just-planned window for the next iteration.
+            now = receiver._zombie_next_allowed_reconnect_monotonic[entry_id]
+        else:
+            now += 1.0
+
+    # Exactly MAX reconnects scheduled, then the hard ceiling stops it.
+    assert receiver._zombie_reconnect_attempts[entry_id] == FCM_ZOMBIE_MAX_RECONNECTS
+    assert len(windows) == FCM_ZOMBIE_MAX_RECONNECTS
+    # Exponential growth from BASE, doubling, capped.
+    expected = [
+        min(
+            FCM_ZOMBIE_RECONNECT_BACKOFF_BASE_S * (2**i),
+            FCM_ZOMBIE_RECONNECT_BACKOFF_CAP_S,
+        )
+        for i in range(FCM_ZOMBIE_MAX_RECONNECTS)
+    ]
+    assert windows == expected
+    assert windows[-1] == FCM_ZOMBIE_RECONNECT_BACKOFF_CAP_S  # cap reached
+
+    # First real delivery resets count + backoff (re-arm).
+    receiver._stamp_data_delivery({entry_id})
+    assert entry_id not in receiver._zombie_reconnect_attempts
+    assert entry_id not in receiver._zombie_next_allowed_reconnect_monotonic
+
+
+# ---------------------------------------------------------------------------
+# T5 -- one-in-flight guard + shared serialization lock
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_t5_one_in_flight_and_shared_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No second reconnect while one is in flight; watchdog shares the locate lock."""
+    receiver = _make_receiver(monkeypatch)
+    hass = _DummyHass()
+    receiver._hass = hass  # type: ignore[assignment]
+    entry_id = "entry-1"
+    now = time.monotonic()
+    stale = _arm_starved(receiver, entry_id, now)
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    monkeypatch.setattr(receiver, "nudge_retry", lambda eid=None: True)
+
+    async def _blocking_stop() -> None:
+        stale.stopped = True
+        entered.set()
+        await release.wait()
+
+    monkeypatch.setattr(stale, "stop", _blocking_stop)
+
+    async def _no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    receiver._maybe_reconnect_starved(entry_id, now)
+    await entered.wait()  # first reconnect task is parked mid-stop().
+
+    # One-in-flight guard: a second scheduling attempt does not create a task.
+    created_before = len(hass.created)
+    receiver._maybe_reconnect_starved(entry_id, now + 10_000.0)
+    assert len(hass.created) == created_before  # no second task scheduled
+
+    # The shared first-locate lock is held by the watchdog reconnect.
+    assert receiver._get_first_locate_lock(entry_id).locked() is True
+
+    release.set()
+    await receiver._zombie_reconnect_tasks[entry_id]
+    assert receiver._get_first_locate_lock(entry_id).locked() is False
+
+
+# ---------------------------------------------------------------------------
+# T6 -- empty account (no locate) -> no false positive
+# ---------------------------------------------------------------------------
+
+
+def test_t6_empty_account_no_reconnect(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No locate ever sent -> not starved even with an old/absent data clock."""
+    receiver = _make_receiver(monkeypatch)
+    entry_id = "entry-1"
+    now = time.monotonic()
+    receiver.pcs[entry_id] = _WatchdogPc(age_s=100.0)  # type: ignore[assignment]
+    receiver._entry_last_activity_monotonic[entry_id] = now - 1.0
+    # No data delivery, no locate sent.
+    assert receiver._is_data_starved(entry_id, now) is False
+
+    # Even an ancient data clock without a locate stays non-starved.
+    receiver._entry_last_data_delivery_monotonic[entry_id] = now - (
+        FCM_DATA_STARVATION_S + 1.0
+    )
+    assert receiver._is_data_starved(entry_id, now) is False
+
+    # A stale locate delivered *before* the last delivery also does not qualify
+    # (no locate since the last delivery).
+    receiver._entry_last_data_delivery_monotonic[entry_id] = now - 10.0
+    receiver._entry_last_locate_sent_monotonic[entry_id] = now - 20.0
+    assert receiver._is_data_starved(entry_id, now) is False
+
+
+# ---------------------------------------------------------------------------
+# T7 -- teardown reset + in-flight task cancel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_t7_purge_resets_state_and_cancels_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_purge_entry_tokens`` clears all watchdog state and cancels the task."""
+    receiver = _make_receiver(monkeypatch)
+    entry_id = "entry-1"
+    now = time.monotonic()
+    _arm_starved(receiver, entry_id, now)
+    receiver._zombie_reconnect_attempts[entry_id] = 2
+    receiver._zombie_next_allowed_reconnect_monotonic[entry_id] = now + 60.0
+    receiver._zombie_next_eval_monotonic[entry_id] = now + 30.0
+
+    started = asyncio.Event()
+
+    async def _long_reconnect() -> None:
+        started.set()
+        await asyncio.Event().wait()  # never completes on its own
+
+    task = asyncio.get_event_loop().create_task(_long_reconnect())
+    receiver._zombie_reconnect_tasks[entry_id] = task  # type: ignore[assignment]
+    await started.wait()
+
+    receiver._purge_entry_tokens(entry_id)
+
+    assert entry_id not in receiver._entry_last_data_delivery_monotonic
+    assert entry_id not in receiver._entry_last_locate_sent_monotonic
+    assert entry_id not in receiver._zombie_reconnect_attempts
+    assert entry_id not in receiver._zombie_next_allowed_reconnect_monotonic
+    assert entry_id not in receiver._zombie_next_eval_monotonic
+    assert entry_id not in receiver._zombie_reconnect_tasks
+    assert task.cancelled() or task.cancelling()  # cancellation requested
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+# ---------------------------------------------------------------------------
+# T8 -- deadlock regression: reconnect is scheduled, never inline-awaited
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_t8_reconnect_is_scheduled_not_inline_awaited(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The scheduler returns immediately (task scheduled), never blocking on it.
+
+    Mutation counter-check A: an inline ``await`` on the reconnect would block the
+    caller until the replacement is built -- proven here by a reconnect that
+    never completes; the scheduler must still return promptly with a pending
+    task. Mutation counter-check B: routing the watchdog through
+    ``_reconnect_for_first_locate`` performs NO reconnect on an aged session
+    (its reuse gate short-circuits), so the zombie is never torn down.
+    """
+    receiver = _make_receiver(monkeypatch)
+    hass = _DummyHass()
+    receiver._hass = hass  # type: ignore[assignment]
+    entry_id = "entry-1"
+    now = time.monotonic()
+    stale = _arm_starved(receiver, entry_id, now)
+
+    reconnect_ran = asyncio.Event()
+
+    async def _never_finishing(eid: str, max_wait_s: float) -> None:
+        reconnect_ran.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(receiver, "_reconnect_for_starvation", _never_finishing)
+
+    # Scheduler returns synchronously even though the reconnect never finishes.
+    receiver._maybe_reconnect_starved(entry_id, now)
+    task = receiver._zombie_reconnect_tasks[entry_id]
+    assert not task.done()  # scheduled, not awaited inline
+    await reconnect_ran.wait()  # the task did start on the loop
+    assert not task.done()  # still running; caller was never blocked
+    task.cancel()
+
+    # Gegen-probe B: the reuse-gated first-locate reconnect does nothing for an
+    # aged (age >= churn) zombie -- proving the dedicated wrapper is required.
+    monkeypatch.setattr(receiver, "nudge_retry", lambda eid=None: True)
+
+    async def _no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+    stale.stopped = False
+    result = await receiver._reconnect_for_first_locate(entry_id, 1.0)
+    assert result is stale  # returned as-is, NOT reconnected
+    assert stale.stopped is False  # aged zombie was never torn down
+
+
+# ---------------------------------------------------------------------------
+# T9 -- target_entries stamp (multi-entry fan-out)
+# ---------------------------------------------------------------------------
+
+
+def test_t9_stamp_all_target_entries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A token-routed delivery stamps EVERY target entry, not just one."""
+    receiver = _make_receiver(monkeypatch)
+    before = time.monotonic()
+    receiver._stamp_data_delivery({"entry-1", "entry-2"})
+    after = time.monotonic()
+
+    for eid in ("entry-1", "entry-2"):
+        stamped = receiver._entry_last_data_delivery_monotonic[eid]
+        assert before <= stamped <= after
+
+    # Mutation counter-check: stamping only ``entry_id`` would leave a co-routed
+    # multi-account entry unstamped and thus falsely starving.
+    receiver._entry_last_data_delivery_monotonic.clear()
+    receiver._stamp_data_delivery({"entry-1"})  # single-entry routing
+    assert "entry-1" in receiver._entry_last_data_delivery_monotonic
+    assert "entry-2" not in receiver._entry_last_data_delivery_monotonic
+
+    # A ``None`` (broadcast/unknown) routing set stamps nothing (conservative).
+    receiver._entry_last_data_delivery_monotonic.clear()
+    receiver._stamp_data_delivery(None)
+    assert receiver._entry_last_data_delivery_monotonic == {}
+
+
+# ---------------------------------------------------------------------------
+# T10-T13 -- _is_data_starved false-positive guards (storm safety, AP2)
+# Each guard rules out a class of non-zombie so the re-arming reconnect never
+# fires on a healthy/young/dead/empty session. Every vector pairs the guarded
+# verdict with a mutation counter-check that flips it.
+# ---------------------------------------------------------------------------
+
+
+def test_t10_young_session_not_starved(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A session younger than the churn window is never starved (age guard)."""
+    receiver = _make_receiver(monkeypatch)
+    entry_id = "entry-1"
+    now = time.monotonic()
+    # Fully armed for starvation, but the session is brand new (age < churn 15s).
+    _arm_starved(receiver, entry_id, now, pc=_WatchdogPc(age_s=5.0))
+    assert receiver._is_data_starved(entry_id, now) is False
+
+    # Mutation counter-check: an established session (age past churn) fires.
+    receiver.pcs[entry_id] = _WatchdogPc(age_s=100.0)  # type: ignore[assignment]
+    assert receiver._is_data_starved(entry_id, now) is True
+
+
+def test_t11_missing_activity_clock_not_starved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No activity clock recorded -> not starved (heartbeat health unknown)."""
+    receiver = _make_receiver(monkeypatch)
+    entry_id = "entry-1"
+    now = time.monotonic()
+    _arm_starved(receiver, entry_id, now)
+    del receiver._entry_last_activity_monotonic[entry_id]
+    assert receiver._is_data_starved(entry_id, now) is False
+
+    # Mutation counter-check: a fresh activity clock restores the starved verdict.
+    receiver._entry_last_activity_monotonic[entry_id] = now - 1.0
+    assert receiver._is_data_starved(entry_id, now) is True
+
+
+def test_t12_dead_heartbeat_not_starved(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A stale activity clock is a dead socket (idle-reset's job), not a zombie."""
+    receiver = _make_receiver(monkeypatch)
+    entry_id = "entry-1"
+    now = time.monotonic()
+    _arm_starved(receiver, entry_id, now)
+    # Heartbeat older than the freshness window (FCM_IDLE_RESET_AFTER_S = 90s).
+    receiver._entry_last_activity_monotonic[entry_id] = now - (
+        receiver._activity_stale_after_s + 1.0
+    )
+    assert receiver._is_data_starved(entry_id, now) is False
+
+    # Mutation counter-check: a fresh heartbeat is a live-but-silent zombie.
+    receiver._entry_last_activity_monotonic[entry_id] = now - 1.0
+    assert receiver._is_data_starved(entry_id, now) is True
+
+
+def test_t13_never_delivered_with_locate_is_starved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Never delivered, but an old locate is pending -> starved (no data clock)."""
+    receiver = _make_receiver(monkeypatch)
+    entry_id = "entry-1"
+    now = time.monotonic()
+    _arm_starved(receiver, entry_id, now)
+    # No data delivery ever; the locate is older than the starvation threshold.
+    del receiver._entry_last_data_delivery_monotonic[entry_id]
+    receiver._entry_last_locate_sent_monotonic[entry_id] = now - (
+        FCM_DATA_STARVATION_S + 1.0
+    )
+    assert receiver._is_data_starved(entry_id, now) is True
+
+    # Mutation counter-check: a recent locate (within threshold) is not yet starved.
+    receiver._entry_last_locate_sent_monotonic[entry_id] = now - 1.0
+    assert receiver._is_data_starved(entry_id, now) is False
+
+
+# ---------------------------------------------------------------------------
+# T14 -- reconnect wrapper aborts when the client vanished under the lock (AP3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_t14_reconnect_wrapper_no_client_is_noop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The wrapper returns without reconnecting when no live client is present."""
+    receiver = _make_receiver(monkeypatch)
+    entry_id = "entry-1"
+    calls: list[tuple[str, Any, float]] = []
+
+    async def _record(eid: str, pc: Any, wait: float) -> None:
+        calls.append((eid, pc, wait))
+
+    monkeypatch.setattr(receiver, "_force_first_locate_reconnect", _record)
+
+    # No pc registered: the supervisor tore it down before the lock was acquired.
+    await receiver._reconnect_for_starvation(entry_id, 30.0)
+    assert calls == []
+
+    # Mutation counter-check: a live STARTED client reconnects unconditionally.
+    receiver.pcs[entry_id] = _WatchdogPc(age_s=100.0)  # type: ignore[assignment]
+    await receiver._reconnect_for_starvation(entry_id, 30.0)
+    assert len(calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# T15-T16 -- scheduler early-exit guards (AP3): no hass, open backoff window
+# ---------------------------------------------------------------------------
+
+
+def test_t15_scheduler_without_hass_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The scheduler is a safe no-op (no crash, no attempt) when hass is absent."""
+    receiver = _make_receiver(monkeypatch)
+    receiver._hass = None  # type: ignore[assignment]
+    entry_id = "entry-1"
+    now = time.monotonic()
+    _arm_starved(receiver, entry_id, now)
+    receiver._maybe_reconnect_starved(entry_id, now)  # must not raise
+    assert entry_id not in receiver._zombie_reconnect_attempts
+
+    # Mutation counter-check: with a hass the same setup schedules one reconnect.
+    hass = _RecordingHass()
+    receiver._hass = hass  # type: ignore[assignment]
+    receiver._maybe_reconnect_starved(entry_id, now)
+    assert len(hass.created) == 1
+    assert receiver._zombie_reconnect_attempts[entry_id] == 1
+
+
+def test_t16_scheduler_inside_backoff_window_is_noop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inside an open backoff window the scheduler defers (no new reconnect)."""
+    receiver = _make_receiver(monkeypatch)
+    hass = _RecordingHass()
+    receiver._hass = hass  # type: ignore[assignment]
+    entry_id = "entry-1"
+    now = time.monotonic()
+    _arm_starved(receiver, entry_id, now)
+    # Backoff window still open: the next allowed reconnect is in the future.
+    receiver._zombie_next_allowed_reconnect_monotonic[entry_id] = now + 60.0
+    receiver._maybe_reconnect_starved(entry_id, now)
+    assert hass.created == []
+
+    # Mutation counter-check: once the window has elapsed the reconnect schedules.
+    receiver._zombie_next_allowed_reconnect_monotonic[entry_id] = now - 1.0
+    receiver._maybe_reconnect_starved(entry_id, now)
+    assert len(hass.created) == 1
+
+
+# ---------------------------------------------------------------------------
+# T17 -- delivery integration: the cb-hit handler branch stamps the data clock
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_t17_delivery_stamps_data_clock_via_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A real cb-hit delivery through the handler stamps the data clock.
+
+    Drives ``_handle_notification_async`` straight to the ``if cb:`` branch with
+    controlled parsing/routing doubles; the real ``_stamp_data_delivery`` call
+    at the delivery site must advance the routed entry's data clock. A mutation
+    dropping that call would leave the clock unstamped -> this test goes red.
+    """
+    receiver = _make_receiver(monkeypatch)
+    entry_id = "entry-1"
+    canonic_id = "canonic-1"
+    cb_calls: list[str] = []
+
+    async def _cb(cid: str, hex_str: str) -> None:
+        cb_calls.append(cid)
+
+    monkeypatch.setattr(receiver, "_extract_hex_payload", lambda payload: "deadbeef")
+
+    async def _canonic(_hex: str) -> str:
+        return canonic_id
+
+    monkeypatch.setattr(receiver, "_extract_canonic_id_async", _canonic)
+    monkeypatch.setattr(receiver, "_extract_push_token", lambda envelope: None)
+    monkeypatch.setattr(
+        receiver, "_route_target_entries", lambda e, c, t: ({entry_id}, "test")
+    )
+    monkeypatch.setattr(receiver, "_coordinators_for_entries", lambda entries: [])
+    monkeypatch.setattr(receiver, "_log_push_received", lambda *a, **k: None)
+
+    async def _run_cb(cb: Any, cid: str, hex_str: str) -> None:
+        await cb(cid, hex_str)
+
+    monkeypatch.setattr(receiver, "_run_callback_async", _run_cb)
+    receiver.location_update_callbacks[canonic_id] = _cb  # type: ignore[assignment]
+
+    before = time.monotonic()
+    await receiver._handle_notification_async(entry_id, {"foo": "bar"})
+    after = time.monotonic()
+
+    # The delivery-site stamp ran: the routed entry's data clock is fresh.
+    stamped = receiver._entry_last_data_delivery_monotonic[entry_id]
+    assert before <= stamped <= after
+    # The cb-hit branch really executed (proves we reached the stamp call site).
+    assert cb_calls == [canonic_id]
+
+
+# ---------------------------------------------------------------------------
+# T18 -- F1 regression: the watchdog bounds the reconnect's wait-for-STARTED
+# to the conservative readiness budget (~22s), never FCM_DATA_STARVATION_S.
+# ---------------------------------------------------------------------------
+
+
+def test_t18_watchdog_wait_budget_is_ready_budget_not_starvation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The scheduler passes ``_max_ready_wait_s()`` (~22s) to the reconnect.
+
+    ``_reconnect_for_starvation`` holds the shared per-entry first-locate lock
+    while awaiting STARTED; binding the wait to FCM_DATA_STARVATION_S (900s)
+    would starve a concurrent manual locate on the same entry for up to 15
+    minutes (Codex F1). Mutation guard: reverting the scheduler to pass
+    ``float(FCM_DATA_STARVATION_S)`` makes ``recorded[0] == 900.0`` -> red.
+    """
+    receiver = _make_receiver(monkeypatch)
+    hass = _RecordingHass()
+    receiver._hass = hass  # type: ignore[assignment]
+    entry_id = "entry-1"
+    now = time.monotonic()
+    _arm_starved(receiver, entry_id, now)
+
+    recorded: list[float] = []
+
+    async def _noop() -> None:
+        return None
+
+    def _capture(eid: str, max_wait_s: float) -> Any:
+        # Sync spy: record the budget at coroutine-creation time. The async
+        # body never runs (``_RecordingHass`` closes the coroutine), so the
+        # value must be captured here, not inside an awaited body.
+        recorded.append(max_wait_s)
+        return _noop()
+
+    monkeypatch.setattr(receiver, "_reconnect_for_starvation", _capture)
+
+    receiver._maybe_reconnect_starved(entry_id, now)
+
+    # Exactly one reconnect scheduled, carrying the bounded readiness budget.
+    assert hass.created == [f"fcm_zombie_reconnect_{entry_id}"]
+    assert recorded == [fcm_mod._max_ready_wait_s()]
+    # The budget is the conservative ~22s, strictly below the 900s starvation
+    # threshold whose lock-hold would starve a concurrent manual locate.
+    assert recorded[0] == pytest.approx(22.0)
+    assert recorded[0] < float(FCM_DATA_STARVATION_S)
+
+
+def test_t19_scheduling_failure_during_shutdown_spends_no_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A shutdown-time ``async_create_task`` failure leaves scheduler state intact.
+
+    During HA shutdown the event loop is closing and ``async_create_task`` raises
+    ``RuntimeError`` (Codex F3). The scheduler must swallow it AND leave the
+    attempt counter, backoff window and task registry untouched, so the tick does
+    not "spend" a reconnect attempt with no task ever running (which would drift
+    the entry toward ``FCM_ZOMBIE_MAX_RECONNECTS`` while never reconnecting).
+    Mutation guards: (a) dropping the ``try/except`` lets the ``RuntimeError``
+    propagate -> red; (b) committing the counter before task creation leaves
+    ``entry_id in _zombie_reconnect_attempts`` -> red.
+    """
+    receiver = _make_receiver(monkeypatch)
+
+    class _ShutdownHass:
+        """Stub whose ``async_create_task`` fails as during a closing loop."""
+
+        def __init__(self) -> None:
+            self.created: list[str | None] = []
+
+        def async_create_task(self, coro: Any, *, name: str | None = None) -> Any:
+            self.created.append(name)
+            coro.close()  # avoid "coroutine was never awaited" warning
+            raise RuntimeError("Event loop is closed")
+
+    hass = _ShutdownHass()
+    receiver._hass = hass  # type: ignore[assignment]
+    entry_id = "entry-1"
+    now = time.monotonic()
+    _arm_starved(receiver, entry_id, now)
+
+    # Must not raise despite the loop-closed failure.
+    receiver._maybe_reconnect_starved(entry_id, now)
+
+    # It attempted to schedule exactly once...
+    assert hass.created == [f"fcm_zombie_reconnect_{entry_id}"]
+    # ...but committed NO scheduler state: no spent attempt, no backoff window,
+    # no dangling task registration.
+    assert entry_id not in receiver._zombie_reconnect_attempts
+    assert entry_id not in receiver._zombie_next_allowed_reconnect_monotonic
+    assert entry_id not in receiver._zombie_reconnect_tasks
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_fcm_repair_reauth.py
+++ b/tests/test_fcm_repair_reauth.py
@@ -17,6 +17,7 @@ import pytest
 from homeassistant.data_entry_flow import FlowResultType
 
 from custom_components.googlefindmy import repairs
+from custom_components.googlefindmy._reauth_reason import ReauthReasonCode
 from custom_components.googlefindmy.Auth import fcm_receiver_ha
 from custom_components.googlefindmy.Auth.fcm_receiver_ha import DOMAIN, FcmReceiverHA
 from custom_components.googlefindmy.exceptions import FatalRegistrationError
@@ -204,6 +205,38 @@ async def test_fix_flow_confirm_starts_reauth() -> None:
     # success path clears it.
     assert flow._async_start_reauth() is True
 
+    entry.async_start_reauth.assert_called_once_with(hass)
+
+
+@pytest.mark.asyncio
+async def test_fix_flow_confirm_records_reauth_reason() -> None:
+    """FIX 3: confirming the repair records the FCM_AUTH_FATAL reason.
+
+    The recorder lives on the coordinator (reachable via ``runtime_data``), not
+    on the RepairsFlow; the flow records defensively when it is available.
+    """
+    recorder = MagicMock(return_value=None)
+    entry = SimpleNamespace(
+        async_start_reauth=MagicMock(return_value=None),
+        runtime_data=SimpleNamespace(
+            coordinator=SimpleNamespace(
+                record_reauth_reason=recorder,
+            )
+        ),
+    )
+    hass = SimpleNamespace(
+        config_entries=SimpleNamespace(
+            async_get_entry=lambda entry_id: (entry if entry_id == "entry-id" else None)
+        )
+    )
+    flow = repairs.FcmReauthRepairFlow("entry-id")
+    flow.hass = hass
+
+    assert flow._async_start_reauth() is True
+
+    recorder.assert_called_once_with(
+        ReauthReasonCode.FCM_AUTH_FATAL, origin="repairs.py:112"
+    )
     entry.async_start_reauth.assert_called_once_with(hass)
 
 

--- a/tests/test_fcm_repair_reauth.py
+++ b/tests/test_fcm_repair_reauth.py
@@ -235,7 +235,48 @@ async def test_fix_flow_confirm_records_reauth_reason() -> None:
     assert flow._async_start_reauth() is True
 
     recorder.assert_called_once_with(
-        ReauthReasonCode.FCM_AUTH_FATAL, origin="repairs.py:112"
+        ReauthReasonCode.FCM_AUTH_FATAL, origin="repairs.py:_async_start_reauth"
+    )
+    entry.async_start_reauth.assert_called_once_with(hass)
+
+
+@pytest.mark.asyncio
+async def test_fix_flow_records_reason_on_legacy_subentry_coordinator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AP-1: on the legacy sub-entry path ``runtime_data`` *is* a bare
+    ``GoogleFindMyCoordinator`` (no wrapper). The reauth reason must still be
+    recorded via the ``isinstance`` branch, not silently dropped by a
+    wrapper-only ``.coordinator`` lookup.
+    """
+
+    class _BareCoordinator:
+        """Lightweight stand-in the production ``isinstance`` check accepts."""
+
+    recorder = MagicMock(return_value=None)
+    bare_coordinator = _BareCoordinator()
+    bare_coordinator.record_reauth_reason = recorder  # type: ignore[attr-defined]
+    # Make ``isinstance(rd, GoogleFindMyCoordinator)`` fire for the stand-in;
+    # constructing a real coordinator would drag in the full runtime.
+    monkeypatch.setattr(repairs, "GoogleFindMyCoordinator", _BareCoordinator)
+
+    entry = SimpleNamespace(
+        async_start_reauth=MagicMock(return_value=None),
+        # Legacy sub-entry shape: runtime_data IS the coordinator, no wrapper.
+        runtime_data=bare_coordinator,
+    )
+    hass = SimpleNamespace(
+        config_entries=SimpleNamespace(
+            async_get_entry=lambda entry_id: (entry if entry_id == "entry-id" else None)
+        )
+    )
+    flow = repairs.FcmReauthRepairFlow("entry-id")
+    flow.hass = hass
+
+    assert flow._async_start_reauth() is True
+
+    recorder.assert_called_once_with(
+        ReauthReasonCode.FCM_AUTH_FATAL, origin="repairs.py:_async_start_reauth"
     )
     entry.async_start_reauth.assert_called_once_with(hass)
 

--- a/tests/test_reauth_reason.py
+++ b/tests/test_reauth_reason.py
@@ -1,0 +1,274 @@
+# tests/test_reauth_reason.py
+"""FIX 3 unit tests: structured reauth-reason model, recording choke point,
+raise-site classification and the redaction-safe diagnostics mirror.
+
+These pin the behaviour introduced by FIX 3 (make *why* a reauth fired visible
+in diagnostics without a ``--debug`` capture):
+
+- :class:`ReauthReasonCode` values are stable literal identifiers and
+  :class:`ReauthReason` is a slotted, literal-only record.
+- ``GoogleFindMyCoordinator.record_reauth_reason`` stores the reason, snapshots
+  the transient-auth counters and emits a once-per ``(code, origin)`` WARNING.
+- Every ``ConfigEntryAuthFailed`` raise site tags the exception with the correct
+  ``reauth_code`` so the coordinator catch sites can record it.
+- ``diagnostics._reauth_reason_block`` mirrors the reason and, by the
+  literal-only-input invariant, never leaks free-form/PII content.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.exceptions import ConfigEntryAuthFailed
+
+import custom_components.googlefindmy.api as api_module
+from custom_components.googlefindmy._reauth_reason import (
+    ReauthReason,
+    ReauthReasonCode,
+)
+from custom_components.googlefindmy.api import GoogleFindMyAPI
+from custom_components.googlefindmy.diagnostics import _reauth_reason_block
+from custom_components.googlefindmy.NovaApi.nova_request import (
+    NovaAuthError,
+    NovaAuthPermanentError,
+    NovaHTTPError,
+)
+from tests.helpers.main_coordinator_stub import MainCoordinatorStub
+
+
+class TestReauthReasonModel:
+    """The enum and dataclass are stable, literal-only value objects."""
+
+    def test_codes_serialize_to_stable_literals(self) -> None:
+        # StrEnum → str(value) is the literal identifier, safe to expose verbatim.
+        assert str(ReauthReasonCode.HTTP_401_AFTER_REFRESH) == "http_401_after_refresh"
+        assert str(ReauthReasonCode.BADAUTH_GPSOAUTH) == "badauth_gpsoauth"
+        assert str(ReauthReasonCode.UNKNOWN) == "unknown"
+
+    def test_dataclass_is_slotted_and_defaults_empty(self) -> None:
+        reason = ReauthReason(
+            code=ReauthReasonCode.DECRYPT_STALE_KEY, origin="locate.py:656"
+        )
+        assert reason.code is ReauthReasonCode.DECRYPT_STALE_KEY
+        assert reason.origin == "locate.py:656"
+        assert reason.counters == {}
+        assert reason.recorded_at == 0.0
+        # slots=True ⇒ no __dict__, and unknown attributes are rejected.
+        assert not hasattr(reason, "__dict__")
+        with pytest.raises((AttributeError, TypeError)):
+            reason.leaked = "secret"  # type: ignore[attr-defined]
+
+
+class TestRecordReauthReason:
+    """``record_reauth_reason`` is the single recording choke point."""
+
+    def _coordinator(self) -> MainCoordinatorStub:
+        coord = MainCoordinatorStub()
+        coord._consecutive_transient_auth_failures = 2
+        return coord
+
+    def test_stores_reason_with_code_origin_and_counter_snapshot(self) -> None:
+        coord = self._coordinator()
+        coord.record_reauth_reason(
+            ReauthReasonCode.HTTP_401_AFTER_REFRESH, "polling.py:1541"
+        )
+        reason = coord._reauth_reason
+        assert reason is not None
+        # Mutation-sharp: wrong code or origin fails here.
+        assert reason.code is ReauthReasonCode.HTTP_401_AFTER_REFRESH
+        assert reason.origin == "polling.py:1541"
+        # Default snapshot captures the live transient-auth counter + threshold.
+        assert reason.counters["consecutive_transient_auth_failures"] == 2
+        assert reason.counters["max_transient_auth_failures"] >= 1
+        assert reason.recorded_at > 0.0
+
+    def test_explicit_counters_override_default_snapshot(self) -> None:
+        coord = self._coordinator()
+        coord.record_reauth_reason(
+            ReauthReasonCode.DECRYPT_STALE_KEY,
+            "locate.py:656",
+            counters={"custom": 7},
+        )
+        reason = coord._reauth_reason
+        assert reason is not None
+        assert reason.counters == {"custom": 7}
+        assert "consecutive_transient_auth_failures" not in reason.counters
+
+    def test_warns_once_per_code_origin(self, caplog: pytest.LogCaptureFixture) -> None:
+        coord = self._coordinator()
+        with caplog.at_level(logging.WARNING):
+            coord.record_reauth_reason(
+                ReauthReasonCode.DECRYPT_STALE_KEY, "locate.py:656"
+            )
+            coord.record_reauth_reason(
+                ReauthReasonCode.DECRYPT_STALE_KEY, "locate.py:656"
+            )
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        # De-dup: identical (code, origin) warns exactly once.
+        assert len(warnings) == 1
+        assert warnings[0].reauth_code == "decrypt_stale_key"
+        assert warnings[0].reauth_origin == "locate.py:656"
+
+    def test_distinct_origin_warns_again(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        coord = self._coordinator()
+        with caplog.at_level(logging.WARNING):
+            # Same code, two real emitting origins (locate direct + poll cycle):
+            # a distinct origin is a distinct dedup key, so it warns again.
+            coord.record_reauth_reason(
+                ReauthReasonCode.DECRYPT_STALE_KEY, "polling.py:619"
+            )
+            coord.record_reauth_reason(
+                ReauthReasonCode.DECRYPT_STALE_KEY, "locate.py:656"
+            )
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        # A different origin is a distinct dedup key ⇒ warns again.
+        assert len(warnings) == 2
+
+
+class TestDiagnosticsReauthReasonBlock:
+    """The diagnostics mirror is redaction-safe by the literal-only invariant."""
+
+    def test_returns_none_when_no_reason_recorded(self) -> None:
+        assert _reauth_reason_block(MagicMock(_reauth_reason=None)) is None
+
+    def test_serializes_recorded_reason(self) -> None:
+        reason = ReauthReason(
+            code=ReauthReasonCode.HTTP_401_AFTER_REFRESH,
+            origin="api.py:1062",
+            counters={"consecutive_transient_auth_failures": 3},
+            recorded_at=1_700_000_000.0,
+        )
+        block = _reauth_reason_block(MagicMock(_reauth_reason=reason))
+        assert block is not None
+        assert block["code"] == "http_401_after_refresh"
+        assert block["origin"] == "api.py:1062"
+        assert block["counters"] == {"consecutive_transient_auth_failures": 3}
+        # recorded_at is rendered as an ISO-8601 string, not a raw float.
+        assert isinstance(block["recorded_at"], str)
+        assert block["recorded_at"].startswith("20")
+
+    def test_filters_non_int_and_bool_counters(self) -> None:
+        # Literal-only invariant: only genuine ints survive; bool/str dropped.
+        reason = ReauthReason(
+            code=ReauthReasonCode.UNKNOWN,
+            origin="api.py:1099",
+            counters={"good": 4, "flag": True, "text": "leak"},  # type: ignore[dict-item]
+            recorded_at=1_700_000_000.0,
+        )
+        block = _reauth_reason_block(MagicMock(_reauth_reason=reason))
+        assert block is not None
+        assert block["counters"] == {"good": 4}
+
+    def test_defensive_return_none_when_attribute_access_raises(self) -> None:
+        # A malformed reason whose attribute access raises must degrade to None
+        # rather than propagate into the diagnostics download.
+        class _Exploding:
+            @property
+            def code(self) -> object:
+                raise RuntimeError("boom")
+
+        assert _reauth_reason_block(MagicMock(_reauth_reason=_Exploding())) is None
+
+
+def _make_api() -> GoogleFindMyAPI:
+    """Build an API instance without running its normal ``__init__`` wiring."""
+    api = GoogleFindMyAPI.__new__(GoogleFindMyAPI)
+    api._session = None
+    api._cache = MagicMock()
+    api._cache.entry_id = "entry-reauth"
+    api._contributor_mode = None
+    api._contributor_mode_switch_epoch = 0
+    api._namespace = lambda: "entry-reauth"
+    return api
+
+
+class TestDeviceListRaiseSiteCodes:
+    """Every device-list ``ConfigEntryAuthFailed`` carries its ``reauth_code``."""
+
+    async def _drive_device_list(
+        self, monkeypatch: pytest.MonkeyPatch, error: Exception
+    ) -> ConfigEntryAuthFailed:
+        async def _raise(*_a: object, **_k: object) -> list[dict[str, Any]]:
+            raise error
+
+        monkeypatch.setattr(api_module, "async_request_device_list", _raise)
+        api = _make_api()
+        with pytest.raises(ConfigEntryAuthFailed) as excinfo:
+            await api.async_get_basic_device_list(username="user@example.com")
+        return excinfo.value
+
+    @pytest.mark.asyncio
+    async def test_http_401_maps_to_after_refresh(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        exc = await self._drive_device_list(monkeypatch, NovaHTTPError(401))
+        assert exc.reauth_code is ReauthReasonCode.HTTP_401_AFTER_REFRESH
+
+    @pytest.mark.asyncio
+    async def test_nova_auth_error_maps_to_nova_auth_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        exc = await self._drive_device_list(monkeypatch, NovaAuthError(401))
+        assert exc.reauth_code is ReauthReasonCode.NOVA_AUTH_FAILED
+
+    @pytest.mark.asyncio
+    async def test_gpsoauth_badauth_maps_to_badauth_gpsoauth(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        exc = await self._drive_device_list(
+            monkeypatch, RuntimeError("BadAuthentication from gpsoauth")
+        )
+        assert exc.reauth_code is ReauthReasonCode.BADAUTH_GPSOAUTH
+
+    @pytest.mark.asyncio
+    async def test_tokencache_closed_maps_to_tokencache_closed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        exc = await self._drive_device_list(
+            monkeypatch, RuntimeError("TokenCache is closed")
+        )
+        assert exc.reauth_code is ReauthReasonCode.TOKENCACHE_CLOSED
+
+
+class TestLocationRaiseSiteCodes:
+    """Every location ``ConfigEntryAuthFailed`` carries its ``reauth_code``."""
+
+    async def _drive_location(
+        self, monkeypatch: pytest.MonkeyPatch, error: Exception
+    ) -> ConfigEntryAuthFailed:
+        async def _raise(*_a: object, **_k: object) -> list[dict[str, Any]]:
+            raise error
+
+        monkeypatch.setattr(api_module, "get_location_data_for_device", _raise)
+        api = _make_api()
+        with pytest.raises(ConfigEntryAuthFailed) as excinfo:
+            await api.async_get_device_location("device-xyz", "Tracker")
+        return excinfo.value
+
+    @pytest.mark.asyncio
+    async def test_permanent_nova_auth_maps_to_nova_auth_permanent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        exc = await self._drive_location(monkeypatch, NovaAuthPermanentError(403))
+        assert exc.reauth_code is ReauthReasonCode.NOVA_AUTH_PERMANENT
+
+    @pytest.mark.asyncio
+    async def test_permanent_flag_nova_auth_maps_to_nova_auth_permanent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        exc = await self._drive_location(
+            monkeypatch, NovaAuthError(401, is_permanent=True)
+        )
+        assert exc.reauth_code is ReauthReasonCode.NOVA_AUTH_PERMANENT
+
+    @pytest.mark.asyncio
+    async def test_http_401_maps_to_after_refresh(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        exc = await self._drive_location(monkeypatch, NovaHTTPError(401))
+        assert exc.reauth_code is ReauthReasonCode.HTTP_401_AFTER_REFRESH

--- a/tests/test_reauth_reason.py
+++ b/tests/test_reauth_reason.py
@@ -50,10 +50,11 @@ class TestReauthReasonModel:
 
     def test_dataclass_is_slotted_and_defaults_empty(self) -> None:
         reason = ReauthReason(
-            code=ReauthReasonCode.DECRYPT_STALE_KEY, origin="locate.py:656"
+            code=ReauthReasonCode.DECRYPT_STALE_KEY,
+            origin="locate.py:async_locate_device:decrypt_stale_key",
         )
         assert reason.code is ReauthReasonCode.DECRYPT_STALE_KEY
-        assert reason.origin == "locate.py:656"
+        assert reason.origin == "locate.py:async_locate_device:decrypt_stale_key"
         assert reason.counters == {}
         assert reason.recorded_at == 0.0
         # slots=True ⇒ no __dict__, and unknown attributes are rejected.
@@ -73,13 +74,13 @@ class TestRecordReauthReason:
     def test_stores_reason_with_code_origin_and_counter_snapshot(self) -> None:
         coord = self._coordinator()
         coord.record_reauth_reason(
-            ReauthReasonCode.HTTP_401_AFTER_REFRESH, "polling.py:1541"
+            ReauthReasonCode.HTTP_401_AFTER_REFRESH, "polling.py:_async_update_data"
         )
         reason = coord._reauth_reason
         assert reason is not None
         # Mutation-sharp: wrong code or origin fails here.
         assert reason.code is ReauthReasonCode.HTTP_401_AFTER_REFRESH
-        assert reason.origin == "polling.py:1541"
+        assert reason.origin == "polling.py:_async_update_data"
         # Default snapshot captures the live transient-auth counter + threshold.
         assert reason.counters["consecutive_transient_auth_failures"] == 2
         assert reason.counters["max_transient_auth_failures"] >= 1
@@ -89,7 +90,7 @@ class TestRecordReauthReason:
         coord = self._coordinator()
         coord.record_reauth_reason(
             ReauthReasonCode.DECRYPT_STALE_KEY,
-            "locate.py:656",
+            "locate.py:async_locate_device:decrypt_stale_key",
             counters={"custom": 7},
         )
         reason = coord._reauth_reason
@@ -101,16 +102,21 @@ class TestRecordReauthReason:
         coord = self._coordinator()
         with caplog.at_level(logging.WARNING):
             coord.record_reauth_reason(
-                ReauthReasonCode.DECRYPT_STALE_KEY, "locate.py:656"
+                ReauthReasonCode.DECRYPT_STALE_KEY,
+                "locate.py:async_locate_device:decrypt_stale_key",
             )
             coord.record_reauth_reason(
-                ReauthReasonCode.DECRYPT_STALE_KEY, "locate.py:656"
+                ReauthReasonCode.DECRYPT_STALE_KEY,
+                "locate.py:async_locate_device:decrypt_stale_key",
             )
         warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
         # De-dup: identical (code, origin) warns exactly once.
         assert len(warnings) == 1
         assert warnings[0].reauth_code == "decrypt_stale_key"
-        assert warnings[0].reauth_origin == "locate.py:656"
+        assert (
+            warnings[0].reauth_origin
+            == "locate.py:async_locate_device:decrypt_stale_key"
+        )
 
     def test_distinct_origin_warns_again(
         self, caplog: pytest.LogCaptureFixture
@@ -120,10 +126,11 @@ class TestRecordReauthReason:
             # Same code, two real emitting origins (locate direct + poll cycle):
             # a distinct origin is a distinct dedup key, so it warns again.
             coord.record_reauth_reason(
-                ReauthReasonCode.DECRYPT_STALE_KEY, "polling.py:619"
+                ReauthReasonCode.DECRYPT_STALE_KEY, "polling.py:_request_poll_reauth"
             )
             coord.record_reauth_reason(
-                ReauthReasonCode.DECRYPT_STALE_KEY, "locate.py:656"
+                ReauthReasonCode.DECRYPT_STALE_KEY,
+                "locate.py:async_locate_device:decrypt_stale_key",
             )
         warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
         # A different origin is a distinct dedup key ⇒ warns again.
@@ -139,14 +146,14 @@ class TestDiagnosticsReauthReasonBlock:
     def test_serializes_recorded_reason(self) -> None:
         reason = ReauthReason(
             code=ReauthReasonCode.HTTP_401_AFTER_REFRESH,
-            origin="api.py:1062",
+            origin="fixture:diagnostics_serialization",
             counters={"consecutive_transient_auth_failures": 3},
             recorded_at=1_700_000_000.0,
         )
         block = _reauth_reason_block(MagicMock(_reauth_reason=reason))
         assert block is not None
         assert block["code"] == "http_401_after_refresh"
-        assert block["origin"] == "api.py:1062"
+        assert block["origin"] == "fixture:diagnostics_serialization"
         assert block["counters"] == {"consecutive_transient_auth_failures": 3}
         # recorded_at is rendered as an ISO-8601 string, not a raw float.
         assert isinstance(block["recorded_at"], str)
@@ -156,7 +163,7 @@ class TestDiagnosticsReauthReasonBlock:
         # Literal-only invariant: only genuine ints survive; bool/str dropped.
         reason = ReauthReason(
             code=ReauthReasonCode.UNKNOWN,
-            origin="api.py:1099",
+            origin="fixture:counter_filter",
             counters={"good": 4, "flag": True, "text": "leak"},  # type: ignore[dict-item]
             recorded_at=1_700_000_000.0,
         )

--- a/tests/test_token_retrieval.py
+++ b/tests/test_token_retrieval.py
@@ -1,0 +1,146 @@
+# tests/test_token_retrieval.py
+"""Regression tests for the AAS-token error classifier in token_retrieval.
+
+These tests pin the FIX 5 matcher hardening: HTTP-generic tokens
+("unauthorized"/"forbidden"/status codes) must no longer promote an arbitrary
+transport/network exception string to :class:`InvalidAasTokenError`, while the
+gpsoauth-specific ``Error`` vocabulary (``badauthentication``) keeps doing so.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from custom_components.googlefindmy.Auth import token_retrieval
+from custom_components.googlefindmy.Auth.token_retrieval import (
+    InvalidAasTokenError,
+    _is_invalid_aas_error_text,
+)
+
+# ---------------------------------------------------------------------------
+# _is_invalid_aas_error_text: HTTP-generic gating
+# ---------------------------------------------------------------------------
+
+
+def test_http_generic_forbidden_gated_off_by_default() -> None:
+    """A bare "403 forbidden" string is NOT an invalid-AAS signal by default."""
+    assert (
+        _is_invalid_aas_error_text(
+            "server returned 403 forbidden", allow_http_generic=False
+        )
+        is False
+    )
+
+
+def test_http_generic_forbidden_honoured_when_opted_in() -> None:
+    """The structured gpsoauth Error field opts in and keeps the old behavior."""
+    assert (
+        _is_invalid_aas_error_text(
+            "server returned 403 forbidden", allow_http_generic=True
+        )
+        is True
+    )
+
+
+def test_http_generic_unauthorized_gated() -> None:
+    """ "unauthorized" mirrors "forbidden": gated off by default, on when opted in."""
+    assert (
+        _is_invalid_aas_error_text("401 unauthorized", allow_http_generic=False)
+        is False
+    )
+    assert (
+        _is_invalid_aas_error_text("401 unauthorized", allow_http_generic=True) is True
+    )
+
+
+def test_gpsoauth_badauthentication_always_matches() -> None:
+    """gpsoauth-specific tokens stay active regardless of the HTTP-generic gate."""
+    assert _is_invalid_aas_error_text("BadAuthentication") is True
+    assert (
+        _is_invalid_aas_error_text("BadAuthentication", allow_http_generic=True) is True
+    )
+
+
+def test_gpsoauth_invalid_credential_vocabulary_always_matches() -> None:
+    """ "invalid" + credential vocabulary is gpsoauth-specific, never gated."""
+    assert _is_invalid_aas_error_text("invalid credential") is True
+    assert _is_invalid_aas_error_text("needsbrowser") is True
+
+
+# ---------------------------------------------------------------------------
+# _perform_oauth_sync: the generic except-Exception call site (Z.222)
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_gpsoauth(monkeypatch: pytest.MonkeyPatch, perform_oauth: Any) -> None:
+    """Patch the module-local gpsoauth accessor with a fake providing perform_oauth."""
+    fake = SimpleNamespace(perform_oauth=perform_oauth)
+    monkeypatch.setattr(token_retrieval, "_gpsoauth", lambda: fake)
+
+
+def test_generic_network_exception_does_not_discard_aas_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A generic transport failure whose text contains "403 Forbidden" must NOT
+    be reclassified as InvalidAasTokenError (which would discard the AAS token);
+    it stays a plain RuntimeError so the caller treats it as retryable."""
+
+    def _boom(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise OSError("WAF blocked request: HTTP 403 Forbidden (getaddrinfo)")
+
+    _install_fake_gpsoauth(monkeypatch, _boom)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        token_retrieval._perform_oauth_sync(
+            "user@example.com",
+            "aas_et/fake",
+            "android_device_manager",
+            False,
+            android_id=0x1234,
+        )
+    assert not isinstance(excinfo.value, InvalidAasTokenError)
+
+
+def test_genuine_badauthentication_still_discards_aas_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A structured gpsoauth Error=BadAuthentication response must still raise
+    InvalidAasTokenError so the stale AAS token is discarded (no regression)."""
+
+    def _bad_auth(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"Error": "BadAuthentication"}
+
+    _install_fake_gpsoauth(monkeypatch, _bad_auth)
+
+    with pytest.raises(InvalidAasTokenError):
+        token_retrieval._perform_oauth_sync(
+            "user@example.com",
+            "aas_et/fake",
+            "android_device_manager",
+            False,
+            android_id=0x1234,
+        )
+
+
+def test_generic_exception_with_gpsoauth_vocabulary_still_discards(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Even via the generic except-Exception path, a gpsoauth-specific token in
+    the exception text still promotes to InvalidAasTokenError."""
+
+    def _boom(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise RuntimeError("gpsoauth rejected: BadAuthentication")
+
+    _install_fake_gpsoauth(monkeypatch, _boom)
+
+    with pytest.raises(InvalidAasTokenError):
+        token_retrieval._perform_oauth_sync(
+            "user@example.com",
+            "aas_et/fake",
+            "android_device_manager",
+            False,
+            android_id=0x1234,
+        )

--- a/tests/test_token_retrieval.py
+++ b/tests/test_token_retrieval.py
@@ -144,3 +144,68 @@ def test_generic_exception_with_gpsoauth_vocabulary_still_discards(
             False,
             android_id=0x1234,
         )
+
+
+# ---------------------------------------------------------------------------
+# _perform_oauth_sync: typed gpsoauth.AuthError structural channel
+# ---------------------------------------------------------------------------
+
+
+class _MockAuthError(Exception):
+    """Stand-in for ``gpsoauth.exceptions.AuthError`` (gpsoauth is absent in CI)."""
+
+
+def test_typed_gpsoauth_autherror_http_only_discards_aas_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A typed gpsoauth AuthError with HTTP-generic-only text must discard the
+    AAS token. gpsoauth may raise its typed AuthError instead of returning an
+    Error dict; classifying it by type (mirroring the AAS exchange path) must
+    promote it to InvalidAasTokenError even though the text matcher gates the
+    HTTP-generic tokens off (``allow_http_generic=False``)."""
+
+    monkeypatch.setattr(
+        token_retrieval,
+        "gpsoauth_exceptions",
+        SimpleNamespace(AuthError=_MockAuthError),
+    )
+
+    def _typed_auth_error(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise _MockAuthError("HTTP 403 Forbidden")
+
+    _install_fake_gpsoauth(monkeypatch, _typed_auth_error)
+
+    with pytest.raises(InvalidAasTokenError):
+        token_retrieval._perform_oauth_sync(
+            "user@example.com",
+            "aas_et/fake",
+            "android_device_manager",
+            False,
+            android_id=0x1234,
+        )
+
+
+def test_typed_channel_absent_http_only_stays_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the gpsoauth exceptions module is unavailable (dependency absent),
+    the typed channel is skipped and an HTTP-generic-only exception text keeps
+    the safe FIX-5 default: it stays a retryable RuntimeError and does not
+    masquerade as an invalid AAS token."""
+
+    monkeypatch.setattr(token_retrieval, "gpsoauth_exceptions", None)
+
+    def _http_only(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise RuntimeError("HTTP 403 Forbidden")
+
+    _install_fake_gpsoauth(monkeypatch, _http_only)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        token_retrieval._perform_oauth_sync(
+            "user@example.com",
+            "aas_et/fake",
+            "android_device_manager",
+            False,
+            android_id=0x1234,
+        )
+    assert not isinstance(excinfo.value, InvalidAasTokenError)


### PR DESCRIPTION
# Summary

This rolls up the next slice of the `jleinenbach` fork's `1.7` line (integration **1.7.9 → 1.7.10**) on top of the already-merged `1.7.9` contribution (#197). It is an **additive** contribution bundling **seven** fork PRs: reauth-classification reliability fixes, a poll-cadence fix, a corrupt-input robustness guard, an FCM "zombie"-session self-heal watchdog, the version bump, plus structured (diagnostics-only) reauth-reason reporting and provenance hardening. GitHub shows a clean **8-commit, 35-file** diff (`+2943 / -83`); seven of those are the functional fork PRs below and one is an empty upstream sync-merge.

- Type: ☑ fix ☑ test ☑ feat (the FCM zombie self-heal watchdog; plus diagnostics-only reporting and a version bump)
- Scope/Area: gpsoauth/AAS reauth classification, coordinator poll cadence, `.storage` input coercion, FCM push-session liveness/self-heal, reauth-reason diagnostics
- Linked issues: bundles fork PRs #1156, #1158, #1159 (version), #1160, #1161, #1162, #1163

> **Note for reviewers:** the two `1.7` branches **share a merge base here** (the merged #197 / `1.7.9` tip `a405b46a`), so GitHub shows a **clean 8-commit diff**, not a full tree diff. This PR **deletes no user-facing files and reverts nothing** from upstream. Every bundled commit was individually reviewed (Codex) and CI-green on the fork. Any higher "commits behind" count GitHub may display is an artifact of BSkando's own merge commits of earlier `jleinenbach` PRs, whose content is already present here; it does not affect the diff above.

## Motivation

Since `1.7.9`, seven things landed on the fork's `1.7` line that are worth contributing upstream together:

1. **A transient network error could discard a valid cached AAS token and force a needless re-authentication (#1160).** Broad substring matchers in the gpsoauth/AAS token path treated any error text containing `401` / `403` / `unauthorized` / `forbidden` as a hard, non-retryable auth failure. In the field this produced a concrete, confusing failure loop, reported by an affected user: a transient network- or gateway-adjacent error whose message merely contained one of those tokens caused a perfectly valid, still-cached AAS token to be discarded from the cache (or a fatal-auth classification to trip). From that point the integration stopped receiving fresh location updates and prompted the user to re-authenticate, even though their AAS credentials were fully intact and no real auth denial had ever occurred.
2. **A typed gpsoauth `AuthError` could be treated as retryable (#1161).** When `gpsoauth.perform_oauth` raises its typed `AuthError` instead of returning an `Error` dict, its message text can be HTTP-generic only (e.g. `"HTTP 403 Forbidden"`). The text-based classifiers deliberately gate those tokens off, so a *definitive* credential rejection was treated as retryable, leaving the rejected AAS token cached and retried indefinitely.
3. **Predictive polling could pull the cadence below the configured interval (#1156).** Adaptive predictive pre-fetch could drag the effective poll cadence down toward the raw `min_poll_interval` safety floor (60s), polling more often than the user's configured `location_poll_interval`.
4. **A corrupt `ignored_at` value could raise instead of being dropped (#1158).** `int(float("nan"))` / `int(float("inf"))` raise, which would break the drop-invalid, never-raise contract of `coerce_ignored_mapping` if a corrupt `.storage` edit or a direct-options writer stored a non-finite value.
5. **An FCM "zombie" session forced a manual reload every ~2 h (#1162).** In a transient failure mode the FCM push session reaches `STARTED` and keeps heartbeating but never delivers location callbacks; the only recovery was a manual integration reload.
6. **Reauth causes were not distinguishable in diagnostics (#1160).** When a reauth did fire, the diagnostics download could not tell *why* (network-adjacent vs. stale shared key vs. permanent Nova/Spot auth failure).
7. **Reauth diagnostics had provenance gaps (#1163).** Legacy sub-entry coordinators silently dropped the reauth reason; `origin="file.py:NNNN"` labels had drifted from their real line numbers; and a missed-denial fingerprint (an untyped exception carrying an HTTP auth marker) was not observable in the field.

---

## Change Log (human-readable)

### Fixed
- **Harden reauth matchers against network-adjacent errors (#1160).** `token_retrieval._is_invalid_aas_error_text` gains an `allow_http_generic` gate (default `False`); only the structured gpsoauth `Error` path opts in, so the generic `except` path can no longer classify broad HTTP text as an invalid AAS token. The broad HTTP substrings are dropped from `_NON_RETRYABLE_PATTERNS` in the adm/aas token paths — genuine HTTP auth denials are already carried structurally via `error_kind` (`_NON_RETRYABLE_KINDS`). `is_fatal_fcm_auth_error` now uses `\b` word boundaries instead of a bare `"401" in error`, so text like `"retry after 4012 ms"` no longer false-fires as a fatal 401. **This is a behavioural fix that changes control flow.**
- **Classify typed gpsoauth `AuthError` structurally on both OAuth token paths (#1161).** Mirrors the AAS exchange path (which already classifies by type) on both `perform_oauth` callers: `token_retrieval._perform_oauth_sync` now raises `InvalidAasTokenError` so the rejected AAS token is invalidated/regenerated, and `adm_token_retrieval._perform_oauth_with_provided_aas` promotes to `error_kind="auth_error"` (in `_NON_RETRYABLE_KINDS`) so the isolated retry loop stops instead of hammering the rejected token. Both branches sit before the text check and are guarded on the optional gpsoauth exceptions module (no-op when the dependency lacks a typed `AuthError`).
- **Predictive poll respects `location_poll_interval` cadence — Stage 1 (#1156).** `is_poll_cycle_due` branch 3 now requires `elapsed >= effective_interval` (`= max(location_poll_interval, min_poll_interval)`), so predictive pre-fetch can no longer pull the cadence down to the raw 60s floor. `min_poll_interval` stays a pure API safety floor. Stage 1 disables adaptive pre-fetch below the configured cadence for all devices; a later stage can restore per-device freshness via a per-device due-gate.
- **Drop non-finite `ignored_at` values instead of raising (#1158).** The `ignored_at` conversion is routed through a new total helper `_finite_int_or_none` that yields `None` for `bool`, non-numeric types and non-finite floats, preserving the never-raise contract on corrupt input.
- **Record reauth reason on legacy sub-entry coordinators (#1163).** On the legacy sub-entry path `entry.runtime_data` *is* a bare `GoogleFindMyCoordinator` rather than a wrapper exposing `.coordinator`, so the repair flow's flat `getattr(..., "coordinator")` lookup silently dropped the reauth reason on those entries. Both shapes are now resolved via the same `isinstance(runtime_data, GoogleFindMyCoordinator)` pattern `__init__.py` already uses, with a risk comment documenting the duality.

### Added
- **Self-heal the FCM "zombie" session via a liveness watchdog (#1162, behavioural).** Detects the transient failure where the FCM session reaches `STARTED` and keeps heartbeating but never delivers location callbacks. A per-entry data-delivery clock plus a starvation predicate (`STARTED` + established + fresh heartbeat + data-gap > threshold + a locate issued since last delivery) triggers a **cooperative single reconnect** with backoff and a MAX-reconnect ceiling, instead of forcing the user to reload every ~2 h. The starvation guard shares the native ready-wait budget (`_max_ready_wait_s` SSOT, ~22 s) so the lock cannot starve concurrent readiness waiters (F1), and the reconnect is commit-after-success so a shutdown scheduling failure spends no attempt (F3).
- **Structured reauth-reason diagnostics (#1160, diagnostics-only).** A `ReauthReasonCode` enum plus recording at the reauth sites, surfaced in the diagnostics download, makes reauth causes distinguishable (network-adjacent, stale shared key, permanent Nova/Spot auth). **Control flow is unchanged**; only the recorded reason code and log wording differ. Direct-path and background sites were aligned to the same canonical exception-type → code mapping the poll-cycle path uses.
- **Auth-token fall-through DEBUG probe (#1163, diagnostics-only, redaction-safe).** Records the classification signature of an auth-token fall-through at DEBUG (exception type, typed-flag, present HTTP markers) so a missed denial slipping past `allow_http_generic=False` becomes observable in the field — **without ever logging `str(err)`** (which may carry a token or email). The inline typed check is refactored into a named `is_typed_autherror` shared with the log line.

### Changed
- **Stabilize reauth-reason provenance labels (#1163).** The drifting `origin="file.py:NNNN"` labels are replaced with stable qualified function names (e.g. `polling.py:_request_poll_reauth`); the two sites in `async_locate_device` carry distinct semantic suffixes to stay unique. Test fixtures were realigned to the same convention, with obviously synthetic `fixture:*` markers where no real recording site exists. Diagnostics-only, no control-flow change.
- Version bumped **1.7.9 → 1.7.10** across the three canonical anchors (`const.py`, `manifest.json`, `pyproject.toml`) (#1159).
- Coverage floor raised **72 → 73 %** (`pyproject.toml` + `ci.yml` in lockstep), locking in the coverage gained by the #1161 classification tests (#1161).

### Removed
- Nothing user-facing. A dead, never-released reauth-reason enum member introduced during diagnostics development was removed once it had no production use.

### Compatibility
- **No breaking changes expected.** The `config_entry` schema version is unchanged; existing working installs are unaffected. The behavioural changes are confined to reauth *classification* (fewer spurious reauths), poll *cadence* (never faster than configured) and the FCM self-heal (a cooperative reconnect that replaces a manual reload).

### Security/Privacy
- No changes to redaction, key handling, or stored secret material. The reauth-reason diagnostics record a coarse cause code, not credential contents, and the #1163 auth fall-through probe logs a classification signature at DEBUG **without** `str(err)`, so no token or email content can leak.

---

## Tests

- ☑ **#1160** inverts the previously broad matcher assertions and pins both the false-fire (network-adjacent text stays retryable) and the genuine-denial (structured `error_kind`) paths; the reauth-reason recording is covered by mutation-sharp per-site tests, and the direct/background sites assert the canonical code.
- ☑ **#1161** adds four mutation-sharp tests pinning the typed-`AuthError` classification on both OAuth token paths, and raises the coverage floor to match.
- ☑ **#1156** updates the predictive-due-below-cadence unit test to the new contract and adds discriminating regression cases around the `effective_interval` floor.
- ☑ **#1158** adds a parametrized regression test (`nan` / `inf` / `-inf` / `bool`), each mutation-sharp.
- ☑ **#1162** adds the watchdog suite: healthy-baseline no-fire oracles (T0a/b/c), starvation-detection and cooperative-reconnect behaviour, the deadlock/reuse-gate guard (T8), the F1 shared-budget bound (T18, mutation-sharp) and the F3 commit-after-success invariant (T19, mutation-sharp). Delta-coverage of the changed production lines is complete.
- ☑ **#1163** covers the bare-coordinator legacy sub-entry branch with a new regression test, updates the coupled `origin` assertion to the stable label, and realigns the reauth-reason fixtures to the stable-name convention.
- Provenance note (honest): this PR **bundles already-merged, individually CI-green and Codex-reviewed fork commits**; **no new code was added in this bundling step**, so no separate full-suite run was performed for the bundle itself. Each bundled PR was full-suite green on the fork at merge time.

---

## Risk & Rollback
- Risk level: ☑ low
- Rollback plan: every bundled change is an isolated, independently revertible commit. No schema or data migrations. Installed HA runtimes gain fewer spurious reauth prompts, correct invalidation of genuinely rejected tokens, a poll cadence that never runs faster than configured, a never-raise guard on corrupt `ignored_at` input, automatic self-heal of the FCM "zombie" session (no more ~2 h manual reload), and richer, drift-proof reauth diagnostics.

