### PR TITLE
fix(ble_scanner): register FMDN callback as connectable=False so proxy-relayed advertisements aren't dropped

### DIFF
--- a/custom_components/googlefindmy/fmdn_finder/ble_scanner.py
+++ b/custom_components/googlefindmy/fmdn_finder/ble_scanner.py
@@ -151,13 +151,21 @@ async def async_setup_ble_scanner(hass: HomeAssistant) -> bool:
     # avoids requesting active scans (no extra power draw).
     #
     # Note: HA's async_register_callback does not support service_data UUID
-    # filtering natively, so we pass no matcher and filter ourselves.
-    # The overhead is minimal — the callback returns immediately for
-    # non-FMDN advertisements after a single dict lookup.
+    # filtering natively, so we filter ourselves inside the callback.
+    #
+    # A falsy matcher (e.g. None) is NOT "match everything" — HA's
+    # BluetoothManager treats it as {"connectable": True}
+    # (homeassistant/components/bluetooth/manager.py), which silently drops
+    # every advertisement relayed through a non-connectable source. ESPHome
+    # and Shelly Bluetooth proxies register as non-connectable, so this
+    # callback never fired for any proxy-heard tracker — only advertisements
+    # picked up by a connectable local adapter got through. Explicitly
+    # passing connectable=False disables that filter, so both local-radio
+    # and proxy-relayed advertisements reach us.
     unsub: CALLBACK_TYPE = async_register_callback(
         hass,
         _fmdn_advertisement_callback,
-        None,  # No matcher — we filter inside the callback
+        {"connectable": False},
         BluetoothScanningMode.PASSIVE,
     )
 


### PR DESCRIPTION
## Problem

The FMDN BLE listener (`fmdn_finder/ble_scanner.py`) registers its `async_register_callback` with `matcher=None`, intending "receive every advertisement." In current Home Assistant, a falsy matcher is not "match everything" — `BluetoothManager` treats it as `{"connectable": True}` (`homeassistant/components/bluetooth/manager.py`):

```python
if not matcher:
    callback_matcher[CONNECTABLE] = True
```

ESPHome and Shelly Bluetooth proxies register their scanners as **non-connectable**. So any advertisement relayed through a proxy is silently filtered out before this integration's callback ever runs — only advertisements picked up by a connectable local adapter got through. In practice this means `GoogleFindMyBLEBatterySensor` (and any other consumer of this listener) can never populate for a tracker that's only ever in range of a Bluetooth proxy, which is a very common home setup (proxy coverage instead of, or in addition to, the HA host's own onboard radio).

## Fix

Pass `{"connectable": False}` as the matcher instead of `None`. Per HA's matching logic in `match.py`:

```python
if matcher.get(CONNECTABLE, True) and not service_info.connectable:
    return False
```

`connectable=False` short-circuits that check regardless of the advertisement's own connectable status, so both local-radio and proxy-relayed advertisements reach the callback.

## Verification

Reproduced and fixed against a live install with a Shelly BLE proxy ~10ft from several trackers:

- **Before**: instrumented the callback with a call counter. Zero invocations over a 5+ minute window post-restart, despite HA's own Bluetooth manager diagnostics (`/api/diagnostics/config_entry/...`) confirming the proxy's scanner was `scanning: true` and actively holding multiple `0xFEAA`-tagged advertisements from known trackers in its live pool (sub-second freshness).
- **After**: same restart, same proxy, same trackers — the callback started firing immediately, resolved multiple trackers via `resolve_eid()`, and `GoogleFindMyBLEBatterySensor` entities appeared within minutes for trackers that had never had a battery sensor before (proxy-only coverage, never in range of the HA host's own radio).

## Scope

Single-line behavioral change (plus an explanatory comment) in `fmdn_finder/ble_scanner.py`. No other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXsckk4TPxReBfo44LAgQt