### PR TITLE
Fix Play/Stop Sound: accept and forward the `cache` kwarg (TypeError on every press)

### DIFF
--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/PlaySound/start_sound_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/PlaySound/start_sound_request.py
@@ -50,6 +50,7 @@ async def async_submit_start_sound_request(
     gcm_registration_id: str,
     *,
     session: Optional[ClientSession] = None,
+    cache: Optional[any] = None,
 ) -> Optional[tuple[str, str]]:
     """Submit a 'Play Sound' action using the shared async Nova client.
 
@@ -70,7 +71,7 @@ async def async_submit_start_sound_request(
     hex_payload, request_uuid = start_sound_request(canonic_device_id, gcm_registration_id)
     try:
         # The async Nova client manages session reuse internally; do not pass session through.
-        response_hex = await async_nova_request(NOVA_ACTION_API_SCOPE, hex_payload)
+        response_hex = await async_nova_request(NOVA_ACTION_API_SCOPE, hex_payload, cache=cache)
         return (response_hex, request_uuid) if response_hex is not None else None
     except asyncio.CancelledError:
         raise

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/PlaySound/stop_sound_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/PlaySound/stop_sound_request.py
@@ -49,6 +49,7 @@ async def async_submit_stop_sound_request(
     *,
     request_uuid: Optional[str] = None,
     session: Optional[ClientSession] = None,
+    cache: Optional[any] = None,
 ) -> Optional[str]:
     """Submit a 'Stop Sound' action using the shared async Nova client.
 
@@ -71,7 +72,7 @@ async def async_submit_stop_sound_request(
     hex_payload = stop_sound_request(canonic_device_id, gcm_registration_id, request_uuid)
     try:
         # The async Nova client manages session reuse internally; do not pass session through.
-        return await async_nova_request(NOVA_ACTION_API_SCOPE, hex_payload)
+        return await async_nova_request(NOVA_ACTION_API_SCOPE, hex_payload, cache=cache)
     except asyncio.CancelledError:
         raise
     except NovaRateLimitError:


### PR DESCRIPTION
## Problem

Pressing any **Play Sound** (or **Stop Sound**) button does nothing. The log shows, on every press:

```
ERROR ... custom_components.googlefindmy.api: Failed to play sound (async) on <id>: async_submit_start_sound_request() got an unexpected keyword argument 'cache'
DEBUG ... custom_components.googlefindmy.coordinator: Entering push cooldown for 90s after transport failure
```

`GoogleFindMyAPI.async_play_sound` / `async_stop_sound` call the submitters with `cache=self._cache`:

- `async_submit_start_sound_request(device_id, token, session=self._session, cache=self._cache)`
- `async_submit_stop_sound_request(device_id, token, request_uuid=..., session=self._session, cache=self._cache)`

but `async_submit_start_sound_request` / `async_submit_stop_sound_request` do **not** accept a `cache` parameter → `TypeError` on every press. The resulting failure also enters a 90s push cooldown, which makes the buttons intermittently appear unavailable too.

## Fix

Add `cache: Optional[any] = None` to both submitters and forward it to `async_nova_request(...)`, which already accepts `cache`. This mirrors the existing device-list path (`async_request_device_list(..., cache=...)`).

Forwarding the entry-scoped cache also ensures the **correct account's tokens** are used in multi-account setups (reproduced with two Google accounts configured — without this, the sound action can resolve against the wrong cache).

## Testing

With two config entries (two Google accounts), Play Sound now reliably rings the target Android phone. Verified via the device's `Émettre un son` button entity and via dashboard `button.press` actions; the `unexpected keyword argument 'cache'` error and the spurious 90s push cooldown are both gone.

Affected version: 1.6.2.3.
