### PR TITLE
fix(gfmy): retune stale threshold to home cadence + accuracy-less fallback

### DIFF
--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -225,19 +225,33 @@ DEFAULT_DELETE_CACHES_ON_REMOVE: bool = True
 # the tracker state becomes "unknown". This is always enabled.
 # Users who need the last known location can use the "Last Location" entity.
 #
-# Based on real-world FMDN tracker update intervals:
-# - Typical update interval: 2-4 minutes (median ~3.4 min)
-# - 95th percentile: ~8 minutes
-# - 99th percentile: ~14 minutes
+# Situation (empirically observed, HA history July 2026):
+# A stationary device at home (smartphone with a dark display, or a Bluetooth
+# tag scanned only by the household's own dark-display phones) reports through
+# the FMDN network roughly every ~30 minutes. Every spurious "unknown" flip in
+# the field carried last_seen ~1800-1835 s old, i.e. exactly at the previous
+# 1800 s threshold: the threshold sat directly on the natural home reporting
+# cadence, so any minor delay tipped an otherwise-present device into "stale"
+# and blanked its coordinates until the next report arrived.
 #
-# Note: EID rotation (1024s) is NOT relevant here. When participating in the
-# FMDN network, we receive updates from smartphones that see the tracker.
-# The update frequency depends on smartphone density and tracker visibility,
-# not on EID rotation.
+# The earlier 1800 s were calibrated to ACTIVE FMDN tracker-scan statistics
+# (median ~3.4 min, p95 ~8 min, p99 ~14 min) that hold when many foreign
+# phones continuously scan a tracker. They do NOT hold for a device sitting at
+# home: a dozing smartphone reports its own position only occasionally, and a
+# tag at home is seen only by the few (also dozing) household phones. A shorter
+# poll does not help - Google returns the last reported fix for a dozing
+# device, so last_seen only advances when the device itself reports.
 #
-# Default: 1800 seconds (30 minutes) - conservative value for "really gone"
-# Minimum: 300 seconds (5 minutes) - allows ~2-3 typical update cycles
-DEFAULT_STALE_THRESHOLD: int = 1800
+# Rationale for the default: 3900 s (65 minutes) ~= 2x the
+# observed ~30 min home cadence plus margin to tolerate one missed report
+# cycle, which removes the flapping for both smartphones and tags while still
+# flagging a genuinely absent device within ~1 h. The threshold stays
+# user-configurable (min 300 s, max 86400 s); only the default was mistuned.
+#
+# Note: EID rotation (1024s) is NOT relevant here.
+# Default: 3900 seconds (65 minutes) - ~2x the observed home reporting cadence
+# Minimum: 300 seconds (5 minutes) - allows ~2-3 active-scan update cycles
+DEFAULT_STALE_THRESHOLD: int = 3900
 DEFAULT_SHOW_LOCATION_AGE: bool = True
 
 CONTRIBUTOR_MODE_HIGH_TRAFFIC: str = "high_traffic"

--- a/custom_components/googlefindmy/coordinator/__init__.py
+++ b/custom_components/googlefindmy/coordinator/__init__.py
@@ -32,6 +32,10 @@ from ..KeyBackup.cloud_key_decryptor import decrypt_eik
 # Re-export helpers subpackage
 from . import helpers
 
+# Re-export the ISO/epoch timestamp parser (dependency-light, used by the
+# device_tracker restore path to recover last_seen after a restart).
+from .helpers import parse_last_seen_timestamp
+
 # Re-export the canonical GPS accuracy normalizer. Exposing it as a direct
 # attribute of the coordinator package (mirroring GoogleFindMyCoordinator) lets
 # lightweight consumers such as map_view resolve it without reaching into the
@@ -101,6 +105,7 @@ __all__ = [
     "get_recorder",
     "is_valid_accuracy",
     "normalize_epoch_seconds",
+    "parse_last_seen_timestamp",
     "recorded_accuracy_pair",
     "resolve_seeded_accuracy",
     "safe_accuracy",

--- a/custom_components/googlefindmy/coordinator/main.py
+++ b/custom_components/googlefindmy/coordinator/main.py
@@ -524,8 +524,11 @@ def _sync_get_last_gps_from_history(
 
         last_state = samples[-1]
         attrs = getattr(last_state, "attributes", {}) or {}
-        lat = attrs.get("latitude")
-        lon = attrs.get("longitude")
+        # Stale/blank recorded states withhold the plain latitude/longitude keys;
+        # the last known fix lives in the recorder-only last_latitude/last_longitude
+        # keys. Fall back to those so history reconstruction still finds a position.
+        lat = attrs.get("latitude", attrs.get("last_latitude"))
+        lon = attrs.get("longitude", attrs.get("last_longitude"))
         if lat is None or lon is None:
             return None
 
@@ -1664,8 +1667,15 @@ class GoogleFindMyCoordinator(
 
             state = self.hass.states.get(entity_id)
             if state:
-                lat = state.attributes.get("latitude")
-                lon = state.attributes.get("longitude")
+                # Stale/blank states withhold the plain latitude/longitude keys;
+                # fall back to the recorder-only last_latitude/last_longitude so
+                # the snapshot keeps the last known position.
+                lat = state.attributes.get(
+                    "latitude", state.attributes.get("last_latitude")
+                )
+                lon = state.attributes.get(
+                    "longitude", state.attributes.get("last_longitude")
+                )
                 # Same authoritative read as the history path: take accuracy
                 # from accuracy_m (stable producer attribute) over the volatile
                 # gps_accuracy and carry accuracy_estimated, so a fallback radius

--- a/custom_components/googlefindmy/device_tracker.py
+++ b/custom_components/googlefindmy/device_tracker.py
@@ -52,6 +52,7 @@ from .const import (
 from .coordinator import (
     GoogleFindMyCoordinator,
     _as_ha_attributes,
+    parse_last_seen_timestamp,
     recorded_accuracy_pair,
     resolve_seeded_accuracy,
 )
@@ -922,12 +923,17 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
         if not last_state:
             return
 
-        # Standard device_tracker attributes (with safe fallbacks for legacy keys)
+        # Standard device_tracker attributes. Fresh states expose the position via
+        # the plain latitude/longitude keys; stale/blank states withhold them (the
+        # producer strips them so a withheld position is not republished as the
+        # live GPS attribute) and keep the last known fix in the recorder-only
+        # last_latitude/last_longitude keys. Fall back to those so a restart still
+        # recovers the last position.
         lat = last_state.attributes.get(
-            ATTR_LATITUDE, last_state.attributes.get("latitude")
+            ATTR_LATITUDE, last_state.attributes.get("last_latitude")
         )
         lon = last_state.attributes.get(
-            ATTR_LONGITUDE, last_state.attributes.get("longitude")
+            ATTR_LONGITUDE, last_state.attributes.get("last_longitude")
         )
         # Read the accuracy value AND its estimated-provenance flag from the
         # same authoritative source as map_view and the snapshot builders:
@@ -970,6 +976,22 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
             restored = {}
 
         if restored:
+            # Restore last_seen so the recovered fix carries its true age.
+            # _get_location_age() reads ``last_seen`` as an epoch float; without
+            # it the age is unknown and _is_location_stale() assumes "not stale",
+            # so a position that predates the restart would look fresh until the
+            # next poll. The recorded value is an ISO string (or last_seen_utc);
+            # parse_last_seen_timestamp() normalizes both back to epoch seconds.
+            last_seen = parse_last_seen_timestamp(
+                last_state.attributes.get("last_seen")
+            )
+            if last_seen is None:
+                last_seen = parse_last_seen_timestamp(
+                    last_state.attributes.get("last_seen_utc")
+                )
+            if last_seen is not None:
+                restored["last_seen"] = last_seen
+
             self._last_good_accuracy_data = {**restored}
             # Prime coordinator cache using its public API (no private access).
             dev_id = self.device_id
@@ -1223,13 +1245,22 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
         # Deriving from display_data keeps the attribute set from exposing a
         # position that differs from the published coordinates (Codex #202).
         attributes: dict[str, Any] = _as_ha_attributes(display_data) or {}
+        # Decouple the live GPS keys from the recorder-only keys. When the live
+        # coordinates are withheld (_attr_latitude is None: stale, or a display
+        # row without usable accuracy), HA's TrackerEntity.state_attributes omits
+        # latitude/longitude -- but extra_state_attributes is merged last
+        # (entity.py: attr |= extra_state_attributes), so leaving the plain
+        # latitude/longitude keys here would republish the withheld position as
+        # the live GPS attribute. closest()/proximity/the built-in map would then
+        # treat a stale fix as the current location (Codex #1177). Strip the plain
+        # keys (via the HA constants, same house-style as the timestamp sensor)
+        # and expose the last known position through the recorder-only
+        # last_latitude/last_longitude keys below. accuracy_m/altitude_m are not
+        # HA GPS attributes and stay untouched, so restore/history/snapshot keep
+        # the accuracy radius (Codex #202 stays fixed: no divergent live position).
         if self._attr_latitude is None:
-            # Coordinates were withheld (stale, or a display row without
-            # accuracy). Strip the positional keys so the attributes never
-            # resurrect coordinates the tracker is deliberately not publishing.
-            for _pos_key in ("latitude", "longitude", "accuracy_m", "altitude_m"):
-                attributes.pop(_pos_key, None)
-
+            attributes.pop(ATTR_LATITUDE, None)
+            attributes.pop(ATTR_LONGITUDE, None)
         attributes["google_device_id"] = self.device_id
 
         location_age = self._get_location_age(display_data)
@@ -1253,9 +1284,13 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
         # and the sensor.*_last_seen entity.
         attributes["location_status"] = self._get_location_status(display_data)
 
-        if stale and display_data:
-            # Main coordinates are withheld while stale; surface the last known
-            # position via dedicated keys instead (same display row).
+        if self._attr_latitude is None and display_data:
+            # Live coordinates are withheld (stale, or a display row without
+            # usable accuracy -- both blank _attr_latitude, not just stale);
+            # surface the last known position via dedicated recorder-only keys
+            # instead (same display row). These feed the restore/history/snapshot
+            # readers, which fall back to them when the plain latitude/longitude
+            # keys are absent (stripped above).
             last_lat = display_data.get("latitude")
             last_lon = display_data.get("longitude")
             if last_lat is not None:

--- a/custom_components/googlefindmy/device_tracker.py
+++ b/custom_components/googlefindmy/device_tracker.py
@@ -73,6 +73,13 @@ from .ha_typing import RestoreEntity, TrackerEntity, callback
 
 _LOGGER = logging.getLogger(__name__)
 
+# Sentinel distinguishing "caller passed no row" (fall back to the live
+# current-or-cache lookup) from "caller explicitly passed a row" (which may
+# legitimately be None -> no data). Without this, an explicit None argument
+# would silently fall back to the internal lookup and reintroduce a second
+# source of truth for the published age/status (Codex #202).
+_ROW_UNSET: Any = object()
+
 # Read-only mirror of coordinator state; no I/O performed per-entity.
 PARALLEL_UPDATES = 0
 
@@ -1071,9 +1078,37 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
         except (TypeError, ValueError):
             return DEFAULT_STALE_THRESHOLD
 
-    def _get_location_age(self) -> float | None:
-        """Return the age of the location data in seconds, or None if unknown."""
-        data = self._current_row() or self._last_good_accuracy_data
+    def _select_display_row(self) -> dict[str, Any] | None:
+        """Return the single row whose data is actually published.
+
+        This is the one source of truth for every published value (coordinates,
+        name, age, status, extra attributes): the current row if it carries a
+        usable accuracy, otherwise the last accuracy-bearing fix. A fresh update
+        can arrive with valid lat/lon yet no accuracy; publishing coordinates
+        from the cached fix while deriving age/status/attributes from the
+        accuracy-less current row would show cached coordinates with fresh
+        metadata (Codex #202). Binding every consumer to this row keeps the
+        published snapshot internally consistent.
+        """
+        current = self._current_row()
+        if current and current.get("accuracy") is not None:
+            return current
+        return self._last_good_accuracy_data
+
+    def _get_location_age(self, row: Any = _ROW_UNSET) -> float | None:
+        """Return the age of the location data in seconds, or None if unknown.
+
+        With no argument the age reflects the live current-or-cache lookup (used
+        by the liveness gate). When an explicit ``row`` is passed it is used
+        verbatim, so callers can tie the published age to the same row that
+        produced the coordinates (``_ROW_UNSET`` distinguishes "omitted" from an
+        explicit ``None``).
+        """
+        data = (
+            (self._current_row() or self._last_good_accuracy_data)
+            if row is _ROW_UNSET
+            else row
+        )
         if not data:
             return None
         last_seen = data.get("last_seen")
@@ -1093,9 +1128,13 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
         threshold = self._get_stale_threshold()
         return age > threshold
 
-    def _get_location_status(self) -> str:
-        """Return the location status string based on data age."""
-        age = self._get_location_age()
+    def _get_location_status(self, row: Any = _ROW_UNSET) -> str:
+        """Return the location status string based on data age.
+
+        Accepts an explicit ``row`` so the published status describes the age of
+        the same row that produced the coordinates (Codex #202).
+        """
+        age = self._get_location_age(row)
         if age is None:
             return "unknown"
         threshold = self._get_stale_threshold()
@@ -1127,6 +1166,14 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
         """
         stale = self._is_location_stale()
 
+        # Single source of truth for every published value below (coordinates,
+        # name, age, status, extra attributes). Binding them all to this one
+        # row prevents publishing cached coordinates with fresh metadata from an
+        # accuracy-less current row (Codex #202). The liveness gate above stays
+        # separate on purpose: a live device sending accuracy-less rows must
+        # keep showing its last good position instead of flapping to "unknown".
+        display_data = self._select_display_row()
+
         # --- latitude / longitude / location_accuracy ---
         if stale:
             self._attr_latitude = None
@@ -1134,25 +1181,19 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
             self._attr_location_accuracy = 0.0
             self._attr_location_name = None
         else:
-            # Prefer the current row, but only if it carries a usable accuracy.
-            # A fresh update can arrive with valid lat/lon yet no accuracy; in
-            # that case fall back to the last fix that DID carry accuracy so an
-            # accuracy-less update does not blank out otherwise-valid
-            # coordinates (spurious "unknown"). The write path keeps
-            # ``_last_good_accuracy_data`` restricted to accuracy-bearing fixes.
-            data = self._current_row()
-            if not data or data.get("accuracy") is None:
-                data = self._last_good_accuracy_data
-            if not data or data.get("accuracy") is None:
-                # Accuracy must be present for a valid GPS fix; without it
-                # HA's zone engine raises TypeError on comparison.
+            # ``display_data`` already prefers the current row and only falls
+            # back to the cached accuracy-bearing fix when the current row lacks
+            # a usable accuracy. A row without accuracy cannot be published:
+            # HA's zone engine raises TypeError on comparison, so blank the
+            # coordinates in that case.
+            if not display_data or display_data.get("accuracy") is None:
                 self._attr_latitude = None
                 self._attr_longitude = None
                 self._attr_location_accuracy = 0.0
             else:
-                self._attr_latitude = data.get("latitude")
-                self._attr_longitude = data.get("longitude")
-                acc = data.get("accuracy")
+                self._attr_latitude = display_data.get("latitude")
+                self._attr_longitude = display_data.get("longitude")
+                acc = display_data.get("accuracy")
                 try:
                     self._attr_location_accuracy = (
                         float(acc) if acc is not None else 0.0
@@ -1160,14 +1201,13 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
                 except (TypeError, ValueError):
                     self._attr_location_accuracy = 0.0
 
-            # --- location_name ---
-            name_data = self._current_row()
-            if not name_data:
+            # --- location_name (same display row as the coordinates) ---
+            if not display_data:
                 self._attr_location_name = None
             else:
-                lat = name_data.get("latitude")
-                lon = name_data.get("longitude")
-                sem = name_data.get("semantic_name")
+                lat = display_data.get("latitude")
+                lon = display_data.get("longitude")
+                sem = display_data.get("semantic_name")
                 if isinstance(lat, (int, float)) and isinstance(lon, (int, float)):
                     # Coordinates present -> let HA zone engine decide.
                     self._attr_location_name = None
@@ -1179,13 +1219,20 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
                 else:
                     self._attr_location_name = sem
 
-        # --- extra_state_attributes ---
-        row = self._current_row()
-        attributes: dict[str, Any] = _as_ha_attributes(row) or {}
+        # --- extra_state_attributes (bound to the SAME display row) ---
+        # Deriving from display_data keeps the attribute set from exposing a
+        # position that differs from the published coordinates (Codex #202).
+        attributes: dict[str, Any] = _as_ha_attributes(display_data) or {}
+        if self._attr_latitude is None:
+            # Coordinates were withheld (stale, or a display row without
+            # accuracy). Strip the positional keys so the attributes never
+            # resurrect coordinates the tracker is deliberately not publishing.
+            for _pos_key in ("latitude", "longitude", "accuracy_m", "altitude_m"):
+                attributes.pop(_pos_key, None)
 
         attributes["google_device_id"] = self.device_id
 
-        location_age = self._get_location_age()
+        location_age = self._get_location_age(display_data)
         # Use the _opt() helper so options-first lookups stay consistent with
         # the rest of the integration and mypy --strict no longer flags the
         # config_entry attribute access (Any | None has no attribute options).
@@ -1204,17 +1251,17 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
         # When show_location_age is False the attribute is omitted entirely.
         # Absolute timestamps remain available via the "last_seen" attribute
         # and the sensor.*_last_seen entity.
-        attributes["location_status"] = self._get_location_status()
+        attributes["location_status"] = self._get_location_status(display_data)
 
-        if stale:
-            stale_data = self._current_row() or self._last_good_accuracy_data
-            if stale_data:
-                last_lat = stale_data.get("latitude")
-                last_lon = stale_data.get("longitude")
-                if last_lat is not None:
-                    attributes["last_latitude"] = last_lat
-                if last_lon is not None:
-                    attributes["last_longitude"] = last_lon
+        if stale and display_data:
+            # Main coordinates are withheld while stale; surface the last known
+            # position via dedicated keys instead (same display row).
+            last_lat = display_data.get("latitude")
+            last_lon = display_data.get("longitude")
+            if last_lat is not None:
+                attributes["last_latitude"] = last_lat
+            if last_lon is not None:
+                attributes["last_longitude"] = last_lon
 
         self._attr_extra_state_attributes = attributes
 
@@ -1313,9 +1360,13 @@ class GoogleFindMyLastLocationTracker(GoogleFindMyDeviceTracker):
         """Never stale - always show last known location."""
         return False
 
-    def _get_location_status(self) -> str:
-        """Return location status - always shows 'last_known' when data is aged."""
-        age = self._get_location_age()
+    def _get_location_status(self, row: Any = _ROW_UNSET) -> str:
+        """Return location status - always shows 'last_known' when data is aged.
+
+        Mirrors the parent's ``row`` parameter so the published status describes
+        the same row that produced the coordinates (Codex #202).
+        """
+        age = self._get_location_age(row)
         if age is None:
             return "unknown"
         threshold = self._get_stale_threshold()

--- a/custom_components/googlefindmy/device_tracker.py
+++ b/custom_components/googlefindmy/device_tracker.py
@@ -1134,7 +1134,15 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
             self._attr_location_accuracy = 0.0
             self._attr_location_name = None
         else:
-            data = self._current_row() or self._last_good_accuracy_data
+            # Prefer the current row, but only if it carries a usable accuracy.
+            # A fresh update can arrive with valid lat/lon yet no accuracy; in
+            # that case fall back to the last fix that DID carry accuracy so an
+            # accuracy-less update does not blank out otherwise-valid
+            # coordinates (spurious "unknown"). The write path keeps
+            # ``_last_good_accuracy_data`` restricted to accuracy-bearing fixes.
+            data = self._current_row()
+            if not data or data.get("accuracy") is None:
+                data = self._last_good_accuracy_data
             if not data or data.get("accuracy") is None:
                 # Accuracy must be present for a valid GPS fix; without it
                 # HA's zone engine raises TypeError on comparison.
@@ -1237,11 +1245,19 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
 
         lat = device_data.get("latitude")
         lon = device_data.get("longitude")
+        acc = device_data.get("accuracy")
 
-        if lat is not None and lon is not None:
+        if lat is not None and lon is not None and acc is not None:
+            # Only cache fixes that actually carry accuracy; the read-path
+            # fallback in _sync_location_attrs relies on this cache holding a
+            # usable fix (its name is _last_good_ACCURACY_data). Overwriting it
+            # with an accuracy-less fix would poison the fallback and could
+            # blank valid coordinates on a later accuracy-less update.
             self._last_good_accuracy_data = device_data.copy()
         elif self._last_good_accuracy_data is None:
-            # Preserve semantic-only updates when no prior location is available.
+            # Bootstrap only: preserve the first update (semantic-only or
+            # accuracy-less) when nothing better has been seen yet, so the
+            # entity still has *something* to report.
             self._last_good_accuracy_data = device_data.copy()
 
         self._sync_location_attrs()

--- a/custom_components/googlefindmy/map_view.py
+++ b/custom_components/googlefindmy/map_view.py
@@ -172,6 +172,30 @@ def _fallback_recorded_accuracy_pair(
     return raw, (bool(flag) if flag is not None else None)
 
 
+_PARSE_LAST_SEEN_TIMESTAMP: Any = None
+
+
+def _resolve_parse_last_seen_timestamp() -> Any:
+    """Import the canonical last_seen timestamp parser lazily.
+
+    ``parse_last_seen_timestamp`` is the single source of truth for turning a
+    recorded ``last_seen``/``last_seen_utc`` attribute (numeric epoch or ISO 8601
+    string) back into epoch seconds. Resolving it here (re-exported on
+    ``.coordinator``, exactly like ``_resolve_safe_accuracy``) keeps the map
+    history timestamps in lockstep with the device_tracker restore path instead
+    of re-deriving the parsing in the view. The stub coordinator module exposes
+    it as a direct attribute (see the test loader), mirroring ``safe_accuracy``,
+    so no in-view fallback copy is needed.
+    """
+
+    global _PARSE_LAST_SEEN_TIMESTAMP
+    if _PARSE_LAST_SEEN_TIMESTAMP is None:
+        from .coordinator import parse_last_seen_timestamp as _parse
+
+        _PARSE_LAST_SEEN_TIMESTAMP = _parse
+    return _PARSE_LAST_SEEN_TIMESTAMP
+
+
 # ------------------------------- HTML Helpers -------------------------------
 
 
@@ -388,6 +412,7 @@ class GoogleFindMyMapView(HomeAssistantView):
         safe_accuracy = _resolve_safe_accuracy()
         is_valid_accuracy = _resolve_is_valid_accuracy()
         recorded_accuracy_pair = _resolve_recorded_accuracy_pair()
+        parse_last_seen_timestamp = _resolve_parse_last_seen_timestamp()
         if entity_id:
             try:
                 from homeassistant.components.recorder import get_instance
@@ -408,8 +433,22 @@ class GoogleFindMyMapView(HomeAssistantView):
                 if entity_id in history:
                     for state in history[entity_id]:
                         try:
-                            lat = float(state.attributes.get("latitude"))
-                            lon = float(state.attributes.get("longitude"))
+                            # Stale/blank recorded states withhold the plain
+                            # latitude/longitude keys; the last known fix lives in
+                            # the recorder-only last_latitude/last_longitude keys.
+                            # Fall back to those so the history still plots the
+                            # point (a TypeError from a fully missing pair is
+                            # caught below and skips the sample).
+                            lat = float(
+                                state.attributes.get(
+                                    "latitude", state.attributes.get("last_latitude")
+                                )
+                            )
+                            lon = float(
+                                state.attributes.get(
+                                    "longitude", state.attributes.get("last_longitude")
+                                )
+                            )
                             # Read the accuracy value AND its estimated-provenance
                             # flag from the same authoritative source. ``accuracy_m``
                             # is the stable producer attribute; it survives Home
@@ -441,20 +480,26 @@ class GoogleFindMyMapView(HomeAssistantView):
                             if accuracy_filter > 0 and acc > accuracy_filter:
                                 continue
 
-                            # Determine timestamp (prefer last_seen attribute if available for precision)
+                            # Determine timestamp (prefer the recorded report
+                            # time over the recorder write time for precision).
+                            # Parse ``last_seen`` first, then ``last_seen_utc`` as
+                            # the same fallback, through the canonical parser --
+                            # mirroring the device_tracker restore path, which
+                            # accepts recorder-only rows carrying only
+                            # ``last_seen_utc``. Without the second key those
+                            # restored/legacy rows would plot at ``last_updated``
+                            # (the recorder write/restart time), making a stale
+                            # fix appear fresh and sort/dedupe incorrectly.
                             ts = state.last_updated.timestamp()
-                            raw_last_seen = state.attributes.get("last_seen")
-                            if raw_last_seen is not None:
-                                try:
-                                    ts = float(raw_last_seen)
-                                except (ValueError, TypeError):
-                                    if isinstance(raw_last_seen, str):
-                                        try:
-                                            ts = datetime.fromisoformat(
-                                                raw_last_seen.replace("Z", "+00:00")
-                                            ).timestamp()
-                                        except ValueError:
-                                            pass
+                            parsed_ts = parse_last_seen_timestamp(
+                                state.attributes.get("last_seen")
+                            )
+                            if parsed_ts is None:
+                                parsed_ts = parse_last_seen_timestamp(
+                                    state.attributes.get("last_seen_utc")
+                                )
+                            if parsed_ts is not None:
+                                ts = parsed_ts
 
                             if ts in seen_timestamps:
                                 continue

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import asyncio
 import importlib
 import logging
+import time
 from collections.abc import Callable, Coroutine
 from types import SimpleNamespace
 from typing import Any
@@ -14,7 +15,11 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from custom_components.googlefindmy.const import DOMAIN, TRACKER_SUBENTRY_KEY
+from custom_components.googlefindmy.const import (
+    DEFAULT_STALE_THRESHOLD,
+    DOMAIN,
+    TRACKER_SUBENTRY_KEY,
+)
 from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
 from custom_components.googlefindmy.coordinator import registry as coordinator_registry
 from tests.helpers.config_entries_stub import make_config_entry
@@ -810,3 +815,120 @@ async def test_restore_marks_estimated_for_flagless_invalid_accuracy(
 
     assert coordinator.primed["data"]["accuracy"] == 200.0
     assert coordinator.primed["data"]["accuracy_estimated"] is True
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for the stale-threshold retune (spurious "unknown" flapping)
+# and the latent accuracy-less-fallback bug B1 (PR #201 follow-up audit).
+#
+# Root cause: a stationary device at home (dozing smartphone, or a tag scanned
+# only by the household's own dozing phones) reports via FMDN roughly every
+# ~30 min. The previous 1800 s default sat exactly on that cadence, so any
+# delayed report tipped an otherwise-present device into "stale" and blanked
+# its coordinates. B1 is the sibling defect: a fresh row with valid lat/lon but
+# no accuracy was blanked instead of falling back to the last accuracy-bearing
+# fix, and the "last good accuracy" cache was overwritten by accuracy-less
+# rows.
+# ---------------------------------------------------------------------------
+
+
+def _make_stale_probe_tracker(coordinator: _ShowAgeCoordinatorStub) -> Any:
+    """Build a tracker with the REAL stale methods (no overrides), so the
+    default threshold actually governs the stale decision."""
+
+    device_tracker = importlib.import_module(
+        "custom_components.googlefindmy.device_tracker"
+    )
+    entity = device_tracker.GoogleFindMyDeviceTracker(
+        coordinator,
+        {"id": "show-age-device", "name": "Tracker"},
+        subentry_key=TRACKER_SUBENTRY_KEY,
+        subentry_identifier=TRACKER_SUBENTRY_KEY,
+    )
+    entity.hass = SimpleNamespace()
+    return entity
+
+
+def test_home_cadence_report_not_stale_under_default_threshold() -> None:
+    """A ~35 min old fix (typical home reporting cadence) must NOT be stale
+    under the retuned default. Under the previous 1800 s default the very same
+    age would have flipped to "stale" and blanked the coordinates."""
+
+    coordinator = _ShowAgeCoordinatorStub(options={}, age_seconds=None)
+    entity = _make_stale_probe_tracker(coordinator)
+    # 2100 s = 35 min: above the old 1800 s default, below the new 3900 s one.
+    entity._get_location_age = lambda: 2100.0  # type: ignore[method-assign]
+
+    assert entity._get_stale_threshold() == DEFAULT_STALE_THRESHOLD
+    assert DEFAULT_STALE_THRESHOLD > 1800, "default must be retuned above 1800 s"
+    assert entity._is_location_stale() is False, (
+        "a 35 min old home report must not be treated as stale"
+    )
+
+
+def test_accuracy_less_fresh_row_falls_back_to_cached_fix() -> None:
+    """B1 read path: a fresh row with valid lat/lon but no accuracy must fall
+    back to the last accuracy-bearing fix instead of blanking coordinates."""
+
+    coordinator = _ShowAgeCoordinatorStub(options={}, age_seconds=100.0)
+    # Fresh current row: valid coordinates, but the accuracy key is absent.
+    coordinator._row = {
+        "id": "show-age-device",
+        "device_id": "show-age-device",
+        "name": "Tracker",
+        "latitude": 11.0,
+        "longitude": 21.0,
+        "last_seen": time.time(),
+    }
+    entity = _make_show_age_tracker(coordinator, age_seconds=100.0)
+    # Prime the cache with a good, accuracy-bearing fix.
+    entity._last_good_accuracy_data = {
+        "latitude": 10.0,
+        "longitude": 20.0,
+        "accuracy": 5,
+        "last_seen": time.time() - 100,
+    }
+
+    entity._sync_location_attrs()
+
+    # Coordinates come from the cached accuracy-bearing fix, not nulled.
+    assert entity._attr_latitude == 10.0
+    assert entity._attr_longitude == 20.0
+    assert entity._attr_location_accuracy == 5.0
+
+
+def test_accuracy_less_update_does_not_poison_accuracy_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """B1 write path: an accuracy-less update must NOT overwrite the cached
+    accuracy-bearing fix (the cache is _last_good_ACCURACY_data)."""
+
+    coordinator = _ShowAgeCoordinatorStub(options={}, age_seconds=100.0)
+    coordinator._row = {
+        "id": "show-age-device",
+        "device_id": "show-age-device",
+        "name": "Tracker",
+        "latitude": 11.0,
+        "longitude": 21.0,
+        "last_seen": time.time(),
+    }
+    entity = _make_show_age_tracker(coordinator, age_seconds=100.0)
+    good = {
+        "latitude": 10.0,
+        "longitude": 20.0,
+        "accuracy": 5,
+        "last_seen": time.time() - 100,
+    }
+    entity._last_good_accuracy_data = dict(good)
+    # Isolate the cache-update branch of _handle_coordinator_update.
+    monkeypatch.setattr(entity, "_sync_location_attrs", lambda: None)
+    monkeypatch.setattr(entity, "async_write_ha_state", lambda: None)
+    monkeypatch.setattr(
+        entity, "refresh_device_label_from_coordinator", lambda **kw: None
+    )
+
+    entity._handle_coordinator_update()
+
+    assert entity._last_good_accuracy_data == good, (
+        "an accuracy-less update must not poison the accuracy cache"
+    )

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -478,8 +478,8 @@ def _make_show_age_tracker(
     entity.hass = SimpleNamespace()
     # Bypass stale-detection and force a deterministic age value.
     entity._is_location_stale = lambda: False  # type: ignore[method-assign]
-    entity._get_location_age = lambda: age_seconds  # type: ignore[method-assign]
-    entity._get_location_status = lambda: "available"  # type: ignore[method-assign]
+    entity._get_location_age = lambda *a, **k: age_seconds  # type: ignore[method-assign]
+    entity._get_location_status = lambda *a, **k: "available"  # type: ignore[method-assign]
     return entity
 
 
@@ -857,7 +857,7 @@ def test_home_cadence_report_not_stale_under_default_threshold() -> None:
     coordinator = _ShowAgeCoordinatorStub(options={}, age_seconds=None)
     entity = _make_stale_probe_tracker(coordinator)
     # 2100 s = 35 min: above the old 1800 s default, below the new 3900 s one.
-    entity._get_location_age = lambda: 2100.0  # type: ignore[method-assign]
+    entity._get_location_age = lambda *a, **k: 2100.0  # type: ignore[method-assign]
 
     assert entity._get_stale_threshold() == DEFAULT_STALE_THRESHOLD
     assert DEFAULT_STALE_THRESHOLD > 1800, "default must be retuned above 1800 s"
@@ -932,3 +932,104 @@ def test_accuracy_less_update_does_not_poison_accuracy_cache(
     assert entity._last_good_accuracy_data == good, (
         "an accuracy-less update must not poison the accuracy cache"
     )
+
+
+def _make_plain_tracker(coordinator: _ShowAgeCoordinatorStub) -> Any:
+    """Build a tracker WITHOUT monkeypatching age/status/stale helpers.
+
+    Used to assert the real derivation ties every published value to the same
+    display row (Codex #202), which the show-age helper cannot verify because it
+    stubs those methods out.
+    """
+    device_tracker = importlib.import_module(
+        "custom_components.googlefindmy.device_tracker"
+    )
+    entity = device_tracker.GoogleFindMyDeviceTracker(
+        coordinator,
+        {"id": "show-age-device", "name": "Tracker"},
+        subentry_key=TRACKER_SUBENTRY_KEY,
+        subentry_identifier=TRACKER_SUBENTRY_KEY,
+    )
+    entity.hass = SimpleNamespace()
+    return entity
+
+
+def test_accuracy_less_row_ties_all_metadata_to_display_row() -> None:
+    """Codex #202: when coordinates fall back to the cached accuracy-bearing
+    fix, the age, status and extra attributes must describe that SAME cached
+    row, never the accuracy-less current row. Otherwise a moving device is shown
+    at cached coordinates with a fresh age and attributes exposing a different
+    lat/lon than the tracker properties."""
+
+    coordinator = _ShowAgeCoordinatorStub(options={}, age_seconds=None)
+    # Fresh current row: NEW lat/lon and a brand-new last_seen, but no accuracy.
+    coordinator._row = {
+        "id": "show-age-device",
+        "device_id": "show-age-device",
+        "name": "Tracker",
+        "latitude": 11.0,
+        "longitude": 21.0,
+        "last_seen": time.time(),
+    }
+    entity = _make_plain_tracker(coordinator)
+    # Cache: the last accuracy-bearing fix, ~2000 s old, at DIFFERENT
+    # coordinates. 2000 s sits in the "aging" band (> half the 3900 s default,
+    # below the full threshold) so its status differs from the fresh current
+    # row's "current" -- this makes the test sharp against age/status still
+    # being read from the current row.
+    entity._last_good_accuracy_data = {
+        "latitude": 10.0,
+        "longitude": 20.0,
+        "accuracy": 5,
+        "last_seen": time.time() - 2000,
+    }
+
+    entity._sync_location_attrs()
+    attrs = entity._attr_extra_state_attributes
+
+    # The liveness gate stays non-stale (current row is fresh), so coordinates
+    # are still published -- from the cached accuracy-bearing fix.
+    assert entity._attr_latitude == 10.0
+    assert entity._attr_longitude == 20.0
+    # Extra attributes must expose the SAME cached position, not the current
+    # row's 11.0/21.0 (this is the divergence Codex flagged).
+    assert attrs.get("latitude") == 10.0
+    assert attrs.get("longitude") == 20.0
+    # Age/status describe the cached row (~2000 s -> "aging"), NOT the fresh
+    # current row (which would read "current"/age 0).
+    assert attrs["location_status"] == "aging"
+    assert attrs["location_age"] == 1980  # round(2000/60)*60
+
+
+def test_stale_branch_strips_positional_attributes() -> None:
+    """Codex #202 sibling: when stale blanks the tracker coordinates, the extra
+    attributes must not resurrect latitude/longitude; the last known position
+    belongs in the dedicated last_latitude/last_longitude keys."""
+
+    coordinator = _ShowAgeCoordinatorStub(options={}, age_seconds=None)
+    coordinator._row = {
+        "id": "show-age-device",
+        "device_id": "show-age-device",
+        "name": "Tracker",
+        "latitude": 12.0,
+        "longitude": 22.0,
+        "accuracy": 8,
+        "last_seen": time.time() - 10000,
+    }
+    entity = _make_plain_tracker(coordinator)
+    entity._is_location_stale = lambda: True  # type: ignore[method-assign]
+
+    entity._sync_location_attrs()
+    attrs = entity._attr_extra_state_attributes
+
+    # Tracker coordinates are withheld while stale.
+    assert entity._attr_latitude is None
+    assert entity._attr_longitude is None
+    # The attribute set must NOT expose latitude/longitude (would contradict the
+    # blanked tracker properties).
+    assert "latitude" not in attrs
+    assert "longitude" not in attrs
+    assert "accuracy_m" not in attrs
+    # The last known position is surfaced via the dedicated keys instead.
+    assert attrs["last_latitude"] == 12.0
+    assert attrs["last_longitude"] == 22.0

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -9,6 +9,7 @@ import importlib
 import logging
 import time
 from collections.abc import Callable, Coroutine
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock
@@ -817,6 +818,154 @@ async def test_restore_marks_estimated_for_flagless_invalid_accuracy(
     assert coordinator.primed["data"]["accuracy_estimated"] is True
 
 
+@pytest.mark.asyncio
+async def test_restore_recovers_last_seen_age(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Restore must recover last_seen so staleness survives a restart.
+
+    Without last_seen the restored row has no age: _get_location_age() returns
+    None and _is_location_stale() assumes "not stale", so a fix that predates
+    the restart looks fresh until the next poll. The restore path parses the
+    recorded ISO last_seen back to epoch seconds and seeds it into the cache
+    row, so the recovered position is correctly aged and flagged stale.
+    """
+
+    coordinator = _RestoreCoordinatorStub()
+    old_epoch = time.time() - (DEFAULT_STALE_THRESHOLD + 5000)
+    old_iso = (
+        datetime.fromtimestamp(old_epoch, tz=UTC).isoformat().replace("+00:00", "Z")
+    )
+    entity = _build_restore_entity(
+        coordinator,
+        monkeypatch,
+        {
+            "latitude": 10.0,
+            "longitude": 20.0,
+            "gps_accuracy": 50,
+            "last_seen": old_iso,
+        },
+    )
+
+    await entity.async_added_to_hass()
+
+    seeded = coordinator.primed["data"]
+    # last_seen is recovered as an epoch float within a second of the source.
+    assert seeded["last_seen"] == pytest.approx(old_epoch, abs=1.0)
+    assert entity._last_good_accuracy_data["last_seen"] == pytest.approx(
+        old_epoch, abs=1.0
+    )
+    # Behavioural consequence: the restored row carries its true age and the
+    # status derived from it is "stale" (not the age-less "unknown").
+    age = entity._get_location_age(seeded)
+    assert age is not None and age > DEFAULT_STALE_THRESHOLD
+    assert entity._get_location_status(seeded) == "stale"
+
+
+@pytest.mark.asyncio
+async def test_restore_recovers_last_seen_from_utc_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``last_seen`` is absent, the restore falls back to ``last_seen_utc``.
+
+    Both keys carry the same ISO timestamp; only one may be present in a given
+    recorded state. The fallback keeps the recovered age correct in either case.
+    """
+
+    coordinator = _RestoreCoordinatorStub()
+    old_epoch = time.time() - (DEFAULT_STALE_THRESHOLD + 5000)
+    old_iso = (
+        datetime.fromtimestamp(old_epoch, tz=UTC).isoformat().replace("+00:00", "Z")
+    )
+    entity = _build_restore_entity(
+        coordinator,
+        monkeypatch,
+        {
+            "latitude": 10.0,
+            "longitude": 20.0,
+            "gps_accuracy": 50,
+            # No "last_seen"; only the UTC mirror is recorded.
+            "last_seen_utc": old_iso,
+        },
+    )
+
+    await entity.async_added_to_hass()
+
+    seeded = coordinator.primed["data"]
+    assert seeded["last_seen"] == pytest.approx(old_epoch, abs=1.0)
+    assert entity._get_location_status(seeded) == "stale"
+
+
+@pytest.mark.asyncio
+async def test_restore_without_timestamp_leaves_last_seen_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A recorded state without any timestamp seeds no last_seen (old behavior).
+
+    With neither ``last_seen`` nor ``last_seen_utc`` present, the restore must
+    not fabricate an age: the key stays absent and the age remains unknown.
+    """
+
+    coordinator = _RestoreCoordinatorStub()
+    entity = _build_restore_entity(
+        coordinator,
+        monkeypatch,
+        {
+            "latitude": 10.0,
+            "longitude": 20.0,
+            "gps_accuracy": 50,
+            # No last_seen / last_seen_utc at all.
+        },
+    )
+
+    await entity.async_added_to_hass()
+
+    seeded = coordinator.primed["data"]
+    assert "last_seen" not in seeded
+    assert entity._get_location_age(seeded) is None
+
+
+@pytest.mark.asyncio
+async def test_restore_falls_back_to_recorder_only_coordinates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A state recorded while stale withholds the plain latitude/longitude keys.
+
+    The producer strips them so HA does not republish a withheld position as the
+    live GPS attribute (Codex #1177) and keeps the last known fix in the
+    recorder-only last_latitude/last_longitude keys. Restore must fall back to
+    those so a restart still recovers the position instead of coming up empty.
+    """
+
+    coordinator = _RestoreCoordinatorStub()
+    old_epoch = time.time() - (DEFAULT_STALE_THRESHOLD + 5000)
+    old_iso = (
+        datetime.fromtimestamp(old_epoch, tz=UTC).isoformat().replace("+00:00", "Z")
+    )
+    entity = _build_restore_entity(
+        coordinator,
+        monkeypatch,
+        {
+            # No plain latitude/longitude: this state was stale at record time,
+            # so the producer stripped them. Only the recorder-only keys carry
+            # the last known fix.
+            "last_latitude": 10.0,
+            "last_longitude": 20.0,
+            "accuracy_m": 50,
+            "last_seen": old_iso,
+        },
+    )
+
+    await entity.async_added_to_hass()
+
+    seeded = coordinator.primed["data"]
+    # Position recovered via the recorder-only fallback keys.
+    assert seeded["latitude"] == 10.0
+    assert seeded["longitude"] == 20.0
+    # And the recovered fix still carries its true (stale) age.
+    assert seeded["last_seen"] == pytest.approx(old_epoch, abs=1.0)
+
+
 # ---------------------------------------------------------------------------
 # Regression tests for the stale-threshold retune (spurious "unknown" flapping)
 # and the latent accuracy-less-fallback bug B1 (PR #201 follow-up audit).
@@ -1001,10 +1150,14 @@ def test_accuracy_less_row_ties_all_metadata_to_display_row() -> None:
     assert attrs["location_age"] == 1980  # round(2000/60)*60
 
 
-def test_stale_branch_strips_positional_attributes() -> None:
-    """Codex #202 sibling: when stale blanks the tracker coordinates, the extra
-    attributes must not resurrect latitude/longitude; the last known position
-    belongs in the dedicated last_latitude/last_longitude keys."""
+def test_stale_branch_strips_live_coordinate_keys() -> None:
+    """Codex #1177: a stale state must NOT leave the plain latitude/longitude keys
+    in extra_state_attributes. HA merges extra_state_attributes last and exposes
+    those keys as the device_tracker GPS attributes, so keeping them would
+    republish the withheld (stale) position as the live location for
+    closest()/proximity/the built-in map. The last known fix is exposed via the
+    recorder-only last_latitude/last_longitude keys instead; accuracy_m is not an
+    HA GPS attribute and stays for restore/history/snapshot."""
 
     coordinator = _ShowAgeCoordinatorStub(options={}, age_seconds=None)
     coordinator._row = {
@@ -1022,14 +1175,15 @@ def test_stale_branch_strips_positional_attributes() -> None:
     entity._sync_location_attrs()
     attrs = entity._attr_extra_state_attributes
 
-    # Tracker coordinates are withheld while stale.
+    # Live tracker coordinates are withheld while stale.
     assert entity._attr_latitude is None
     assert entity._attr_longitude is None
-    # The attribute set must NOT expose latitude/longitude (would contradict the
-    # blanked tracker properties).
+    # The plain GPS keys must be stripped so HA does not republish the stale
+    # position as the live location (the #1177 leak).
     assert "latitude" not in attrs
     assert "longitude" not in attrs
-    assert "accuracy_m" not in attrs
-    # The last known position is surfaced via the dedicated keys instead.
+    # accuracy_m is not an HA GPS attribute; it stays for restore/history.
+    assert attrs["accuracy_m"] == 8.0
+    # The last known position is exposed via the recorder-only keys instead.
     assert attrs["last_latitude"] == 12.0
     assert attrs["last_longitude"] == 22.0

--- a/tests/test_map_view_accuracy_estimated.py
+++ b/tests/test_map_view_accuracy_estimated.py
@@ -572,3 +572,54 @@ async def test_map_view_legacy_row_without_flag_prefers_accuracy_m(
     assert len(captured) == 1
     assert captured[0]["accuracy"] == 18.0
     assert captured[0]["accuracy_estimated"] is False
+
+
+@pytest.mark.asyncio
+async def test_map_view_history_uses_last_seen_utc_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A row carrying only ``last_seen_utc`` plots at its report time.
+
+    Codex #1177: once the history fallback accepts recorder-only rows, the
+    timestamp logic must parse ``last_seen_utc`` as the same fallback as the
+    device_tracker restore path. Without it a restored/legacy row lacking the
+    plain ``last_seen`` attribute would fall back to ``state.last_updated`` (the
+    recorder write/restart time), making a stale fix appear fresh and
+    sort/dedupe incorrectly. The report time (2024-01-01) and the write time
+    (2024-08-01) are deliberately far apart so the assertion discriminates the
+    fallback from the write-time default.
+    """
+
+    map_view = _load_map_view_module(monkeypatch)
+
+    device_id = "dev-lsu"
+    coordinator = _StubCoordinator(devices=[{"id": device_id, "name": "Device"}])
+    registry = _registry_for("entry-acc", device_id, coordinator)
+    entry, captured = _wire_view(
+        monkeypatch, map_view, device_id=device_id, registry=registry
+    )
+
+    report_time = datetime(2024, 1, 1, tzinfo=UTC)
+    write_time = datetime(2024, 8, 1, tzinfo=UTC)
+    states = [
+        SimpleNamespace(
+            attributes={
+                "latitude": "10.0",
+                "longitude": "20.0",
+                # Only the UTC mirror is present, no plain ``last_seen``.
+                "last_seen_utc": "2024-01-01T00:00:00Z",
+                "accuracy_m": 15.0,
+            },
+            last_updated=write_time,
+            state="legacy-lsu",
+        ),
+    ]
+    _install_history(monkeypatch, states)
+
+    response = await _run_get(map_view, entry, device_id)
+
+    assert response.status == 200
+    assert len(captured) == 1
+    # The point carries the recorded report time, not the recorder write time.
+    assert captured[0]["last_seen"] == pytest.approx(report_time.timestamp())
+    assert captured[0]["last_seen"] != pytest.approx(write_time.timestamp())

--- a/tests/test_map_view_unique_id_resolution.py
+++ b/tests/test_map_view_unique_id_resolution.py
@@ -172,6 +172,34 @@ def _load_real_is_valid_accuracy() -> Any:
     return geo.is_valid_accuracy
 
 
+def _load_real_parse_last_seen_timestamp() -> Any:
+    """Load the canonical ``parse_last_seen_timestamp`` from subentry.py by path.
+
+    Mirrors ``_load_real_safe_accuracy`` so the stub exposes the same timestamp
+    parser that production re-exports on ``coordinator.parse_last_seen_timestamp``.
+    subentry.py imports only ``math``/``datetime``/``typing`` (and defines its own
+    ``normalize_epoch_seconds`` helper), so it loads in isolation without dragging
+    in the heavy integration import chain.
+    """
+
+    subentry_path = (
+        Path(__file__).resolve().parents[1]
+        / "custom_components"
+        / "googlefindmy"
+        / "coordinator"
+        / "helpers"
+        / "subentry.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "googlefindmy_test_subentry", subentry_path
+    )
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError("Failed to load subentry module for testing")
+    subentry = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(subentry)
+    return subentry.parse_last_seen_timestamp
+
+
 def _load_map_view_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
     """Load the map_view module with stubbed Home Assistant dependencies."""
 
@@ -269,6 +297,13 @@ def _load_map_view_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
     # coordinator/__init__.py) so the map can flag estimated points without the
     # plain ModuleType stub (no __path__) breaking the lazy import.
     coordinator_module.is_valid_accuracy = _load_real_is_valid_accuracy()
+    # Mirror the production re-export of ``parse_last_seen_timestamp`` (see
+    # coordinator/__init__.py) so the map history can normalize recorded
+    # last_seen/last_seen_utc attributes without the plain ModuleType stub (no
+    # __path__) breaking the lazy import.
+    coordinator_module.parse_last_seen_timestamp = (
+        _load_real_parse_last_seen_timestamp()
+    )
     monkeypatch.setitem(
         sys.modules, "custom_components.googlefindmy.coordinator", coordinator_module
     )
@@ -622,3 +657,33 @@ def test_resolve_is_valid_accuracy_falls_back_when_symbol_missing(
 
     # Second call must hit the cache instead of re-resolving (same object).
     assert map_view._resolve_is_valid_accuracy() is is_valid_accuracy
+
+
+def test_map_view_resolves_parse_last_seen_timestamp_under_stub(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The timestamp parser resolver must work under the coordinator stub.
+
+    The stub re-exports ``parse_last_seen_timestamp`` exactly like production
+    (coordinator/__init__.py), so ``_resolve_parse_last_seen_timestamp`` returns
+    the real parser. It normalizes numeric epochs and ISO 8601 strings (incl. the
+    ``last_seen_utc`` mirror) back to epoch seconds, and returns None for
+    unparseable input so the map history can fall through to ``last_updated``.
+    """
+
+    map_view = _load_map_view_module(monkeypatch)
+
+    parse_last_seen_timestamp = map_view._resolve_parse_last_seen_timestamp()
+
+    # ISO 8601 (the recorded last_seen/last_seen_utc shape) -> epoch seconds.
+    assert parse_last_seen_timestamp("2024-01-01T00:00:00Z") == pytest.approx(
+        datetime(2024, 1, 1, tzinfo=UTC).timestamp()
+    )
+    # Numeric epoch passes through as float.
+    assert parse_last_seen_timestamp(1704067200.0) == pytest.approx(1704067200.0)
+    # Unparseable input yields None (caller keeps the last_updated default).
+    assert parse_last_seen_timestamp("not-a-timestamp") is None
+    assert parse_last_seen_timestamp(None) is None
+
+    # Second call must hit the cache instead of re-importing (same object).
+    assert map_view._resolve_parse_last_seen_timestamp() is parse_last_seen_timestamp


### PR DESCRIPTION
## Contribution to BSkando/GoogleFindMy-HA `1.7`

This forwards the single upstream fix merged into `jleinenbach:1.7` as [jleinenbach#1175](https://github.com/jleinenbach/GoogleFindMy-HA/pull/1175) (merge commit `c1add39`). It lands after #201 and contains exactly that one commit: 3 files, +168/-16. No version bump (stays `1.7.11`).

---

## Summary

Fixes spurious `unknown` flapping of Google Find My device trackers **at home**. Devices that are demonstrably present (a smartphone on the desk, a tag in a drawer) repeatedly flip to `unknown` and back, sometimes within seconds, sometimes ~180 s apart. Root cause: the stale-threshold default was tuned for *active* tracker-scan cadence and sat directly on the natural *home* reporting cadence.

## Root cause (empirically grounded)

A stationary device at home reports through the FMDN network only about **every ~30 minutes**:
- a **smartphone** with a dark display reports its own position occasionally (Doze / battery saver), and
- a **Bluetooth tag** at home is seen only by the household's own (also dozing) phones, i.e. the very same ~30 min cadence — confirmed empirically from the logs, so this is **not** a smartphone-only effect.

The Home Assistant history showed **every** spurious `unknown` transition carrying `location_status=stale` with `last_seen` aged **1800-1835 s**, i.e. exactly the previous `DEFAULT_STALE_THRESHOLD = 1800`. The threshold sat on the reporting cadence, so any minor delay tipped an otherwise-present device into `stale`, which blanks the coordinates until the next report arrives (1-2 s if it lands immediately, otherwise up to ~180 s over the locate/token cooldown).

The earlier `1800 s` were calibrated to **active** FMDN tracker-scan statistics (median ~3.4 min, p95 ~8 min, p99 ~14 min), which hold when many foreign phones continuously scan a tracker — not for a device sitting at home. A shorter poll does not help: Google returns the last reported fix for a dozing device, so `last_seen` only advances when the device itself reports.

## Changes

**Fix 1 — retune `DEFAULT_STALE_THRESHOLD` 1800 -> 3900 s (65 min)** (`const.py`).
~2x the observed ~30 min home cadence plus margin for one missed report cycle. Removes the flapping for **both** smartphones and tags while still flagging a genuinely absent device within ~1 h. The threshold stays user-configurable (`min 300 s`, `max 86400 s`); only the default was mistuned. The code comment is rewritten to state the observed cadence and the decision rationale.

**Fix 2 — latent accuracy-less-fallback bug (same "spurious unknown" family)** (`device_tracker.py`).
- Read path (`_sync_location_attrs`): a fresh row with valid lat/lon but **no accuracy** was blanked to `unknown`. It now falls back to the last accuracy-bearing fix (`_last_good_accuracy_data`) instead of blanking otherwise-valid coordinates.
- Write path (`_handle_coordinator_update`): `_last_good_accuracy_data` is now overwritten **only** by fixes that actually carry accuracy (its name is `_last_good_ACCURACY_data`); an accuracy-less update no longer poisons the fallback cache. The bootstrap `elif ... is None` case is preserved so the entity always has something to report.

## Tests

Three new regression tests in `tests/test_device_tracker.py`, each proven sharp by a mutation gegenprobe (revert the fix -> its test goes red):
- `test_home_cadence_report_not_stale_under_default_threshold` — a 35 min old home report is not stale under 3900 s (was stale under 1800 s).
- `test_accuracy_less_fresh_row_falls_back_to_cached_fix` — B1 read path.
- `test_accuracy_less_update_does_not_poison_accuracy_cache` — B1 write path.

## Verification

- 2374 tests pass (device_tracker / sensor / coordinator / fcm / restore / stale sweep); 43 in the directly touched families.
- Changed-code coverage: all delta logic lines exercised.
- ruff 0.14.14 **and** 0.15.x (check + format) clean; mypy clean on source and tests; `asyncio.run` guard green.
- Independent read-only terminal-diff review: PASS.

## Risk

Low. A phone that goes offline **at home** (dead battery) now shows its last position as valid for up to ~65 min before turning `unknown`, instead of ~30 min. Leaving the house is unaffected: a moving phone emits fresh fixes. Users who prefer the old behavior can lower the `stale_threshold` option.
